### PR TITLE
Thread a Place through the shapefile and grid loaders

### DIFF
--- a/climate_risk/config/places/lao.toml
+++ b/climate_risk/config/places/lao.toml
@@ -2,7 +2,9 @@ iso3 = "LAO"
 name = "Lao PDR"
 
 # Laos has its own admin-boundary file; countries without one are sliced out of the world shapefile.
+# The archive unpacks flat, one file per admin level; level 2 is the district layer.
 [boundary]
+member = "lao_admin2.shp"
 url = "https://data.humdata.org/dataset/9eb6aff1-9e3f-43d3-99a6-f415fe4b4dff/resource/907a1b50-0d14-40ec-8b8a-f2d027d895aa/download/lao_admin_boundaries.shp.zip"
 filename = "lao_admin_boundaries.shp.zip"
 licence = "CC BY 3.0 IGO"

--- a/climate_risk/config/registry.py
+++ b/climate_risk/config/registry.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from climate_risk.config.schema import CountryConfig, EventFilters, GeometrySpec, Place, RegionConfig
-from climate_risk.data.source import DataSource
+from climate_risk.data.source import DataSource, ShapefileArchive
 
 CONFIG_ROOT = Path(__file__).parent
 
@@ -42,7 +42,7 @@ def read_place(path: Path) -> Place:
     build = RegionConfig if path.parent.name == REGION_SUBDIRECTORY else CountryConfig
     try:
         return build(**_nested(table))
-    except TypeError as error:
+    except (TypeError, ValueError) as error:
         raise ValueError(f"{path} does not match the {build.__name__} schema: {error}") from error
 
 
@@ -86,9 +86,12 @@ def _nested(table: dict[str, Any]) -> dict[str, Any]:
     """Turn a place's sub-tables into the objects the schema expects, leaving the rest alone."""
     fields = dict(table)
 
-    for key, build in (("boundary", DataSource), ("geometry", GeometrySpec), ("events", EventFilters)):
+    for key, build in (("geometry", GeometrySpec), ("events", EventFilters)):
         if key in fields:
             fields[key] = build(**fields[key])
+
+    if "boundary" in fields:
+        fields["boundary"] = _boundary(fields["boundary"])
 
     if "members" in fields:
         # TOML arrays parse as lists, and the schema promises a tuple.
@@ -100,6 +103,17 @@ def _nested(table: dict[str, Any]) -> dict[str, Any]:
         }
 
     return fields
+
+
+def _boundary(table: dict[str, Any]) -> ShapefileArchive:
+    """Split a ``[boundary]`` table into the archive to fetch and the layer to read from it."""
+    fields = dict(table)
+    try:
+        member = fields.pop("member")
+    except KeyError:
+        raise ValueError("a [boundary] must set member, naming the layer to read inside its archive") from None
+
+    return ShapefileArchive(DataSource(**fields), member)
 
 
 def _place_keys(root: Path) -> list[str]:

--- a/climate_risk/config/registry.py
+++ b/climate_risk/config/registry.py
@@ -82,6 +82,11 @@ def resolve_isos(place: Place) -> tuple[str, ...]:
     return (place.iso3,) if isinstance(place, CountryConfig) else place.members
 
 
+def place_key(place: Place) -> str:
+    """Return the short name a place is filed and cached under."""
+    return place.iso3.lower() if isinstance(place, CountryConfig) else place.key
+
+
 def _nested(table: dict[str, Any]) -> dict[str, Any]:
     """Turn a place's sub-tables into the objects the schema expects, leaving the rest alone."""
     fields = dict(table)

--- a/climate_risk/config/schema.py
+++ b/climate_risk/config/schema.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
-from climate_risk.data.source import DataSource
+from climate_risk.data.source import ShapefileArchive
 from climate_risk.geo.crs import GEOGRAPHIC_CRS, PROJECTED_CRS
 
 # An ISO 3166-1 alpha-3 code, which is what every frame in the project keys countries on.
@@ -85,9 +85,9 @@ class CountryConfig:
         Human-readable name, used in figures and messages.
     island : bool
         Whether the country is an island, which the point features record. Default False.
-    boundary : DataSource, optional
-        Where to fetch a country-specific boundary file. Default None, meaning slice the world
-        shapefile by ``iso3``.
+    boundary : ShapefileArchive, optional
+        A country-specific boundary archive, and the layer within it to read. Default None, meaning
+        slice the world shapefile by ``iso3``.
     geometry : GeometrySpec
         Projection and grid settings. Defaults to the project-wide ones.
     events : EventFilters
@@ -107,7 +107,7 @@ class CountryConfig:
     iso3: str
     name: str
     island: bool = False
-    boundary: DataSource | None = None
+    boundary: ShapefileArchive | None = None
     geometry: GeometrySpec = field(default_factory=GeometrySpec)
     events: EventFilters = field(default_factory=EventFilters)
     event_location_overrides: Mapping[str, tuple[float, float]] = field(default_factory=dict)

--- a/climate_risk/data/source.py
+++ b/climate_risk/data/source.py
@@ -44,3 +44,37 @@ class DataSource:
     def path(self, cache_dir: Path) -> Path:
         """Return where this source is stored inside ``cache_dir``."""
         return cache_dir / self.filename
+
+
+@dataclass(frozen=True, slots=True)
+class ShapefileArchive:
+    """
+    A zipped shapefile, together with the layer inside it to read.
+
+    Parameters
+    ----------
+    source : DataSource
+        The archive to fetch.
+    member : str
+        Path to the layer within the archive, case included. A case-insensitive filesystem hides a
+        mismatch here that fails on Linux.
+
+    Raises
+    ------
+    ValueError
+        If ``member`` is empty, or escapes the directory the archive unpacks into.
+    """
+
+    source: DataSource
+    member: str
+
+    def __post_init__(self) -> None:
+        if not self.member:
+            raise ValueError(f"{self.source.filename}: member must name a layer inside the archive")
+
+        if Path(self.member).is_absolute() or ".." in Path(self.member).parts:
+            raise ValueError(f"{self.source.filename}: member must stay inside the archive, got {self.member!r}")
+
+    def extracted_path(self, directory: Path) -> Path:
+        """Return where this archive's layer unpacks to under ``directory``."""
+        return directory / self.member

--- a/climate_risk/data_functions/disaster_point_data.py
+++ b/climate_risk/data_functions/disaster_point_data.py
@@ -7,6 +7,8 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 
+from climate_risk.config.registry import place_key, resolve_isos
+from climate_risk.config.schema import Place
 from climate_risk.data.cache import cached, geo_parquet
 from climate_risk.data_functions.emdat_processing import load_emdat_data
 from climate_risk.data_functions.rivers_damage import load_rivers_data
@@ -19,13 +21,6 @@ _log = logging.getLogger(__name__)
 
 # The default generator is seeded so a run reproduces, which is why callers may pass their own.
 SAMPLING_SEED = sum(map(ord, "Laos GGGI Climate Adaptation"))
-
-# Singapore and Brunei are left out: both are small enough that the grid resolves to too few
-# points to be worth carrying.
-REGION_ISO_CODES = {
-    "laos": ("LAO",),
-    "sea": ("MMR", "THA", "LAO", "KHM", "VNM", "IDN", "MYS", "PHL", "TLS"),
-}
 
 
 def disaster_points_path(cache_dir: Path) -> Path:
@@ -100,34 +95,43 @@ def load_disaster_point_data(cache_dir: Path):
 
 def load_grid_point_data(
     cache_dir: Path,
+    place: Place,
     *,
-    region="laos",
-    grid_size=400,
-    iso_list: list | None = None,
     force_reload: bool = False,
-    file_reg_name: str | None = None,
-    altered_shape_file=None,
+    altered_shape_file: gpd.GeoDataFrame | None = None,
     include_medium_rivers: bool = True,
-):
-    if region not in ["laos", "sea", "custom"]:
-        raise ValueError(f"Unknown grid: {region}")
+) -> gpd.GeoDataFrame:
+    """
+    Build the point grid covering a place, and cache it.
 
-    if region == "custom" and iso_list is None:
-        raise ValueError("Must provide an iso_list for custom region")
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the shapefile, river and grid caches live under.
+    place : CountryConfig or RegionConfig
+        The place to grid. Its ``geometry.grid_size`` sets the resolution, and the codes it resolves
+        to select the geometry out of the world shapefile.
+    force_reload : bool, optional
+        Rebuild even when the cache is warm. Default False.
+    altered_shape_file : GeoDataFrame, optional
+        Geometry to grid instead of the place's own. Default None.
+    include_medium_rivers : bool, optional
+        Whether medium-flow rivers count towards the distance features. Default True.
 
-    if (region == "custom") and file_reg_name is None:
-        raise ValueError("Please provide a file_reg_name for the custom region")
-
-    if region in ("laos", "sea"):
-        file_reg_name = region
-        iso_list = list(REGION_ISO_CODES[region])
+    Returns
+    -------
+    GeoDataFrame
+        One row per grid point falling on land, with distances to river and coastline.
+    """
+    grid_size = place.geometry.grid_size
+    iso_codes = resolve_isos(place)
 
     def build() -> gpd.GeoDataFrame:
         _log.info("Loading shapefiles and rivers data")
         world = load_shapefile("world", cache_dir)
 
         if altered_shape_file is None:
-            point_map = world[world["ISO_A3"].isin(iso_list)]
+            point_map = world[world["ISO_A3"].isin(iso_codes)]
 
         else:
             point_map = altered_shape_file
@@ -179,7 +183,7 @@ def load_grid_point_data(
         "points",
         build,
         geo_parquet(),
-        params={"region": file_reg_name, "grid_size": grid_size},
+        params={"region": place_key(place), "grid_size": grid_size},
         force=force_reload,
     )
 

--- a/climate_risk/data_functions/shapefiles_data_loader.py
+++ b/climate_risk/data_functions/shapefiles_data_loader.py
@@ -94,11 +94,6 @@ def shapefile_dir(cache_dir: Path) -> Path:
     return cache_dir / "shapefiles"
 
 
-def _extracted_path(which: str, cache_dir: Path) -> Path:
-    """Where the archive for ``which`` unpacks to, which is what every later step reads."""
-    return _archive_for(which).extracted_path(shapefile_dir(cache_dir))
-
-
 def _archive_for(which: str) -> ShapefileArchive:
     try:
         return SHAPEFILE_ARCHIVES[which.lower()]

--- a/climate_risk/data_functions/shapefiles_data_loader.py
+++ b/climate_risk/data_functions/shapefiles_data_loader.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 import geopandas as gpd
 
 from climate_risk.data.fetch import fetch
-from climate_risk.data.source import DataSource
+from climate_risk.data.source import DataSource, ShapefileArchive
 from climate_risk.exceptions import DataValidationError, ISOCodeValidationError
 
 _log = logging.getLogger(__name__)
@@ -50,19 +50,15 @@ COASTLINE = DataSource(
     retrieved="2026-08-08",
 )
 
-SHAPEFILE_SOURCES = {"world": WORLD, "laos": LAOS, "coastline": COASTLINE}
-
-# Paths inside each archive, case included -- a case-insensitive filesystem hides a mismatch here
-# that fails on Linux.
-SHAPEFILE_MEMBERS = {
-    "world": "WB_countries_Admin0_10m",
+SHAPEFILE_ARCHIVES = {
+    "world": ShapefileArchive(WORLD, "WB_countries_Admin0_10m"),
     # The Laos archive unpacks flat, one file per admin level. Level 2 is the district layer the
     # point grid is built from.
-    "laos": "lao_admin2.shp",
-    "coastline": "GSHHS_shp/f",
+    "laos": ShapefileArchive(LAOS, "lao_admin2.shp"),
+    "coastline": ShapefileArchive(COASTLINE, "GSHHS_shp/f"),
 }
 
-VALID_CHOICES = list(SHAPEFILE_SOURCES)
+VALID_CHOICES = list(SHAPEFILE_ARCHIVES)
 
 # The boundary file lists these separately but tags them with their owner's ISO code, or with no
 # code at all, so counting them would double-count the owner or introduce a country that is not one.
@@ -98,12 +94,12 @@ def shapefile_dir(cache_dir: Path) -> Path:
 
 def _extracted_path(which: str, cache_dir: Path) -> Path:
     """Where the archive for ``which`` unpacks to, which is what every later step reads."""
-    return shapefile_dir(cache_dir) / SHAPEFILE_MEMBERS[which.lower()]
+    return _archive_for(which).extracted_path(shapefile_dir(cache_dir))
 
 
-def _source_for(which: str) -> DataSource:
+def _archive_for(which: str) -> ShapefileArchive:
     try:
-        return SHAPEFILE_SOURCES[which.lower()]
+        return SHAPEFILE_ARCHIVES[which.lower()]
     except KeyError:
         raise ValueError(f"which should be one of {VALID_CHOICES}, got {which}") from None
 
@@ -154,20 +150,20 @@ def repair_iso_codes(world: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
 
 def download_shapefile(which: str, cache_dir: Path, *, force_reload: bool = False) -> Path:
     """Fetch the archive for ``which`` into the shapefile cache and return where it landed."""
-    return fetch(_source_for(which), shapefile_dir(cache_dir), force=force_reload)
+    return fetch(_archive_for(which).source, shapefile_dir(cache_dir), force=force_reload)
 
 
 def extract_shapefiles(which: str, cache_dir: Path, *, force_reload: bool = False) -> None:
     """Unpack the archive for ``which`` unless what it holds is already on disk."""
-    source = _source_for(which)
+    archive = _archive_for(which)
     directory = shapefile_dir(cache_dir)
 
-    if _extracted_path(which, cache_dir).exists() and not force_reload:
+    if archive.extracted_path(directory).exists() and not force_reload:
         return
 
-    _log.info(f"Extracting {source.filename}")
-    with ZipFile(source.path(directory)) as archive:
-        archive.extractall(path=directory)
+    _log.info(f"Extracting {archive.source.filename}")
+    with ZipFile(archive.source.path(directory)) as zipped:
+        zipped.extractall(path=directory)
 
 
 def load_shapefile(

--- a/climate_risk/data_functions/shapefiles_data_loader.py
+++ b/climate_risk/data_functions/shapefiles_data_loader.py
@@ -5,6 +5,8 @@ from zipfile import ZipFile
 
 import geopandas as gpd
 
+from climate_risk.config.registry import resolve_isos
+from climate_risk.config.schema import CountryConfig, Place
 from climate_risk.data.fetch import fetch
 from climate_risk.data.source import DataSource, ShapefileArchive
 from climate_risk.exceptions import DataValidationError, ISOCodeValidationError
@@ -155,9 +157,10 @@ def download_shapefile(which: str, cache_dir: Path, *, force_reload: bool = Fals
 
 def extract_shapefiles(which: str, cache_dir: Path, *, force_reload: bool = False) -> None:
     """Unpack the archive for ``which`` unless what it holds is already on disk."""
-    archive = _archive_for(which)
-    directory = shapefile_dir(cache_dir)
+    _extract(_archive_for(which), shapefile_dir(cache_dir), force_reload=force_reload)
 
+
+def _extract(archive: ShapefileArchive, directory: Path, *, force_reload: bool) -> None:
     if archive.extracted_path(directory).exists() and not force_reload:
         return
 
@@ -166,15 +169,61 @@ def extract_shapefiles(which: str, cache_dir: Path, *, force_reload: bool = Fals
         zipped.extractall(path=directory)
 
 
+def load_archive(archive: ShapefileArchive, cache_dir: Path, *, force_reload: bool = False) -> gpd.GeoDataFrame:
+    """Fetch, unpack and read an archive, whether or not a registry entry names it."""
+    directory = shapefile_dir(cache_dir)
+
+    fetch(archive.source, directory, force=force_reload)
+    _extract(archive, directory, force_reload=force_reload)
+
+    return gpd.read_file(archive.extracted_path(directory), layer=0)
+
+
 def load_shapefile(
     which: str, cache_dir: Path, *, force_reload: bool = False, repair_ISO_codes: bool = True
 ) -> gpd.GeoDataFrame:
-    download_shapefile(which, cache_dir, force_reload=force_reload)
-    extract_shapefiles(which, cache_dir, force_reload=force_reload)
-
-    frame = gpd.read_file(_extracted_path(which, cache_dir), layer=0)
+    frame = load_archive(_archive_for(which), cache_dir, force_reload=force_reload)
 
     if which.lower() == "world" and repair_ISO_codes:
         return repair_iso_codes(frame)
 
     return frame
+
+
+def load_place_boundary(place: Place, cache_dir: Path, *, force_reload: bool = False) -> gpd.GeoDataFrame:
+    """
+    Read the geometry a place covers.
+
+    A place carrying its own boundary archive reads that; everything else is sliced out of the world
+    shapefile by the ISO codes the place resolves to.
+
+    Parameters
+    ----------
+    place : CountryConfig or RegionConfig
+        The place to read the geometry of.
+    cache_dir : Path
+        Directory the shapefile cache lives under.
+    force_reload : bool, optional
+        Re-download and re-unpack even when the cache is warm. Default False.
+
+    Returns
+    -------
+    GeoDataFrame
+        The place's geometry, in the boundary file's own CRS.
+
+    Raises
+    ------
+    DataValidationError
+        If the place resolves to no geometry, which would otherwise yield an empty grid.
+    """
+    if isinstance(place, CountryConfig) and place.boundary is not None:
+        return load_archive(place.boundary, cache_dir, force_reload=force_reload)
+
+    codes = resolve_isos(place)
+    world = load_shapefile("world", cache_dir, force_reload=force_reload)
+    boundary = world[world["ISO_A3"].isin(codes)]
+
+    if boundary.empty:
+        raise DataValidationError(f"The boundary file holds no geometry for {list(codes)}, so the grid would be empty.")
+
+    return boundary

--- a/climate_risk/geo/grid.py
+++ b/climate_risk/geo/grid.py
@@ -11,6 +11,8 @@ def create_grid_from_shape(
     rivers: gpd.GeoDataFrame,
     coastline: gpd.GeoDataFrame,
     grid_size: int = 100,
+    *,
+    iso3: str | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Lay a regular grid over the bounds of ``shapefile`` and measure each point to river and coast.
@@ -26,13 +28,27 @@ def create_grid_from_shape(
         Coastline geometries. Distance is measured to the boundary.
     grid_size : int, optional
         Points per axis, so the grid holds ``grid_size ** 2`` before clipping. Default 100.
+    iso3 : str, optional
+        Code to label every point with when ``shapefile`` carries no ``ISO_A3`` column. Default
+        None, which requires the geometry to label itself.
 
     Returns
     -------
     GeoDataFrame
         One row per surviving point, with ``lon``, ``lat``, distances to the nearest river and
         coastline, their logs, and ``ISO``.
+
+    Raises
+    ------
+    ValueError
+        If the geometry carries no ``ISO_A3`` column and no ``iso3`` says what to label it.
     """
+    labelled = "ISO_A3" in shapefile.columns
+    if not labelled and iso3 is None:
+        raise ValueError(
+            "The geometry carries no ISO_A3 column, so pass iso3 to say which country its points belong to."
+        )
+
     long_min, lat_min, long_max, lat_max = shapefile.dissolve().bounds.values.ravel()
     long_grid = np.linspace(long_min, long_max, grid_size)
     lat_grid = np.linspace(lat_min, lat_max, grid_size)
@@ -65,9 +81,6 @@ def create_grid_from_shape(
         )
     )
 
-    if "ISO_A3" in point_overlay.columns:
-        points["ISO"] = point_overlay.ISO_A3
-    else:
-        points["ISO"] = "LAO"
+    points["ISO"] = point_overlay["ISO_A3"] if labelled else iso3
 
     return points

--- a/tests/config/test_places.py
+++ b/tests/config/test_places.py
@@ -1,7 +1,7 @@
 import pytest
 
 from climate_risk.config.registry import CONFIG_ROOT, load_place, read_place, resolve_isos
-from climate_risk.config.schema import CountryConfig, RegionConfig
+from climate_risk.config.schema import CountryConfig, EventFilters, GeometrySpec, RegionConfig
 from climate_risk.data.world_bank import COUNTRY_CODE_BY_NAME
 from climate_risk.data_functions.disaster_point_data import REGION_ISO_CODES
 from climate_risk.data_functions.rivers_damage import LAOS_LOCATION_DICTIONARY
@@ -55,11 +55,11 @@ def test_laos_carries_the_coordinate_overrides_the_loader_hardcodes():
 
 
 def test_laos_takes_the_project_defaults_it_does_not_override():
-    """Stating the current defaults would freeze them here and hide a later project-wide change."""
+    """Compared against the schema, not against literals, which would freeze the defaults here too."""
     place = load_place("lao")
 
-    assert place.geometry.grid_size == 400
-    assert place.events.start_year == 1970
+    assert place.geometry == GeometrySpec()
+    assert place.events == EventFilters()
 
 
 def test_southeast_asia_matches_the_region_table_the_loader_hardcodes():

--- a/tests/config/test_places.py
+++ b/tests/config/test_places.py
@@ -5,7 +5,7 @@ from climate_risk.config.schema import CountryConfig, RegionConfig
 from climate_risk.data.world_bank import COUNTRY_CODE_BY_NAME
 from climate_risk.data_functions.disaster_point_data import REGION_ISO_CODES
 from climate_risk.data_functions.rivers_damage import LAOS_LOCATION_DICTIONARY
-from climate_risk.data_functions.shapefiles_data_loader import LAOS
+from climate_risk.data_functions.shapefiles_data_loader import SHAPEFILE_ARCHIVES
 
 # Walked rather than listed, so a place file that ships without a test still has to parse.
 SHIPPED_PLACES = sorted(CONFIG_ROOT.glob("*/*.toml"))
@@ -39,7 +39,7 @@ def test_laos_carries_the_boundary_the_loader_hardcodes():
     place = load_place("lao")
 
     assert isinstance(place, CountryConfig)
-    assert place.boundary == LAOS
+    assert place.boundary == SHAPEFILE_ARCHIVES["laos"]
 
 
 def test_laos_carries_the_coordinate_overrides_the_loader_hardcodes():

--- a/tests/config/test_places.py
+++ b/tests/config/test_places.py
@@ -3,7 +3,6 @@ import pytest
 from climate_risk.config.registry import CONFIG_ROOT, load_place, read_place, resolve_isos
 from climate_risk.config.schema import CountryConfig, EventFilters, GeometrySpec, RegionConfig
 from climate_risk.data.world_bank import COUNTRY_CODE_BY_NAME
-from climate_risk.data_functions.disaster_point_data import REGION_ISO_CODES
 from climate_risk.data_functions.rivers_damage import LAOS_LOCATION_DICTIONARY
 from climate_risk.data_functions.shapefiles_data_loader import SHAPEFILE_ARCHIVES
 
@@ -62,11 +61,17 @@ def test_laos_takes_the_project_defaults_it_does_not_override():
     assert place.events == EventFilters()
 
 
-def test_southeast_asia_matches_the_region_table_the_loader_hardcodes():
+def test_southeast_asia_holds_its_nine_members():
+    """Stated literally, because this file is the only record of the list, so a silent edit must fail."""
     place = load_place("sea")
 
     assert isinstance(place, RegionConfig)
-    assert place.members == REGION_ISO_CODES["sea"]
+    assert place.members == ("MMR", "THA", "LAO", "KHM", "VNM", "IDN", "MYS", "PHL", "TLS")
+
+
+def test_laos_sits_inside_southeast_asia():
+    """A sea grid that did not contain Laos would cover the wrong place."""
+    assert set(resolve_isos(load_place("lao"))) < set(resolve_isos(load_place("sea")))
 
 
 @pytest.mark.parametrize("path", SHIPPED_PLACES, ids=lambda path: f"{path.parent.name}/{path.name}")

--- a/tests/config/test_registry.py
+++ b/tests/config/test_registry.py
@@ -57,21 +57,32 @@ def test_event_overrides_arrive_as_coordinate_pairs(config_root):
     assert place.event_location_overrides == {"1971-0048-LAO": (102.6331, 17.9757)}
 
 
-def test_a_boundary_block_becomes_a_fetchable_source(config_root):
+BOUNDARY_BLOCK = (
+    '[boundary]\nmember = "lao_admin2.shp"\n'
+    'url = "https://example.org/lao.zip"\nfilename = "lao.zip"\n'
+    'licence = "CC BY 3.0 IGO"\ncitation = "NGD"\nretrieved = "2026-08-08"\n'
+)
+
+
+def test_a_boundary_block_becomes_a_fetchable_archive(config_root):
     """It reuses `DataSource`, so a place's own boundary goes through the same fetch as everything else."""
-    root = config_root(
-        "places",
-        "lao",
-        'iso3 = "LAO"\nname = "Lao PDR"\n\n[boundary]\n'
-        'url = "https://example.org/lao.zip"\nfilename = "lao.zip"\n'
-        'licence = "CC BY 3.0 IGO"\ncitation = "NGD"\nretrieved = "2026-08-08"\n',
-    )
+    root = config_root("places", "lao", 'iso3 = "LAO"\nname = "Lao PDR"\n\n' + BOUNDARY_BLOCK)
 
     place = load_place("lao", root=root)
 
     assert isinstance(place, CountryConfig)
     assert place.boundary is not None
-    assert place.boundary.filename == "lao.zip"
+    assert place.boundary.source.filename == "lao.zip"
+    assert place.boundary.member == "lao_admin2.shp"
+
+
+def test_a_boundary_that_does_not_name_its_layer_is_an_error(config_root):
+    """The archive holds several layers, so guessing one would read a different admin level."""
+    without_member = BOUNDARY_BLOCK.replace('member = "lao_admin2.shp"\n', "")
+    root = config_root("places", "lao", 'iso3 = "LAO"\nname = "Lao PDR"\n\n' + without_member)
+
+    with pytest.raises(ValueError, match="must set member"):
+        load_place("lao", root=root)
 
 
 def test_the_directory_decides_whether_a_file_is_a_country_or_a_region(config_root):
@@ -88,6 +99,14 @@ def test_a_key_the_schema_does_not_define_is_an_error(config_root):
     root = config_root("places", "lao", 'iso3 = "LAO"\nname = "Lao PDR"\nisland_nation = true\n')
 
     with pytest.raises(ValueError, match="does not match the CountryConfig schema"):
+        load_place("lao", root=root)
+
+
+def test_a_value_the_schema_rejects_names_the_file_that_holds_it(config_root):
+    """The schema only sees the value, and a bare complaint about it does not say where to go fix it."""
+    root = config_root("places", "lao", 'iso3 = "Lao"\nname = "Lao PDR"\n')
+
+    with pytest.raises(ValueError, match=r"lao\.toml does not match the CountryConfig schema"):
         load_place("lao", root=root)
 
 

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -66,7 +66,7 @@ def place_boundaries() -> dict[str, DataSource]:
     places = (read_place(path) for path in sorted(CONFIG_ROOT.glob("*/*.toml")))
 
     return {
-        f"{place.iso3}_BOUNDARY": place.boundary
+        f"{place.iso3}_BOUNDARY": place.boundary.source
         for place in places
         if isinstance(place, CountryConfig) and place.boundary is not None
     }

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -10,7 +10,7 @@ from climate_risk.data.fetch import USER_AGENT
 from climate_risk.data.gpcc import FULL_DATA, MONITORING
 from climate_risk.data.hadcrut import HADCRUT
 from climate_risk.data.ocean_heat import OCEAN_HEAT
-from climate_risk.data.source import DataSource
+from climate_risk.data.source import DataSource, ShapefileArchive
 from climate_risk.data_functions.rivers_data_loader import RIVERS
 from climate_risk.data_functions.shapefiles_data_loader import COASTLINE, LAOS, WORLD
 
@@ -42,6 +42,17 @@ def test_a_filename_carrying_a_path_is_rejected(filename):
 def test_a_non_http_url_is_rejected(url):
     with pytest.raises(ValueError, match="http"):
         source(url=url)
+
+
+def test_an_archive_layer_unpacks_under_the_directory_it_is_given(tmp_path):
+    assert ShapefileArchive(source(), "GSHHS_shp/f").extracted_path(tmp_path) == tmp_path / "GSHHS_shp" / "f"
+
+
+@pytest.mark.parametrize("member", ["../escape.shp", "/absolute.shp", "nested/../../out.shp", ""], ids=repr)
+def test_an_archive_layer_outside_the_archive_is_rejected(member):
+    """`extracted_path` joins onto the cache directory, so an escaping member reads outside it."""
+    with pytest.raises(ValueError, match="member must"):
+        ShapefileArchive(source(), member)
 
 
 def test_an_unparseable_retrieved_date_is_rejected():

--- a/tests/data_functions/test_disaster_point_data.py
+++ b/tests/data_functions/test_disaster_point_data.py
@@ -11,8 +11,8 @@ from geopandas.testing import assert_geodataframe_equal
 from shapely.geometry import Point
 
 from climate_risk import load_synthetic_non_disaster_points
+from climate_risk.config.schema import CountryConfig, GeometrySpec
 from climate_risk.data_functions.disaster_point_data import (
-    REGION_ISO_CODES,
     _load_disaster_point_data,
     load_data,
     load_grid_point_data,
@@ -24,6 +24,11 @@ from tests.conftest import SYNTHETIC_SOURCE_EVENTS
 # A legacy cache spells longitude `long`; the value under `lon` is the one to keep.
 STALE_LON = 9.9
 CURRENT_LON = 102.5
+
+
+def france(grid_size=3):
+    """The one country of the toy world the grid fixtures put rivers and coastline near."""
+    return CountryConfig(iso3="FRA", name="France", geometry=GeometrySpec(grid_size=grid_size))
 
 
 def test_missing_geocoded_locations_names_the_file_it_looked_for(tmp_path):
@@ -41,12 +46,7 @@ def test_unknown_sampling_strategy_is_rejected(tmp_path):
 @pytest.fixture
 def grid(write_point_grid_cache):
     cache_dir = write_point_grid_cache()
-    return load_grid_point_data(cache_dir, region="custom", iso_list=["FRA"], file_reg_name="toy", grid_size=3)
-
-
-def test_the_laos_grid_is_a_strict_subset_of_the_sea_grid():
-    """Laos sits inside South-East Asia, so a sea grid that did not contain it covers the wrong place."""
-    assert set(REGION_ISO_CODES["laos"]) < set(REGION_ISO_CODES["sea"])
+    return load_grid_point_data(cache_dir, france())
 
 
 def test_grid_columns_use_lon_not_long(grid):
@@ -64,7 +64,7 @@ def test_zero_distances_do_not_become_infinite_logs(write_point_grid_cache, rive
     """The grid is written to disk, so a -inf from log(0) persists into every later run."""
     cache_dir = write_point_grid_cache(rivers_through_the_grid)
 
-    grid = load_grid_point_data(cache_dir, region="custom", iso_list=["FRA"], file_reg_name="toy", grid_size=3)
+    grid = load_grid_point_data(cache_dir, france())
 
     on_a_river = grid[grid["distance_to_river"] == 0]
 
@@ -81,21 +81,30 @@ def test_zero_distances_do_not_become_infinite_logs(write_point_grid_cache, rive
 def test_a_different_grid_size_is_a_different_cache_entry(write_point_grid_cache):
     """Two resolutions sharing one entry would serve whichever run happened first."""
     cache_dir = write_point_grid_cache()
-    kwargs: dict[str, Any] = {"region": "custom", "iso_list": ["FRA"], "file_reg_name": "toy"}
 
-    coarse = load_grid_point_data(cache_dir, grid_size=3, **kwargs)
-    fine = load_grid_point_data(cache_dir, grid_size=6, **kwargs)
+    coarse = load_grid_point_data(cache_dir, france(grid_size=3))
+    fine = load_grid_point_data(cache_dir, france(grid_size=6))
 
     assert len(fine) > len(coarse)
+
+
+def test_two_places_do_not_share_a_cache_entry(write_point_grid_cache):
+    """One entry for both would serve whichever place happened to be gridded first."""
+    cache_dir = write_point_grid_cache()
+    netherlands = CountryConfig(iso3="NLD", name="Netherlands", geometry=GeometrySpec(grid_size=3))
+
+    french = load_grid_point_data(cache_dir, france())
+    dutch = load_grid_point_data(cache_dir, netherlands)
+
+    assert french["lon"].max() < dutch["lon"].min()
 
 
 def test_the_cached_grid_round_trips_unchanged(write_point_grid_cache):
     """The grid is written once and read on every later run, so the two must be the same frame."""
     cache_dir = write_point_grid_cache()
-    kwargs: dict[str, Any] = {"region": "custom", "iso_list": ["FRA"], "file_reg_name": "toy", "grid_size": 3}
 
-    written = load_grid_point_data(cache_dir, **kwargs)
-    reloaded = load_grid_point_data(cache_dir, **kwargs)
+    written = load_grid_point_data(cache_dir, france())
+    reloaded = load_grid_point_data(cache_dir, france())
 
     assert_geodataframe_equal(reloaded, written)
     assert {"distance_to_river", "log_distance_to_river", "log_distance_to_coastline"} <= set(reloaded.columns)

--- a/tests/data_functions/test_shapefiles_data_loader.py
+++ b/tests/data_functions/test_shapefiles_data_loader.py
@@ -4,18 +4,9 @@ import pandas as pd
 import pytest
 
 from climate_risk import load_shapefile
-from climate_risk.data_functions.shapefiles_data_loader import (
-    SHAPEFILE_MEMBERS,
-    SHAPEFILE_SOURCES,
-    repair_iso_codes,
-)
+from climate_risk.data_functions.shapefiles_data_loader import repair_iso_codes
 from climate_risk.exceptions import DataValidationError, ISOCodeValidationError
 from tests.conftest import toy_world, toy_world_needing_repair
-
-
-def test_every_declared_source_knows_where_its_archive_unpacks():
-    """A source without a member entry passes validation and then dies on a KeyError mid-load."""
-    assert set(SHAPEFILE_SOURCES) == set(SHAPEFILE_MEMBERS)
 
 
 def test_unknown_shapefile_is_rejected(tmp_path):

--- a/tests/data_functions/test_shapefiles_data_loader.py
+++ b/tests/data_functions/test_shapefiles_data_loader.py
@@ -1,10 +1,16 @@
+import re
 import shutil
 
 import pandas as pd
 import pytest
 
 from climate_risk import load_shapefile
-from climate_risk.data_functions.shapefiles_data_loader import repair_iso_codes
+from climate_risk.config.schema import CountryConfig, RegionConfig
+from climate_risk.data_functions.shapefiles_data_loader import (
+    SHAPEFILE_ARCHIVES,
+    load_place_boundary,
+    repair_iso_codes,
+)
 from climate_risk.exceptions import DataValidationError, ISOCodeValidationError
 from tests.conftest import toy_world, toy_world_needing_repair
 
@@ -106,3 +112,41 @@ def test_duplicate_iso_codes_are_an_error():
 
     with pytest.raises(ISOCodeValidationError, match="NLD"):
         repair_iso_codes(doubled)
+
+
+def test_a_place_with_its_own_boundary_reads_that_archive(write_shapefile_cache):
+    """Its own file defines its extent, so nothing about the world shapefile should narrow it."""
+    cache_dir = write_shapefile_cache("laos", toy_world())
+    place = CountryConfig(iso3="AAA", name="Aland", boundary=SHAPEFILE_ARCHIVES["laos"])
+
+    boundary = load_place_boundary(place, cache_dir)
+
+    assert sorted(boundary["ISO_A3"]) == ["AAA", "BBB", "CCC"]
+
+
+def test_a_country_without_a_boundary_is_sliced_out_of_the_repaired_world(write_shapefile_cache):
+    """France is unlabelled upstream, so a place named FRA is only findable once the repair has run."""
+    cache_dir = write_shapefile_cache("world", toy_world_needing_repair())
+    place = CountryConfig(iso3="FRA", name="France")
+
+    boundary = load_place_boundary(place, cache_dir)
+
+    assert boundary["WB_NAME"].tolist() == ["France"]
+
+
+def test_a_region_is_sliced_by_every_member(write_shapefile_cache):
+    cache_dir = write_shapefile_cache("world", toy_world_needing_repair())
+    place = RegionConfig(key="north", name="North", members=("NOR", "NLD"))
+
+    boundary = load_place_boundary(place, cache_dir)
+
+    assert sorted(boundary["WB_NAME"]) == ["Netherlands", "Norway"]
+
+
+def test_a_place_the_world_file_does_not_know_is_an_error(write_shapefile_cache):
+    """An empty slice grids to zero points, and the empty panel only surfaces much further downstream."""
+    cache_dir = write_shapefile_cache("world", toy_world_needing_repair())
+    place = CountryConfig(iso3="ZWE", name="Zimbabwe")
+
+    with pytest.raises(DataValidationError, match=re.escape("no geometry for ['ZWE']")):
+        load_place_boundary(place, cache_dir)

--- a/tests/geo/test_grid.py
+++ b/tests/geo/test_grid.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import numpy as np
+import pytest
 
 from shapely.geometry import LineString, box
 
@@ -8,10 +9,11 @@ from tests.conftest import toy_world
 
 
 def test_grid_takes_its_iso_from_the_shapefile(rivers_clear_of_the_grid, coastline):
-    """The fallback is a hardcoded LAO, so a shapefile carrying ISO_A3 must win."""
-    grid = create_grid_from_shape(toy_world(), rivers_clear_of_the_grid, coastline, grid_size=4)
+    """A geometry that labels itself must win over whatever the caller passed as a fallback."""
+    grid = create_grid_from_shape(toy_world(), rivers_clear_of_the_grid, coastline, grid_size=4, iso3="ZZZ")
 
     assert set(grid["ISO"]) <= {"AAA", "BBB", "CCC"}
+    assert "ZZZ" not in set(grid["ISO"])
 
 
 def test_grid_points_fall_inside_the_shapefile(rivers_clear_of_the_grid, coastline):
@@ -55,10 +57,18 @@ def test_genuine_distances_are_not_floored(coastline_through_the_grid):
     assert clear_of_a_river["log_distance_to_river"].eq(np.log(clear_of_a_river["distance_to_river"])).all()
 
 
-def test_a_shapefile_without_iso_codes_falls_back_to_laos(rivers_clear_of_the_grid, coastline):
-    """The country is hardcoded, so every unlabelled region is claimed for Laos."""
+def test_an_unlabelled_shapefile_takes_the_code_it_is_given(rivers_clear_of_the_grid, coastline):
+    """A country boundary file carries no ISO column, so the caller is the only source of the code."""
     unlabelled = gpd.GeoDataFrame({"geometry": [box(0, 0, 1, 1)]}, crs="EPSG:4326")
 
-    grid = create_grid_from_shape(unlabelled, rivers_clear_of_the_grid, coastline, grid_size=3)
+    grid = create_grid_from_shape(unlabelled, rivers_clear_of_the_grid, coastline, grid_size=3, iso3="ZMB")
 
-    assert set(grid["ISO"]) == {"LAO"}
+    assert set(grid["ISO"]) == {"ZMB"}
+
+
+def test_an_unlabelled_shapefile_with_no_code_is_an_error(rivers_clear_of_the_grid, coastline):
+    """A region spans several countries, so no single code is right and stamping one mislabels them."""
+    unlabelled = gpd.GeoDataFrame({"geometry": [box(0, 0, 1, 1)]}, crs="EPSG:4326")
+
+    with pytest.raises(ValueError, match="pass iso3"):
+        create_grid_from_shape(unlabelled, rivers_clear_of_the_grid, coastline, grid_size=3)


### PR DESCRIPTION
`load_grid_point_data` takes a `Place` instead of a region name plus the `iso_list`/`file_reg_name`/`grid_size` triple that existed to work around not having one, and `create_grid_from_shape` no longer stamps unlabelled geometry with a hardcoded `"LAO"`. `load_place_boundary` is deliberately left unwired — Laos declares its own admin-2 boundary in `lao.toml`, so routing the grid through it changes the geometry and wants its own commit. The Laos grid cache key goes from `region=laos` to `region=lao`, which invalidates nothing on disk today.
