### PR TITLE
fix_wb_data_error

### DIFF
--- a/laos_gggi/data_functions/world_bank_data_loader.py
+++ b/laos_gggi/data_functions/world_bank_data_loader.py
@@ -43,4 +43,7 @@ def load_wb_data(folder_path="data", force_reload=False):
     else:
         wb_df = pd.read_csv(path_to_wb_data, index_col=["country_code", "year"])
 
+    wb_df.reset_index().dropna(subset="country_code").set_index(
+        ["country_code", "year"]
+    )
     return wb_df


### PR DESCRIPTION
The World Bank data is generating an error due to a bunch of rows with no country being downloaded from their webpage. This fixes the problem.