### PR TITLE
Don't run pre-commit CI on merge

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,8 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
I was previously running the pre-commit CI after a PR is merged, but the pre-commit has a check that we're not commiting to main. So it always fails. Also it's pointless to run, because if it passed on the commit, it doesn't need to be run again, so I removed it.