### PR TITLE
Extend GPCC to 1891-2025 and draw the climatology from 1961-1990

### DIFF
--- a/climate_risk/data/gpcc.py
+++ b/climate_risk/data/gpcc.py
@@ -20,6 +20,10 @@ _log = logging.getLogger(__name__)
 
 GPCC_DECADES = ("1981_1990", "1991_2000", "2001_2010", "2011_2020")
 
+# The span the cache entry is keyed on, so extending the record writes a new entry rather than
+# serving the shorter one already on disk.
+GPCC_COVERAGE = f"{GPCC_DECADES[0].split('_')[0]}-{GPCC_DECADES[-1].split('_')[1]}"
+
 GPCC = {
     decade: DataSource(
         url=(
@@ -105,6 +109,6 @@ def load_gpcc_data(cache_dir: Path, *, force_reload: bool = False, repair_ISO_co
         "gpcc",
         build,
         pandas_parquet(),
-        params={"repaired_iso": repair_ISO_codes},
+        params={"repaired_iso": repair_ISO_codes, "coverage": GPCC_COVERAGE},
         force=force_reload,
     )

--- a/climate_risk/data/gpcc.py
+++ b/climate_risk/data/gpcc.py
@@ -18,7 +18,9 @@ from climate_risk.geo.crs import GEOGRAPHIC_CRS
 
 _log = logging.getLogger(__name__)
 
-GPCC_DECADES = ("1981_1990", "1991_2000", "2001_2010", "2011_2020")
+# The full extent of the v2022 product. The climatology baseline is drawn from these years, so a
+# shortened list moves every published precipitation deviation.
+GPCC_DECADES = tuple(f"{start}_{start + 9}" for start in range(1891, 2020, 10))
 
 # The span the cache entry is keyed on, so extending the record writes a new entry rather than
 # serving the shorter one already on disk.

--- a/climate_risk/data/gpcc.py
+++ b/climate_risk/data/gpcc.py
@@ -4,9 +4,11 @@ import os
 import shutil
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -18,31 +20,106 @@ from climate_risk.geo.crs import GEOGRAPHIC_CRS
 
 _log = logging.getLogger(__name__)
 
-# The full extent of the v2022 product. The climatology baseline is drawn from these years, so a
-# shortened list moves every published precipitation deviation.
-GPCC_DECADES = tuple(f"{start}_{start + 9}" for start in range(1891, 2020, 10))
+GPCC_URL = "https://opendata.dwd.de/climate_environment/GPCC"
 
-# The span the cache entry is keyed on, so extending the record writes a new entry rather than
-# serving the shorter one already on disk.
-GPCC_COVERAGE = f"{GPCC_DECADES[0].split('_')[0]}-{GPCC_DECADES[-1].split('_')[1]}"
+# The name every grid carries once read, whatever the product it came from calls it.
+PRECIPITATION = "precip"
 
-GPCC = {
-    decade: DataSource(
-        url=(
-            "https://opendata.dwd.de/climate_environment/GPCC/full_data_monthly_v2022/10"
-            f"/full_data_monthly_v2022_{decade}_10.nc.gz"
-        ),
-        filename=f"full_data_monthly_v2022_{decade}_10.nc.gz",
+# DWD writes the monitoring dates as YYYYMMDD floats under this unit string. CF does not define it,
+# so xarray hands the axis back undecoded and it has to be read here.
+DWD_DATE_UNITS = "day as %Y%m%d.%f"
+
+FULL_DATA_START = 1891
+FULL_DATA_END = 2020
+
+# The gauge analysis stops at FULL_DATA_END and the near-real-time product carries on from there.
+# Complete calendar years only: the annual totals downstream would read a part-year as a drought.
+MONITORING_YEARS = tuple(range(FULL_DATA_END + 1, 2026))
+
+FULL_DATA_DECADES = tuple(f"{start}_{start + 9}" for start in range(FULL_DATA_START, FULL_DATA_END, 10))
+
+FULL_DATA_CITATION = (
+    "Schneider, U., Hänsel, S., Finger, P., Rustemeier, E., Ziese, M. (2022): GPCC Full Data "
+    "Monthly Product Version 2022 at 1.0 degrees. "
+    "https://doi.org/10.5676/DWD_GPCC/FD_M_V2022_100"
+)
+
+MONITORING_CITATION = (
+    "Schneider, U., Becker, A., Finger, P., Rustemeier, E., Ziese, M. (2022): GPCC Monitoring "
+    "Product: Near Real-Time Monthly Land-Surface Precipitation from Rain-Gauges based on SYNOP and "
+    "CLIMAT data, at 1.0 degrees. https://doi.org/10.5676/DWD_GPCC/MP_M_V2022_100"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GriddedProduct:
+    """
+    A GPCC product and the archives it is published in.
+
+    Parameters
+    ----------
+    variable : str
+        Name of the precipitation grid inside each archive.
+    first_year, last_year : int
+        The span the archives cover, both years included.
+    sources : tuple of DataSource
+        The archives making up the product, in time order.
+    """
+
+    variable: str
+    first_year: int
+    last_year: int
+    sources: tuple[DataSource, ...]
+
+
+def coverage_of(products: Iterable[GriddedProduct]) -> str:
+    """Return the span a set of products covers, as the string their cache entry is keyed on."""
+    spans = tuple(products)
+
+    return f"{min(product.first_year for product in spans)}-{max(product.last_year for product in spans)}"
+
+
+def _full_data_archive(decade: str) -> DataSource:
+    name = f"full_data_monthly_v2022_{decade}_10.nc.gz"
+
+    return DataSource(
+        url=f"{GPCC_URL}/full_data_monthly_v2022/10/{name}",
+        filename=name,
         licence="CC BY 4.0",
-        citation=(
-            "Schneider, U., H\u00e4nsel, S., Finger, P., Rustemeier, E., Ziese, M. (2022): GPCC Full Data "
-            "Monthly Product Version 2022 at 1.0 degrees. "
-            "https://doi.org/10.5676/DWD_GPCC/FD_M_V2022_100"
-        ),
+        citation=FULL_DATA_CITATION,
         retrieved="2026-08-05",
     )
-    for decade in GPCC_DECADES
-}
+
+
+def _monitoring_archive(year: int, month: int) -> DataSource:
+    name = f"monitoring_v2022_10_{year}_{month:02d}.nc.gz"
+
+    return DataSource(
+        url=f"{GPCC_URL}/monitoring_v2022/{year}/{name}",
+        filename=name,
+        licence="CC BY 4.0",
+        citation=MONITORING_CITATION,
+        retrieved="2026-08-07",
+    )
+
+
+# The reanalysed gauge record, published a decade to an archive.
+FULL_DATA = GriddedProduct(
+    variable="precip",
+    first_year=FULL_DATA_START,
+    last_year=FULL_DATA_END,
+    sources=tuple(_full_data_archive(decade) for decade in FULL_DATA_DECADES),
+)
+
+# The near-real-time continuation, published a month to an archive and built from fewer stations.
+MONITORING = GriddedProduct(
+    variable="p",
+    first_year=MONITORING_YEARS[0],
+    last_year=MONITORING_YEARS[-1],
+    sources=tuple(_monitoring_archive(year, month) for year in MONITORING_YEARS for month in range(1, 13)),
+)
+
+GPCC_PRODUCTS = (FULL_DATA, MONITORING)
 
 # The archives are large enough to keep out of the top-level cache listing.
 GPCC_SUBDIRECTORY = "gpcc"
@@ -55,13 +132,13 @@ WORLD_COLUMNS = {
 }
 
 
-def transform_gpcc(decades: Iterable[pd.DataFrame], world: gpd.GeoDataFrame) -> pd.DataFrame:
+def transform_gpcc(grids: Iterable[pd.DataFrame], world: gpd.GeoDataFrame) -> pd.DataFrame:
     """
     Average gridded precipitation to one value per country and month.
 
     Parameters
     ----------
-    decades : iterable of DataFrame
+    grids : iterable of DataFrame
         Gridded precipitation, one frame per archive, with ``lat``, ``lon``, ``time`` and ``precip``.
     world : GeoDataFrame
         Country boundaries, carrying the columns named in ``WORLD_COLUMNS``.
@@ -73,19 +150,53 @@ def transform_gpcc(decades: Iterable[pd.DataFrame], world: gpd.GeoDataFrame) -> 
     """
     countries = world.rename(columns=WORLD_COLUMNS)
 
-    # Each decade is reduced to land cells before the next is read, so the whole grid is never held.
+    # Each grid is reduced to land cells before the next is read, so the whole record is never held.
     over_land = [
         gpd.GeoDataFrame(
             gridded, geometry=gpd.points_from_xy(gridded["lon"], gridded["lat"]), crs=GEOGRAPHIC_CRS
-        ).sjoin(countries, how="inner", predicate="intersects")[["time", "precip", "country_code"]]
-        for gridded in decades
+        ).sjoin(countries, how="inner", predicate="intersects")[["time", PRECIPITATION, "country_code"]]
+        for gridded in grids
     ]
 
-    return pd.concat(over_land, axis=0).pivot_table(values="precip", index=["country_code", "time"], aggfunc="mean")
+    return pd.concat(over_land, axis=0).pivot_table(
+        values=PRECIPITATION, index=["country_code", "time"], aggfunc="mean"
+    )
 
 
-def _read_decade(archive: Path) -> pd.DataFrame:
-    """Decompress the archive beside itself if needed, then read its precipitation grid."""
+def _as_timestamps(time: xr.DataArray) -> np.ndarray:
+    """
+    Return an archive's time axis as timestamps, whichever way the product encoded it.
+
+    Parameters
+    ----------
+    time : DataArray
+        The ``time`` coordinate as read from the archive.
+
+    Returns
+    -------
+    ndarray
+        The axis as ``datetime64``.
+
+    Raises
+    ------
+    ValueError
+        If the axis is neither already decoded nor written under ``DWD_DATE_UNITS``.
+    """
+    if np.issubdtype(time.dtype, np.datetime64):
+        return time.values
+
+    units = time.attrs.get("units")
+    if units != DWD_DATE_UNITS:
+        raise ValueError(
+            f"The time axis is {time.dtype} under units {units!r}, which is neither a decoded datetime nor "
+            f"the {DWD_DATE_UNITS!r} convention. Reading it as a number would date every row to 1970."
+        )
+
+    return pd.to_datetime(time.values.astype("int64").astype(str), format="%Y%m%d").values
+
+
+def _extract(archive: Path) -> Path:
+    """Decompress the archive beside itself if needed, and return the plain file."""
     extracted = archive.with_suffix("")
 
     if not extracted.exists():
@@ -96,21 +207,39 @@ def _read_decade(archive: Path) -> pd.DataFrame:
             shutil.copyfileobj(compressed, plain)
         os.replace(partial, extracted)
 
-    return xr.open_dataset(extracted)["precip"].to_dataframe().reset_index()
+    return extracted
 
 
-def load_gpcc_data(cache_dir: Path, *, force_reload: bool = False, repair_ISO_codes: bool = True) -> pd.DataFrame:
+def _read_archive(archive: Path, variable: str) -> pd.DataFrame:
+    """Read one archive's precipitation grid, under the canonical name and with its dates decoded."""
+    with xr.open_dataset(_extract(archive)) as dataset:
+        grid = dataset[variable]
+
+        return grid.assign_coords(time=_as_timestamps(grid["time"])).rename(PRECIPITATION).to_dataframe().reset_index()
+
+
+def load_gpcc_data(
+    cache_dir: Path,
+    *,
+    products: tuple[GriddedProduct, ...] = GPCC_PRODUCTS,
+    force_reload: bool = False,
+    repair_ISO_codes: bool = True,
+) -> pd.DataFrame:
     def build() -> pd.DataFrame:
-        archives = [fetch(source, cache_dir / GPCC_SUBDIRECTORY, force=force_reload) for source in GPCC.values()]
+        archives = [
+            (fetch(source, cache_dir / GPCC_SUBDIRECTORY, force=force_reload), product.variable)
+            for product in products
+            for source in product.sources
+        ]
         world = load_shapefile("world", cache_dir, repair_ISO_codes=repair_ISO_codes)
 
-        return transform_gpcc((_read_decade(archive) for archive in archives), world)
+        return transform_gpcc((_read_archive(archive, variable) for archive, variable in archives), world)
 
     return cached(
         cache_dir,
         "gpcc",
         build,
         pandas_parquet(),
-        params={"repaired_iso": repair_ISO_codes, "coverage": GPCC_COVERAGE},
+        params={"repaired_iso": repair_ISO_codes, "coverage": coverage_of(products)},
         force=force_reload,
     )

--- a/climate_risk/data/gpcc.py
+++ b/climate_risk/data/gpcc.py
@@ -32,9 +32,10 @@ DWD_DATE_UNITS = "day as %Y%m%d.%f"
 FULL_DATA_START = 1891
 FULL_DATA_END = 2020
 
-# The gauge analysis stops at FULL_DATA_END and the near-real-time product carries on from there.
-# Complete calendar years only: the annual totals downstream would read a part-year as a drought.
-MONITORING_YEARS = tuple(range(FULL_DATA_END + 1, 2026))
+# The near-real-time product carries on where the gauge analysis stops. Complete calendar years
+# only: the annual totals downstream would read a part-year as a drought.
+MONITORING_END = 2025
+MONITORING_YEARS = tuple(range(FULL_DATA_END + 1, MONITORING_END + 1))
 
 FULL_DATA_DECADES = tuple(f"{start}_{start + 9}" for start in range(FULL_DATA_START, FULL_DATA_END, 10))
 
@@ -74,9 +75,9 @@ class GriddedProduct:
 
 def coverage_of(products: Iterable[GriddedProduct]) -> str:
     """Return the span a set of products covers, as the string their cache entry is keyed on."""
-    spans = tuple(products)
+    covered = tuple(products)
 
-    return f"{min(product.first_year for product in spans)}-{max(product.last_year for product in spans)}"
+    return f"{min(product.first_year for product in covered)}-{max(product.last_year for product in covered)}"
 
 
 def _full_data_archive(decade: str) -> DataSource:
@@ -214,8 +215,9 @@ def _read_archive(archive: Path, variable: str) -> pd.DataFrame:
     """Read one archive's precipitation grid, under the canonical name and with its dates decoded."""
     with xr.open_dataset(_extract(archive)) as dataset:
         grid = dataset[variable]
+        dated = grid.assign_coords(time=_as_timestamps(grid["time"]))
 
-        return grid.assign_coords(time=_as_timestamps(grid["time"])).rename(PRECIPITATION).to_dataframe().reset_index()
+        return dated.rename(PRECIPITATION).to_dataframe().reset_index()
 
 
 def load_gpcc_data(

--- a/climate_risk/data/ocean_heat.py
+++ b/climate_risk/data/ocean_heat.py
@@ -32,16 +32,20 @@ def transform_ocean_heat(seasonal: pl.DataFrame) -> pl.DataFrame:
     Parameters
     ----------
     seasonal : DataFrame
-        Anomalies with a ``Date`` column formatted ``YYYY-MM`` and a ``Temp`` column.
+        Anomalies with a ``Date`` column of ``YYYY-M`` text, whose month upstream leaves unpadded
+        below October, and a ``Temp`` column.
 
     Returns
     -------
     DataFrame
         Annual means dated to each year's first day, offset by ``OCEAN_HEAT_BASELINE_OFFSET``.
     """
+    # Only the year survives the average, so the year is all that is read. A date parse here would
+    # have to accept both the padded and the unpadded months upstream mixes.
+    year = pl.col("Date").str.split("-").list.first().cast(pl.Int32)
+
     return (
-        seasonal.with_columns(pl.col("Date").str.to_date("%Y-%m"))
-        .group_by(pl.col("Date").dt.year().alias("year"))
+        seasonal.group_by(year.alias("year"))
         .agg(pl.col("Temp").mean())
         .select(pl.date(pl.col("year"), 1, 1).alias("Date"), pl.col("Temp") + OCEAN_HEAT_BASELINE_OFFSET)
         .sort("Date")

--- a/climate_risk/data/ocean_heat.py
+++ b/climate_risk/data/ocean_heat.py
@@ -40,8 +40,7 @@ def transform_ocean_heat(seasonal: pl.DataFrame) -> pl.DataFrame:
     DataFrame
         Annual means dated to each year's first day, offset by ``OCEAN_HEAT_BASELINE_OFFSET``.
     """
-    # Only the year survives the average, so the year is all that is read. A date parse here would
-    # have to accept both the padded and the unpadded months upstream mixes.
+    # Only the year survives the average, so the year is all that is read.
     year = pl.col("Date").str.split("-").list.first().cast(pl.Int32)
 
     return (

--- a/climate_risk/data_functions/combine_data.py
+++ b/climate_risk/data_functions/combine_data.py
@@ -14,6 +14,10 @@ from climate_risk.data_functions.emdat_processing import DISASTER_TYPES, load_em
 PANEL_KEY = ["ISO", "Start_Year"]
 SERIES_KEY = "year"
 
+# Annual precipitation is a sum, so a year the record only partly covers totals low. Dropping those
+# keeps a part-year at the end of the record from entering the panel as a drought.
+MONTHS_IN_YEAR = 12
+
 
 def _as_polars(frame: pd.DataFrame) -> pl.DataFrame:
     """Convert a pandas frame from the geospatial layer into the polars this module merges in."""
@@ -64,6 +68,8 @@ def _annual_precipitation(gpcc: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFram
     """
     Total monthly precipitation to years.
 
+    Years the record covers only partly are dropped from both.
+
     Returns
     -------
     by_country : DataFrame
@@ -74,13 +80,21 @@ def _annual_precipitation(gpcc: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFram
     dated = gpcc.select(
         pl.col("country_code").alias("ISO"),
         pl.date(pl.col("time").dt.year(), 1, 1).alias(SERIES_KEY),
+        pl.col("time").dt.month().alias("month"),
         "precip",
     )
 
-    return (
-        dated.group_by("ISO", SERIES_KEY).agg(pl.col("precip").sum()).sort("ISO", SERIES_KEY),
-        dated.group_by(SERIES_KEY).agg(pl.col("precip").sum()).sort(SERIES_KEY),
+    whole_years = (
+        dated.group_by(SERIES_KEY)
+        .agg(pl.col("month").n_unique().alias("months"))
+        .filter(pl.col("months") == MONTHS_IN_YEAR)
+        .select(SERIES_KEY)
     )
+    covered = dated.join(whole_years, on=SERIES_KEY, how="inner")
+
+    by_country = covered.group_by("ISO", SERIES_KEY).agg(pl.col("precip").sum()).sort("ISO", SERIES_KEY)
+
+    return by_country, by_country.group_by(SERIES_KEY).agg(pl.col("precip").sum()).sort(SERIES_KEY)
 
 
 def _keyed_by_year(series: pl.DataFrame) -> pl.DataFrame:

--- a/climate_risk/replication_data.py
+++ b/climate_risk/replication_data.py
@@ -11,9 +11,8 @@ PANEL_KEY = ["ISO", "year"]
 HYDROLOGICAL_TYPES = ["Flood", "Storm"]
 CLIMATOLOGICAL_TYPES = ["Extreme temperature", "Wildfire", "Drought"]
 
-# Each country's precipitation is centred on its mean over this many years, counted from the start
-# of the record rather than from a fixed calendar period.
-CLIMATOLOGY_YEARS = 30
+# The WMO reference period each country's precipitation is centred on, inclusive of both ends.
+CLIMATOLOGY_BASELINE = (1961, 1990)
 
 # The seasonal period the ocean-heat trend is fitted with.
 OCEAN_TREND_PERIOD = 3
@@ -53,14 +52,40 @@ def _counted_or_missing(types: list[str]) -> pl.Expr:
     )
 
 
-def _precipitation_deviation(precipitation: pl.DataFrame) -> pl.DataFrame:
-    """Centre each country's precipitation on its own mean over the baseline climatology period."""
-    baseline_years = precipitation["year"].unique().sort().head(CLIMATOLOGY_YEARS)
-    climatology = (
-        precipitation.filter(pl.col("year").is_in(baseline_years))
-        .group_by("ISO")
-        .agg(pl.col("precip").mean().alias("baseline"))
-    )
+def _precipitation_deviation(precipitation: pl.DataFrame, baseline: tuple[int, int]) -> pl.DataFrame:
+    """
+    Centre each country's precipitation on its own mean over the baseline climatology period.
+
+    Parameters
+    ----------
+    precipitation : DataFrame
+        One row per country and year, carrying ``ISO``, ``year`` and ``precip``.
+    baseline : tuple of int
+        The first and last year of the reference period, both included.
+
+    Returns
+    -------
+    DataFrame
+        One row per country and year, carrying the deviation from that country's baseline mean.
+
+    Raises
+    ------
+    ValueError
+        If the record does not reach across every year of the baseline period.
+    """
+    first_year, last_year = baseline
+    within_baseline = pl.col("year").dt.year().is_between(first_year, last_year)
+    reference = precipitation.filter(within_baseline)
+
+    covered = reference["year"].dt.year().n_unique()
+    if covered < last_year - first_year + 1:
+        raise ValueError(
+            f"The precipitation record covers {covered} of the {last_year - first_year + 1} years in the "
+            f"{first_year}-{last_year} baseline, so the climatology would be drawn from a shorter period "
+            f"than the one it is named for."
+        )
+
+    climatology = reference.group_by("ISO").agg(pl.col("precip").mean().alias("baseline"))
 
     return precipitation.join(climatology, on="ISO", how="left").select(
         *PANEL_KEY, (pl.col("precip") - pl.col("baseline")).alias("precip_deviation")
@@ -78,7 +103,7 @@ def _deviation_from_trend(climate: pl.DataFrame) -> pl.DataFrame:
     return converted.with_columns(pl.col("year").cast(pl.Date))
 
 
-def create_replication_data(cache_dir: Path) -> pl.DataFrame:
+def create_replication_data(cache_dir: Path, *, baseline: tuple[int, int] = CLIMATOLOGY_BASELINE) -> pl.DataFrame:
     data = load_all_data(cache_dir)
 
     events = data["emdat_events"].rename({"Start_Year": "year"})
@@ -112,7 +137,7 @@ def create_replication_data(cache_dir: Path) -> pl.DataFrame:
     frame = (
         disasters.join(development, on=PANEL_KEY, how="left")
         .join(damages, on=PANEL_KEY, how="left")
-        .join(_precipitation_deviation(data["gpcc"]), on=PANEL_KEY, how="left")
+        .join(_precipitation_deviation(data["gpcc"], baseline), on=PANEL_KEY, how="left")
         .join(climate.select("year", "co2"), on="year", how="left")
         .join(_deviation_from_trend(climate), on="year", how="left")
     )

--- a/climate_risk/replication_data.py
+++ b/climate_risk/replication_data.py
@@ -77,10 +77,11 @@ def _precipitation_deviation(precipitation: pl.DataFrame, baseline: tuple[int, i
     within_baseline = pl.col("year").dt.year().is_between(first_year, last_year)
     reference = precipitation.filter(within_baseline)
 
+    span = last_year - first_year + 1
     covered = reference["year"].dt.year().n_unique()
-    if covered < last_year - first_year + 1:
+    if covered < span:
         raise ValueError(
-            f"The precipitation record covers {covered} of the {last_year - first_year + 1} years in the "
+            f"The precipitation record covers {covered} of the {span} years in the "
             f"{first_year}-{last_year} baseline, so the climatology would be drawn from a shorter period "
             f"than the one it is named for."
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,12 +268,14 @@ def write_full_cache(tmp_path, write_emdat_cache):
         pl.DataFrame({"Date": [date(1990, 1, 1), date(1991, 1, 1)], "Temp": [1.0, 2.0]}).write_parquet(
             tmp_path / "ocean_heat.parquet"
         )
-        # GPCC publishes monthly, so two months a year keeps a total distinguishable from an average.
+        # GPCC publishes monthly, and only whole years survive the annual total, so each year here
+        # carries all twelve months. A total stays distinguishable from an average.
         pd.DataFrame(
             [
-                (iso, pd.Timestamp(f"{year}-{month:02d}-01"), base + 10.0 * offset)
+                (iso, pd.Timestamp(f"{year}-{month:02d}-01"), base + 1000.0 * (year - 1990) + month)
                 for iso, base in (("AAA", 100.0), ("BBB", 200.0), ("FFF", 300.0))
-                for offset, (year, month) in enumerate([(1990, 1), (1990, 7), (1991, 1), (1991, 7)])
+                for year in (1990, 1991)
+                for month in range(1, 13)
             ],
             columns=["country_code", "time", "precip"],
         ).set_index(["country_code", "time"]).to_parquet(tmp_path / GPCC_CACHE_FILE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import socket
 import zipfile
 
 from datetime import date
+from functools import partial
 
 import geopandas as gpd
 import numpy as np
@@ -205,8 +206,7 @@ def write_gpcc_archives(tmp_path):
     return write
 
 
-@pytest.fixture
-def write_full_cache(tmp_path, write_emdat_cache):
+def write_merge_cache(cache_dir):
     """Seed every cache `load_all_data` reads, so the whole merge runs offline.
 
     AAA and BBB appear in every source. CCC is EM-DAT only and DDD World Bank only, so the first
@@ -214,74 +214,76 @@ def write_full_cache(tmp_path, write_emdat_cache):
     survives that pass and is dropped only from the GPCC frame. FFF has precipitation and
     nothing else, so the GPCC pass has something of its own to drop.
     """
-
-    def write():
-        events = [
-            emdat_event({"ISO": iso, "DisNo.": f"{iso}-{year}", "Start Year": year, "End Year": year})
-            for iso in ("AAA", "BBB", "CCC", "EEE")
+    events = [
+        emdat_event({"ISO": iso, "DisNo.": f"{iso}-{year}", "Start Year": year, "End Year": year})
+        for iso in ("AAA", "BBB", "CCC", "EEE")
+        for year in (1990, 1991)
+    ]
+    # A climatological event, so the hydro/clim damage split has something on both sides.
+    events.append(
+        emdat_event(
+            {
+                "ISO": "AAA",
+                "DisNo.": "AAA-drought",
+                "Start Year": 1990,
+                "End Year": 1990,
+                "Disaster Type": "Drought",
+            }
+        )
+    )
+    # One country has a disaster type in a single year, so a per-year column mistaken for a
+    # country constant shows up as a duplicated country.
+    events.append(
+        emdat_event(
+            {
+                "ISO": "AAA",
+                "DisNo.": "AAA-landslide",
+                "Start Year": 1991,
+                "End Year": 1991,
+                "Disaster Type": "Mass movement (wet)",
+            }
+        )
+    )
+    write_emdat_workbook(cache_dir, events)
+    pl.DataFrame(
+        [
+            ("AAA", 1990, 1000.0, 10.0, 1000000),
+            ("AAA", 1991, 1100.0, 11.0, 1010000),
+            ("BBB", 1990, 2000.0, 20.0, 2000000),
+            ("BBB", 1991, 2200.0, 22.0, 2020000),
+            ("DDD", 1990, 3000.0, 30.0, 3000000),
+            ("DDD", 1991, 3300.0, 33.0, 3030000),
+            ("EEE", 1990, 4000.0, 40.0, 4000000),
+            ("EEE", 1991, 4400.0, 44.0, 4040000),
+        ],
+        schema=["country_code", "year", "gdp_per_cap", "population_density", "Population"],
+        orient="row",
+    ).write_parquet(cache_dir / "world_bank.parquet")
+    # The cache key is stated literally, so a wrong one fails rather than agreeing with itself.
+    pl.DataFrame({"Date": [date(1990, 1, 1), date(1991, 1, 1)], "co2": [354.0, 355.0]}).write_parquet(
+        cache_dir / "co2.parquet"
+    )
+    pl.DataFrame({"Date": [date(1990, 1, 1), date(1991, 1, 1)], "Temp": [1.0, 2.0]}).write_parquet(
+        cache_dir / "ocean_heat.parquet"
+    )
+    # GPCC publishes monthly, and only whole years survive the annual total, so each year here
+    # carries all twelve months. A total stays distinguishable from an average.
+    pd.DataFrame(
+        [
+            (iso, pd.Timestamp(f"{year}-{month:02d}-01"), base + 1000.0 * (year - 1990) + month)
+            for iso, base in (("AAA", 100.0), ("BBB", 200.0), ("FFF", 300.0))
             for year in (1990, 1991)
-        ]
-        # A climatological event, so the hydro/clim damage split has something on both sides.
-        events.append(
-            emdat_event(
-                {
-                    "ISO": "AAA",
-                    "DisNo.": "AAA-drought",
-                    "Start Year": 1990,
-                    "End Year": 1990,
-                    "Disaster Type": "Drought",
-                }
-            )
-        )
-        # One country has a disaster type in a single year, so a per-year column mistaken for a
-        # country constant shows up as a duplicated country.
-        events.append(
-            emdat_event(
-                {
-                    "ISO": "AAA",
-                    "DisNo.": "AAA-landslide",
-                    "Start Year": 1991,
-                    "End Year": 1991,
-                    "Disaster Type": "Mass movement (wet)",
-                }
-            )
-        )
-        write_emdat_cache(events)
-        pl.DataFrame(
-            [
-                ("AAA", 1990, 1000.0, 10.0, 1000000),
-                ("AAA", 1991, 1100.0, 11.0, 1010000),
-                ("BBB", 1990, 2000.0, 20.0, 2000000),
-                ("BBB", 1991, 2200.0, 22.0, 2020000),
-                ("DDD", 1990, 3000.0, 30.0, 3000000),
-                ("DDD", 1991, 3300.0, 33.0, 3030000),
-                ("EEE", 1990, 4000.0, 40.0, 4000000),
-                ("EEE", 1991, 4400.0, 44.0, 4040000),
-            ],
-            schema=["country_code", "year", "gdp_per_cap", "population_density", "Population"],
-            orient="row",
-        ).write_parquet(tmp_path / "world_bank.parquet")
-        # The cache key is stated literally, so a wrong one fails rather than agreeing with itself.
-        pl.DataFrame({"Date": [date(1990, 1, 1), date(1991, 1, 1)], "co2": [354.0, 355.0]}).write_parquet(
-            tmp_path / "co2.parquet"
-        )
-        pl.DataFrame({"Date": [date(1990, 1, 1), date(1991, 1, 1)], "Temp": [1.0, 2.0]}).write_parquet(
-            tmp_path / "ocean_heat.parquet"
-        )
-        # GPCC publishes monthly, and only whole years survive the annual total, so each year here
-        # carries all twelve months. A total stays distinguishable from an average.
-        pd.DataFrame(
-            [
-                (iso, pd.Timestamp(f"{year}-{month:02d}-01"), base + 1000.0 * (year - 1990) + month)
-                for iso, base in (("AAA", 100.0), ("BBB", 200.0), ("FFF", 300.0))
-                for year in (1990, 1991)
-                for month in range(1, 13)
-            ],
-            columns=["country_code", "time", "precip"],
-        ).set_index(["country_code", "time"]).to_parquet(tmp_path / GPCC_CACHE_FILE)
-        return tmp_path
+            for month in range(1, 13)
+        ],
+        columns=["country_code", "time", "precip"],
+    ).set_index(["country_code", "time"]).to_parquet(cache_dir / GPCC_CACHE_FILE)
+    return cache_dir
 
-    return write
+
+@pytest.fixture
+def write_full_cache(tmp_path):
+    """Return a callable seeding every cache `load_all_data` reads, and giving back its directory."""
+    return partial(write_merge_cache, tmp_path)
 
 
 @pytest.fixture
@@ -380,16 +382,18 @@ class NetworkAccessError(RuntimeError):
     """Raised when a test that is not marked `network` opens a connection."""
 
 
+def write_emdat_workbook(cache_dir, events):
+    """Write the given events to a synthetic EM-DAT workbook in ``cache_dir``."""
+    with pd.ExcelWriter(cache_dir / "emdat.xlsx") as writer:
+        pd.DataFrame(list(events)).to_excel(writer, sheet_name="EM-DAT Data", index=False)
+
+    return cache_dir
+
+
 @pytest.fixture
 def write_emdat_cache(tmp_path):
     """Return a callable writing the given events to a synthetic EM-DAT workbook in the cache."""
-
-    def write(events):
-        with pd.ExcelWriter(tmp_path / "emdat.xlsx") as writer:
-            pd.DataFrame(list(events)).to_excel(writer, sheet_name="EM-DAT Data", index=False)
-        return tmp_path
-
-    return write
+    return partial(write_emdat_workbook, tmp_path)
 
 
 OUTBOUND_SOCKET_METHODS = ("connect", "connect_ex", "sendto", "sendmsg")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,10 @@ def toy_precipitation(year_range):
 GPCC_DECADES = ("1981_1990", "1991_2000", "2001_2010", "2011_2020")
 
 
+# The processed GPCC cache. Its key carries the span, so extending the record renames the entry.
+GPCC_CACHE_FILE = "gpcc__coverage=1981-2020__repaired_iso=True.parquet"
+
+
 def gpcc_archive_name(decade: str) -> str:
     return f"full_data_monthly_v2022_{decade}_10.nc.gz"
 
@@ -237,7 +241,7 @@ def write_full_cache(tmp_path, write_emdat_cache):
                 for offset, (year, month) in enumerate([(1990, 1), (1990, 7), (1991, 1), (1991, 7)])
             ],
             columns=["country_code", "time", "precip"],
-        ).set_index(["country_code", "time"]).to_parquet(tmp_path / "gpcc__repaired_iso=True.parquet")
+        ).set_index(["country_code", "time"]).to_parquet(tmp_path / GPCC_CACHE_FILE)
         return tmp_path
 
     return write

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ from climate_risk.const_vars import (
     BIG_RIVERS_FILENAME,
     MEDIUM_BIG_RIVERS_FILENAME,
 )
+from climate_risk.data.gpcc import GriddedProduct
+from climate_risk.data.source import DataSource
 
 # One event that clears every downstream filter: deaths above 100, affected above 1000, and a start
 # year inside both the 1970 and 1980 cutoffs. Tests override only the field under examination.
@@ -129,7 +131,7 @@ UPSTREAM_SHAPEFILE_LAYOUT = {
 
 
 def toy_precipitation(year_range):
-    """A GPCC grid with one point inside each country of `toy_world`."""
+    """A full-data grid with one point inside each country of `toy_world`."""
     start = int(year_range.split("_")[0])
     return xr.Dataset(
         {"precip": (("time", "lat", "lon"), np.arange(3.0).reshape(1, 1, 3))},
@@ -141,44 +143,63 @@ def toy_precipitation(year_range):
     )
 
 
-# The archive layout is stated literally, not derived from the loader, so a wrong path fails.
-GPCC_DECADES = (
-    "1891_1900",
-    "1901_1910",
-    "1911_1920",
-    "1921_1930",
-    "1931_1940",
-    "1941_1950",
-    "1951_1960",
-    "1961_1970",
-    "1971_1980",
-    "1981_1990",
-    "1991_2000",
-    "2001_2010",
-    "2011_2020",
-)
+def toy_monitoring(year, month):
+    """A monitoring grid, which names its variable ``p`` and dates it with a YYYYMMDD float."""
+    return xr.Dataset(
+        {"p": (("time", "lat", "lon"), np.arange(3.0).reshape(1, 1, 3))},
+        coords={
+            "time": ("time", [float(f"{year}{month:02d}01")], {"units": "day as %Y%m%d.%f"}),
+            "lat": [0.5],
+            "lon": [0.5, 2.5, 4.5],
+        },
+    )
 
 
-# The processed GPCC cache. Its key carries the span, so extending the record renames the entry.
-GPCC_CACHE_FILE = "gpcc__coverage=1891-2020__repaired_iso=True.parquet"
+# Archive names as they appear upstream, stated literally so a wrong path fails rather than agreeing
+# with the loader. One archive per product is the whole manifest a test needs: nothing the loader
+# does varies with how many are listed.
+TOY_ARCHIVES = ("full_data_monthly_v2022_1981_1990_10.nc.gz", "monitoring_v2022_10_2021_01.nc.gz")
+
+# The processed cache each manifest writes. The key carries the span, so extending the record renames
+# the entry instead of shadowing it.
+TOY_GPCC_CACHE = "gpcc__coverage=1981-2021__repaired_iso=True.parquet"
+GPCC_CACHE_FILE = "gpcc__coverage=1891-2025__repaired_iso=True.parquet"
 
 
-def gpcc_archive_name(decade: str) -> str:
-    return f"full_data_monthly_v2022_{decade}_10.nc.gz"
+def toy_gpcc_products() -> tuple[GriddedProduct, ...]:
+    """The published manifest cut to one archive from each product, which differ in both fields."""
+
+    def source(filename: str) -> DataSource:
+        return DataSource(
+            url=f"https://opendata.dwd.de/climate_environment/GPCC/{filename}",
+            filename=filename,
+            licence="CC BY 4.0",
+            citation="GPCC",
+            retrieved="2026-08-07",
+        )
+
+    full_data, monitoring = TOY_ARCHIVES
+
+    return (
+        GriddedProduct(variable="precip", first_year=1981, last_year=1990, sources=(source(full_data),)),
+        GriddedProduct(variable="p", first_year=2021, last_year=2021, sources=(source(monitoring),)),
+    )
 
 
 @pytest.fixture
 def write_gpcc_archives(tmp_path):
-    """Return a callable writing one gzipped archive per decade, some already extracted."""
+    """Return a callable writing one gzipped archive per product, some already extracted."""
 
     def write(extracted=()):
         gpcc_dir = tmp_path / "gpcc"
         gpcc_dir.mkdir(parents=True, exist_ok=True)
-        for decade in GPCC_DECADES:
-            raw = bytes(toy_precipitation(decade).to_netcdf())
-            (gpcc_dir / gpcc_archive_name(decade)).write_bytes(gzip.compress(raw))
-            if decade in extracted:
-                (gpcc_dir / gpcc_archive_name(decade).removesuffix(".gz")).write_bytes(raw)
+
+        grids = zip(TOY_ARCHIVES, (toy_precipitation("1981_1990"), toy_monitoring(2021, 1)), strict=True)
+        for name, grid in grids:
+            raw = bytes(grid.to_netcdf())
+            (gpcc_dir / name).write_bytes(gzip.compress(raw))
+            if name in extracted:
+                (gpcc_dir / name.removesuffix(".gz")).write_bytes(raw)
         return tmp_path
 
     return write

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,11 +142,25 @@ def toy_precipitation(year_range):
 
 
 # The archive layout is stated literally, not derived from the loader, so a wrong path fails.
-GPCC_DECADES = ("1981_1990", "1991_2000", "2001_2010", "2011_2020")
+GPCC_DECADES = (
+    "1891_1900",
+    "1901_1910",
+    "1911_1920",
+    "1921_1930",
+    "1931_1940",
+    "1941_1950",
+    "1951_1960",
+    "1961_1970",
+    "1971_1980",
+    "1981_1990",
+    "1991_2000",
+    "2001_2010",
+    "2011_2020",
+)
 
 
 # The processed GPCC cache. Its key carries the span, so extending the record renames the entry.
-GPCC_CACHE_FILE = "gpcc__coverage=1981-2020__repaired_iso=True.parquet"
+GPCC_CACHE_FILE = "gpcc__coverage=1891-2020__repaired_iso=True.parquet"
 
 
 def gpcc_archive_name(decade: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,9 +161,8 @@ def toy_monitoring(year, month):
 # does varies with how many are listed.
 TOY_ARCHIVES = ("full_data_monthly_v2022_1981_1990_10.nc.gz", "monitoring_v2022_10_2021_01.nc.gz")
 
-# The processed cache each manifest writes. The key carries the span, so extending the record renames
-# the entry instead of shadowing it.
-TOY_GPCC_CACHE = "gpcc__coverage=1981-2021__repaired_iso=True.parquet"
+# The processed cache the published manifest writes. The key carries the span, so extending the
+# record renames the entry instead of shadowing it.
 GPCC_CACHE_FILE = "gpcc__coverage=1891-2025__repaired_iso=True.parquet"
 
 

--- a/tests/data/test_gpcc.py
+++ b/tests/data/test_gpcc.py
@@ -102,7 +102,7 @@ def test_a_warm_cache_does_not_touch_the_archives(write_gpcc_archives, write_sha
 
 
 def test_cells_are_averaged_per_country_and_month():
-    decade = gridded(
+    grid = gridded(
         [
             ("1981-01-01", 0.5, 0.5, 4.0),
             ("1981-01-01", 0.75, 0.75, 6.0),
@@ -110,25 +110,25 @@ def test_cells_are_averaged_per_country_and_month():
         ]
     )
 
-    monthly = transform_gpcc([decade], toy_world())
+    monthly = transform_gpcc([grid], toy_world())
 
     assert monthly.loc[("AAA", pd.Timestamp("1981-01-01")), "precip"] == pytest.approx(5.0)
     assert monthly.loc[("BBB", pd.Timestamp("1981-01-01")), "precip"] == pytest.approx(100.0)
 
 
 def test_cells_over_the_ocean_are_dropped():
-    decade = gridded([("1981-01-01", 0.5, 0.5, 4.0), ("1981-01-01", 50.0, 50.0, 999.0)])
+    grid = gridded([("1981-01-01", 0.5, 0.5, 4.0), ("1981-01-01", 50.0, 50.0, 999.0)])
 
-    monthly = transform_gpcc([decade], toy_world())
+    monthly = transform_gpcc([grid], toy_world())
 
     assert monthly["precip"].tolist() == [4.0]
 
 
-def test_every_decade_reaches_the_result():
-    """The decades are read one at a time; dropping one loses ten years without an error."""
-    decades = [gridded([("1981-01-01", 0.5, 0.5, 1.0)]), gridded([("1991-01-01", 0.5, 0.5, 2.0)])]
+def test_every_archive_reaches_the_result():
+    """The archives are read one at a time; dropping one loses its years without an error."""
+    grids = [gridded([("1981-01-01", 0.5, 0.5, 1.0)]), gridded([("1991-01-01", 0.5, 0.5, 2.0)])]
 
-    monthly = transform_gpcc(decades, toy_world())
+    monthly = transform_gpcc(grids, toy_world())
 
     assert pd.DatetimeIndex(monthly.index.get_level_values("time")).year.tolist() == [1981, 1991]
 
@@ -164,9 +164,9 @@ def test_the_archives_are_decompressed_before_reading(write_gpcc_archives, write
 
 def test_the_world_boundaries_decide_the_countries():
     """Passing the boundaries in is what lets this run without the 606MB shapefile."""
-    decade = gridded([("1981-01-01", 0.5, 0.5, 4.0)])
+    grid = gridded([("1981-01-01", 0.5, 0.5, 4.0)])
     one_country = gpd.GeoDataFrame(toy_world().iloc[:1])
 
-    monthly = transform_gpcc([decade], one_country)
+    monthly = transform_gpcc([grid], one_country)
 
     assert monthly.index.get_level_values("country_code").tolist() == ["AAA"]

--- a/tests/data/test_gpcc.py
+++ b/tests/data/test_gpcc.py
@@ -4,38 +4,40 @@ import shutil
 import geopandas as gpd
 import pandas as pd
 import pytest
+import xarray as xr
 
-from climate_risk.data.gpcc import load_gpcc_data, transform_gpcc
-from tests.conftest import GPCC_DECADES, gpcc_archive_name, toy_world
+from climate_risk.data.gpcc import GPCC_PRODUCTS, _as_timestamps, load_gpcc_data, transform_gpcc
+from tests.conftest import TOY_ARCHIVES, toy_gpcc_products, toy_world
 
-# Stated literally, so a wrong cache key fails rather than agreeing with itself.
-UNREPAIRED_CACHE = "gpcc__coverage=1891-2020__repaired_iso=False.parquet"
-REPAIRED_CACHE = "gpcc__coverage=1891-2020__repaired_iso=True.parquet"
+# Stated literally, so a wrong cache key fails rather than agreeing with itself. The span is the
+# toy manifest's, not the published one.
+UNREPAIRED_CACHE = "gpcc__coverage=1981-2021__repaired_iso=False.parquet"
+REPAIRED_CACHE = "gpcc__coverage=1981-2021__repaired_iso=True.parquet"
 
 
 def gridded(rows) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=["time", "lat", "lon", "precip"]).assign(time=lambda x: pd.to_datetime(x["time"]))
 
 
-def extracted_name(decade: str) -> str:
-    return gpcc_archive_name(decade).removesuffix(".gz")
+def extracted_name(archive: str) -> str:
+    return archive.removesuffix(".gz")
 
 
 def test_interrupted_extraction_resumes(write_gpcc_archives, write_shapefile_cache):
     """One extracted archive once stood in for all of them, so an interrupted run never recovered."""
-    cache_dir = write_gpcc_archives(extracted=[GPCC_DECADES[0]])
+    cache_dir = write_gpcc_archives(extracted=[TOY_ARCHIVES[0]])
     write_shapefile_cache("world", toy_world())
 
-    load_gpcc_data(cache_dir, repair_ISO_codes=False)
+    load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False)
 
-    assert all((cache_dir / "gpcc" / extracted_name(decade)).exists() for decade in GPCC_DECADES)
+    assert all((cache_dir / "gpcc" / extracted_name(archive)).exists() for archive in TOY_ARCHIVES)
 
 
 def test_cold_run_aggregates_precipitation_by_country(write_gpcc_archives, write_shapefile_cache):
     cache_dir = write_gpcc_archives()
     write_shapefile_cache("world", toy_world())
 
-    frame = load_gpcc_data(cache_dir, repair_ISO_codes=False)
+    frame = load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False)
 
     assert frame.index.names == ["country_code", "time"]
     assert sorted(frame.index.get_level_values("country_code").unique()) == ["AAA", "BBB", "CCC"]
@@ -46,22 +48,57 @@ def test_the_cold_run_writes_the_cache_it_will_read(write_gpcc_archives, write_s
     cache_dir = write_gpcc_archives()
     write_shapefile_cache("world", toy_world())
 
-    load_gpcc_data(cache_dir, repair_ISO_codes=False)
+    load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False)
 
     assert (cache_dir / UNREPAIRED_CACHE).exists()
+
+
+def test_the_monitoring_dates_are_decoded_rather_than_read_as_numbers(write_gpcc_archives, write_shapefile_cache):
+    """The monitoring archives date rows as YYYYMMDD floats; taken as numbers they all land in 1970."""
+    cache_dir = write_gpcc_archives()
+    write_shapefile_cache("world", toy_world())
+
+    frame = load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False)
+    months = pd.DatetimeIndex(frame.index.get_level_values("time"))
+
+    assert months.min() == pd.Timestamp("1981-01-01")
+    assert months.max() == pd.Timestamp("2021-01-01")
+
+
+def test_the_published_manifest_lists_an_archive_for_every_period_it_claims():
+    """A decade or a month left off the list is a hole in the record that nothing downstream sees."""
+    full_data, monitoring = GPCC_PRODUCTS
+
+    assert len(full_data.sources) * 10 == full_data.last_year - full_data.first_year + 1
+    assert len(monitoring.sources) == (monitoring.last_year - monitoring.first_year + 1) * 12
+
+
+def test_the_two_products_meet_without_a_gap_or_an_overlap():
+    """An overlap would total a month twice; a gap would leave a year out of the panel entirely."""
+    full_data, monitoring = GPCC_PRODUCTS
+
+    assert monitoring.first_year == full_data.last_year + 1
+
+
+def test_a_time_axis_in_an_unknown_encoding_is_refused():
+    """Reading an unrecognised numeric axis as-is would date the record silently, not loudly."""
+    time = xr.DataArray([20210101.0], dims="time", attrs={"units": "days since 1900-01-01"})
+
+    with pytest.raises(ValueError, match="neither a decoded datetime"):
+        _as_timestamps(time)
 
 
 def test_a_warm_cache_does_not_touch_the_archives(write_gpcc_archives, write_shapefile_cache):
     """The archives are gigabytes; a warm processed cache must not read or extract them."""
     cache_dir = write_gpcc_archives()
     write_shapefile_cache("world", toy_world())
-    load_gpcc_data(cache_dir, repair_ISO_codes=False)
+    load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False)
 
-    for decade in GPCC_DECADES:
-        (cache_dir / "gpcc" / gpcc_archive_name(decade)).unlink()
-        (cache_dir / "gpcc" / extracted_name(decade)).unlink()
+    for archive in TOY_ARCHIVES:
+        (cache_dir / "gpcc" / archive).unlink()
+        (cache_dir / "gpcc" / extracted_name(archive)).unlink()
 
-    assert not load_gpcc_data(cache_dir, repair_ISO_codes=False).empty
+    assert not load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False).empty
 
 
 def test_cells_are_averaged_per_country_and_month():
@@ -107,22 +144,22 @@ def test_an_interrupted_extraction_leaves_nothing_to_trust(write_gpcc_archives, 
 
     monkeypatch.setattr(shutil, "copyfileobj", die_partway)
     with pytest.raises(OSError, match="no space left"):
-        load_gpcc_data(cache_dir, repair_ISO_codes=False)
+        load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False)
 
     monkeypatch.undo()
-    assert not (cache_dir / "gpcc" / extracted_name(GPCC_DECADES[0])).exists()
-    assert not load_gpcc_data(cache_dir, repair_ISO_codes=False).empty
+    assert not (cache_dir / "gpcc" / extracted_name(TOY_ARCHIVES[0])).exists()
+    assert not load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False).empty
 
 
 def test_the_archives_are_decompressed_before_reading(write_gpcc_archives, write_shapefile_cache):
     """The published files are gzipped NetCDF; reading one without decompressing raises."""
     cache_dir = write_gpcc_archives()
-    archive = cache_dir / "gpcc" / gpcc_archive_name(GPCC_DECADES[0])
+    archive = cache_dir / "gpcc" / TOY_ARCHIVES[0]
 
     assert gzip.decompress(archive.read_bytes())[1:4] == b"HDF"
 
     write_shapefile_cache("world", toy_world())
-    assert not load_gpcc_data(cache_dir, repair_ISO_codes=False).empty
+    assert not load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False).empty
 
 
 def test_the_world_boundaries_decide_the_countries():

--- a/tests/data/test_gpcc.py
+++ b/tests/data/test_gpcc.py
@@ -9,8 +9,8 @@ from climate_risk.data.gpcc import load_gpcc_data, transform_gpcc
 from tests.conftest import GPCC_DECADES, gpcc_archive_name, toy_world
 
 # Stated literally, so a wrong cache key fails rather than agreeing with itself.
-UNREPAIRED_CACHE = "gpcc__coverage=1981-2020__repaired_iso=False.parquet"
-REPAIRED_CACHE = "gpcc__coverage=1981-2020__repaired_iso=True.parquet"
+UNREPAIRED_CACHE = "gpcc__coverage=1891-2020__repaired_iso=False.parquet"
+REPAIRED_CACHE = "gpcc__coverage=1891-2020__repaired_iso=True.parquet"
 
 
 def gridded(rows) -> pd.DataFrame:

--- a/tests/data/test_gpcc.py
+++ b/tests/data/test_gpcc.py
@@ -9,8 +9,8 @@ from climate_risk.data.gpcc import load_gpcc_data, transform_gpcc
 from tests.conftest import GPCC_DECADES, gpcc_archive_name, toy_world
 
 # Stated literally, so a wrong cache key fails rather than agreeing with itself.
-UNREPAIRED_CACHE = "gpcc__repaired_iso=False.parquet"
-REPAIRED_CACHE = "gpcc__repaired_iso=True.parquet"
+UNREPAIRED_CACHE = "gpcc__coverage=1981-2020__repaired_iso=False.parquet"
+REPAIRED_CACHE = "gpcc__coverage=1981-2020__repaired_iso=True.parquet"
 
 
 def gridded(rows) -> pd.DataFrame:

--- a/tests/data/test_gpcc.py
+++ b/tests/data/test_gpcc.py
@@ -65,6 +65,18 @@ def test_the_monitoring_dates_are_decoded_rather_than_read_as_numbers(write_gpcc
     assert months.max() == pd.Timestamp("2021-01-01")
 
 
+def test_a_wider_manifest_rebuilds_rather_than_reading_the_narrower_cache(write_gpcc_archives, write_shapefile_cache):
+    """Extending the record must not serve the shorter frame a previous run left on disk."""
+    cache_dir = write_gpcc_archives()
+    write_shapefile_cache("world", toy_world())
+    full_data, monitoring = toy_gpcc_products()
+
+    narrow = load_gpcc_data(cache_dir, products=(full_data,), repair_ISO_codes=False)
+    wide = load_gpcc_data(cache_dir, products=(full_data, monitoring), repair_ISO_codes=False)
+
+    assert len(wide) > len(narrow)
+
+
 def test_the_published_manifest_lists_an_archive_for_every_period_it_claims():
     """A decade or a month left off the list is a hole in the record that nothing downstream sees."""
     full_data, monitoring = GPCC_PRODUCTS

--- a/tests/data/test_ocean_heat.py
+++ b/tests/data/test_ocean_heat.py
@@ -6,8 +6,9 @@ import requests
 
 from climate_risk.data.ocean_heat import OCEAN_HEAT, load_ocean_heat_data, transform_ocean_heat
 
-# Upstream names its columns date and anomaly; the loader replaces the header row.
-PUBLISHED = "date,anomaly\n1960-01,0.0\n1960-07,2.0\n1961-02,10.0\n1961-08,20.0\n"
+# Upstream names its columns date and anomaly; the loader replaces the header row. The record is
+# quarterly and the month is written unpadded below October, so both spellings appear here.
+PUBLISHED = "date,anomaly\n1960-3,0.0\n1960-6,2.0\n1961-9,10.0\n1961-12,20.0\n"
 
 
 @pytest.fixture
@@ -41,13 +42,21 @@ def published(monkeypatch):
 
 @pytest.fixture
 def seasonal():
-    return pl.DataFrame({"Date": ["1960-01", "1960-07", "1961-02", "1961-08"], "Temp": [0.0, 2.0, 10.0, 20.0]})
+    return pl.DataFrame({"Date": ["1960-3", "1960-6", "1961-9", "1961-12"], "Temp": [0.0, 2.0, 10.0, 20.0]})
 
 
 def test_annual_means_are_shifted_onto_the_baseline(seasonal):
     """The offset is stated literally: the published results move if it is ever retuned."""
     annual = transform_ocean_heat(seasonal)
 
+    assert annual["Temp"].to_list() == pytest.approx([153.0, 167.0])
+
+
+def test_a_month_upstream_left_unpadded_is_still_read(seasonal):
+    """NCEI writes 1960-3, not 1960-03. A %Y-%m parse rejects 214 of the 285 published rows."""
+    annual = transform_ocean_heat(seasonal)
+
+    assert annual["Date"].to_list() == [date(1960, 1, 1), date(1961, 1, 1)]
     assert annual["Temp"].to_list() == pytest.approx([153.0, 167.0])
 
 

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -5,7 +5,7 @@ import requests
 
 from climate_risk.data.co2 import CO2
 from climate_risk.data.fetch import USER_AGENT
-from climate_risk.data.gpcc import GPCC
+from climate_risk.data.gpcc import FULL_DATA, MONITORING
 from climate_risk.data.hadcrut import HADCRUT
 from climate_risk.data.ocean_heat import OCEAN_HEAT
 from climate_risk.data.source import DataSource
@@ -47,9 +47,12 @@ def test_an_unparseable_retrieved_date_is_rejected():
 
 
 # Every source the library downloads. A new one is added here so the reachability check covers it.
-SOURCES = {"CO2": CO2, "OCEAN_HEAT": OCEAN_HEAT, "HADCRUT": HADCRUT} | {
-    f"GPCC[{decade}]": archive for decade, archive in GPCC.items()
-}
+# The monitoring archives all share one URL pattern, so its ends are checked rather than every month.
+SOURCES = (
+    {"CO2": CO2, "OCEAN_HEAT": OCEAN_HEAT, "HADCRUT": HADCRUT}
+    | {archive.filename: archive for archive in FULL_DATA.sources}
+    | {archive.filename: archive for archive in (MONITORING.sources[0], MONITORING.sources[-1])}
+)
 
 
 @pytest.mark.network

--- a/tests/data_functions/test_combine_data.py
+++ b/tests/data_functions/test_combine_data.py
@@ -5,12 +5,13 @@ import pytest
 
 from climate_risk import load_all_data
 from climate_risk.data_functions.combine_data import _annual_precipitation
-from tests.conftest import emdat_event
+from tests.conftest import emdat_event, write_merge_cache
 
 
-@pytest.fixture
-def merged(write_full_cache):
-    return load_all_data(write_full_cache())
+@pytest.fixture(scope="module")
+def merged(tmp_path_factory):
+    """Built once: every test here only reads the merge, and rebuilding it per test dominated them."""
+    return load_all_data(write_merge_cache(tmp_path_factory.mktemp("merge")))
 
 
 @pytest.mark.parametrize("frame", ["emdat_events", "emdat_damage", "wb_data"])

--- a/tests/data_functions/test_combine_data.py
+++ b/tests/data_functions/test_combine_data.py
@@ -1,9 +1,10 @@
-from datetime import date
+from datetime import date, datetime
 
 import polars as pl
 import pytest
 
 from climate_risk import load_all_data
+from climate_risk.data_functions.combine_data import _annual_precipitation
 from tests.conftest import emdat_event
 
 
@@ -46,14 +47,32 @@ def test_precipitation_is_totalled_over_the_year_not_averaged(merged):
     """GPCC publishes monthly; the panel wants the year's total rainfall, not a monthly mean."""
     annual = merged["gpcc"].filter((pl.col("ISO") == "AAA") & (pl.col("year") == date(1990, 1, 1)))
 
-    assert annual["precip"].to_list() == [pytest.approx(210.0)]
+    # AAA's 1990 months run 101..112, totalling 1278 against a monthly mean of 106.5.
+    assert annual["precip"].to_list() == [pytest.approx(1278.0)]
+
+
+def test_a_year_the_record_only_partly_covers_is_dropped():
+    """The near-real-time product ends mid-year, and a part-year total reads as a drought, not a gap."""
+    monthly = pl.DataFrame(
+        {
+            "country_code": ["AAA"] * 15,
+            "time": [datetime(2020, month, 1) for month in range(1, 13)]
+            + [datetime(2021, month, 1) for month in range(1, 4)],
+            "precip": [10.0] * 15,
+        }
+    )
+
+    by_country, worldwide = _annual_precipitation(monthly)
+
+    assert by_country["year"].to_list() == [date(2020, 1, 1)]
+    assert worldwide["year"].to_list() == [date(2020, 1, 1)]
 
 
 def test_the_worldwide_series_totals_every_country(merged):
     """It feeds a country-invariant regressor, so it sums across countries rather than averaging."""
     nineteen_ninety = merged["gpcc_agg"].filter(pl.col("year") == date(1990, 1, 1))
 
-    assert nineteen_ninety["precip"].to_list() == [pytest.approx(210.0 + 410.0 + 610.0)]
+    assert nineteen_ninety["precip"].to_list() == [pytest.approx(1278.0 + 2478.0 + 3678.0)]
 
 
 def test_the_time_series_carries_no_country(merged):

--- a/tests/test_replication_data.py
+++ b/tests/test_replication_data.py
@@ -6,7 +6,7 @@ import polars as pl
 import pytest
 
 from climate_risk.replication_data import create_replication_data
-from tests.conftest import GPCC_CACHE_FILE, emdat_event
+from tests.conftest import GPCC_CACHE_FILE, emdat_event, write_emdat_workbook
 
 # Long enough that `iloc[1:-1]` still leaves an STL-able series: STL(period=3) needs 2*3+1 points.
 YEARS = tuple(range(1985, 2021))
@@ -35,13 +35,14 @@ SAMPLE_YEAR = YEARS[1]
 QUIET_YEAR = 1975
 
 
-@pytest.fixture
-def wide_cache(tmp_path, write_emdat_cache):
+@pytest.fixture(scope="module")
+def wide_cache(tmp_path_factory):
     """A cache spanning enough years for the trend fit and the climatology to do anything.
 
     AAA gets a drought on top of its flood, so climatological and hydrological damage are both
     present for one country and only hydrological for the others.
     """
+    tmp_path = tmp_path_factory.mktemp("replication")
     events = [
         emdat_event({"ISO": iso, "DisNo.": f"{iso}-{year}", "Start Year": year, "End Year": year})
         for iso in EMDAT_COUNTRIES
@@ -59,7 +60,7 @@ def wide_cache(tmp_path, write_emdat_cache):
         )
         for year in YEARS
     ]
-    write_emdat_cache(events)
+    write_emdat_workbook(tmp_path, events)
 
     world_bank = [
         (iso, year, 1000 + 100 * n + 10 * i, 10 + 10 * n + i, 1_000_000 + 100_000 * n + 1000 * i)
@@ -92,8 +93,9 @@ def wide_cache(tmp_path, write_emdat_cache):
     return tmp_path
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def replication(wide_cache):
+    """Built once: every test here only reads the panel."""
     return create_replication_data(wide_cache)
 
 

--- a/tests/test_replication_data.py
+++ b/tests/test_replication_data.py
@@ -78,10 +78,13 @@ def wide_cache(tmp_path, write_emdat_cache):
     pl.DataFrame(
         {"Date": [date(year, 1, 1) for year in YEARS], "Temp": [i + np.sin(i) for i in range(len(YEARS))]}
     ).write_parquet(tmp_path / "ocean_heat.parquet")
+    # A whole year of months, since only years the record covers in full survive the annual total.
+    # They share the year's total evenly, so the annual series is the 100(n + 1) + 5i below.
     precipitation = [
-        (iso, pd.Timestamp(f"{year}-01-01"), 100.0 * (n + 1) + 5 * i)
+        (iso, pd.Timestamp(f"{year}-{month:02d}-01"), (100.0 * (n + 1) + 5 * i) / 12)
         for n, iso in enumerate(PRECIPITATION_COUNTRIES)
         for i, year in enumerate(PRECIPITATION_YEARS)
+        for month in range(1, 13)
     ]
     pd.DataFrame(precipitation, columns=["country_code", "time", "precip"]).set_index(
         ["country_code", "time"]

--- a/tests/test_replication_data.py
+++ b/tests/test_replication_data.py
@@ -6,7 +6,7 @@ import polars as pl
 import pytest
 
 from climate_risk.replication_data import create_replication_data
-from tests.conftest import emdat_event
+from tests.conftest import GPCC_CACHE_FILE, emdat_event
 
 # Long enough that `iloc[1:-1]` still leaves an STL-able series: STL(period=3) needs 2*3+1 points.
 # Longer than CLIMATOLOGY_YEARS, so the baseline window is a real subset of the record.
@@ -79,7 +79,7 @@ def wide_cache(tmp_path, write_emdat_cache):
     ]
     pd.DataFrame(precipitation, columns=["country_code", "time", "precip"]).set_index(
         ["country_code", "time"]
-    ).to_parquet(tmp_path / "gpcc__repaired_iso=True.parquet")
+    ).to_parquet(tmp_path / GPCC_CACHE_FILE)
     return tmp_path
 
 

--- a/tests/test_replication_data.py
+++ b/tests/test_replication_data.py
@@ -15,9 +15,6 @@ YEARS = tuple(range(1985, 2021))
 # the baseline so that the reference period is neither the start of the record nor the whole of it.
 PRECIPITATION_YEARS = tuple(range(1955, 2021))
 
-# Stated literally rather than imported, so a narrowed baseline fails instead of moving with it.
-CLIMATOLOGY_BASELINE = (1961, 1990)
-
 # AAA and BBB appear everywhere. CCC is EM-DAT only and DDD World Bank only, so reconciliation has
 # something to drop from each side. EEE has both but no precipitation; FFF has only precipitation.
 EMDAT_COUNTRIES = ("AAA", "BBB", "CCC", "EEE")

--- a/tests/test_replication_data.py
+++ b/tests/test_replication_data.py
@@ -9,8 +9,14 @@ from climate_risk.replication_data import create_replication_data
 from tests.conftest import GPCC_CACHE_FILE, emdat_event
 
 # Long enough that `iloc[1:-1]` still leaves an STL-able series: STL(period=3) needs 2*3+1 points.
-# Longer than CLIMATOLOGY_YEARS, so the baseline window is a real subset of the record.
 YEARS = tuple(range(1985, 2021))
+
+# Precipitation reaches back before the panel does, as the real record does, and opens well before
+# the baseline so that the reference period is neither the start of the record nor the whole of it.
+PRECIPITATION_YEARS = tuple(range(1955, 2021))
+
+# Stated literally rather than imported, so a narrowed baseline fails instead of moving with it.
+CLIMATOLOGY_BASELINE = (1961, 1990)
 
 # AAA and BBB appear everywhere. CCC is EM-DAT only and DDD World Bank only, so reconciliation has
 # something to drop from each side. EEE has both but no precipitation; FFF has only precipitation.
@@ -75,7 +81,7 @@ def wide_cache(tmp_path, write_emdat_cache):
     precipitation = [
         (iso, pd.Timestamp(f"{year}-01-01"), 100.0 * (n + 1) + 5 * i)
         for n, iso in enumerate(PRECIPITATION_COUNTRIES)
-        for i, year in enumerate(YEARS)
+        for i, year in enumerate(PRECIPITATION_YEARS)
     ]
     pd.DataFrame(precipitation, columns=["country_code", "time", "precip"]).set_index(
         ["country_code", "time"]
@@ -198,13 +204,20 @@ def test_the_damage_logs_are_offset_so_a_zero_survives(replication):
     assert entry["ln_damage_millions"] == pytest.approx(np.log(entry["damage_millions"] + LOG_EPSILON))
 
 
-def test_precipitation_deviation_is_measured_against_the_opening_window(replication):
-    """The baseline is the first years of the record, not the whole of it."""
-    # AAA's precipitation runs 100 + 5i over 36 years: the first 30 average 172.5, all 36 average
-    # 187.5. Only the opening window centres the first year on -72.5.
-    opening = replication.filter((pl.col("ISO") == "AAA") & (pl.col("year") == date(YEARS[0], 1, 1)))
+def test_precipitation_deviation_is_measured_against_the_named_baseline_period(replication):
+    """The baseline is a fixed calendar period, not whichever years the record happens to open with."""
+    # AAA's precipitation runs 100 + 5i from 1955. The 1961-1990 window is i = 6..35 and averages
+    # 202.5, so 1985 sits 47.5 above it; the record's first 30 years would average 172.5 and put it
+    # at 77.5 instead.
+    sample = replication.filter((pl.col("ISO") == "AAA") & (pl.col("year") == date(1985, 1, 1)))
 
-    assert opening["precip_deviation"].to_list() == [pytest.approx(-72.5)]
+    assert sample["precip_deviation"].to_list() == [pytest.approx(47.5)]
+
+
+def test_a_baseline_the_record_does_not_cover_is_refused(wide_cache):
+    """A baseline drawn from a handful of years would be published under the name of a full period."""
+    with pytest.raises(ValueError, match="baseline"):
+        create_replication_data(wide_cache, baseline=(1900, 1929))
 
 
 def test_the_ocean_temperature_deviation_is_residual_around_its_trend(replication):


### PR DESCRIPTION
The climatology took the first thirty years of whatever was loaded, and GPCC only ever fetched 1981 onward, so the 1961-1990 the comment claimed was never true. Now pulls the full published record plus the near-real-time monitoring product and pins the baseline to the real period — 2021-2024 gain precipitation they never had, and those years come from a thinner analysis than the rest of the record.

Also fixes ocean heat, which couldn't parse NCEI's unpadded months and so failed on any cold cache.
