### PR TITLE
Take the last hardcoded country out of the loaders

### DIFF
--- a/climate_risk/config/registry.py
+++ b/climate_risk/config/registry.py
@@ -127,3 +127,37 @@ def _place_keys(root: Path) -> list[str]:
         for subdirectory in (COUNTRY_SUBDIRECTORY, REGION_SUBDIRECTORY)
         for path in (root / subdirectory).glob("*.toml")
     )
+
+
+def all_event_location_overrides(*, root: Path = CONFIG_ROOT) -> dict[str, tuple[float, float]]:
+    """
+    Collect the coordinate corrections every shipped country declares.
+
+    Parameters
+    ----------
+    root : Path, optional
+        Directory holding ``places/``. Default the shipped configuration.
+
+    Returns
+    -------
+    dict mapping str to tuple of float
+        Longitude and latitude, keyed by EM-DAT event id.
+
+    Raises
+    ------
+    ValueError
+        If two countries both claim the same event.
+    """
+    overrides: dict[str, tuple[float, float]] = {}
+    for path in sorted((root / COUNTRY_SUBDIRECTORY).glob("*.toml")):
+        place = read_place(path)
+        if not isinstance(place, CountryConfig):
+            continue
+
+        claimed = overrides.keys() & place.event_location_overrides.keys()
+        if claimed:
+            raise ValueError(f"{path} re-declares {sorted(claimed)}, which another country already corrects")
+
+        overrides.update(place.event_location_overrides)
+
+    return overrides

--- a/climate_risk/config/schema.py
+++ b/climate_risk/config/schema.py
@@ -135,6 +135,8 @@ class RegionConfig:
         Projection and grid settings. Defaults to the project-wide ones.
     events : EventFilters
         Which EM-DAT records count. Defaults to the project-wide thresholds.
+    random_seed : int
+        Seeds the synthetic non-disaster sampling. Default ``DEFAULT_RANDOM_SEED``.
 
     Raises
     ------
@@ -147,6 +149,7 @@ class RegionConfig:
     members: tuple[str, ...]
     geometry: GeometrySpec = field(default_factory=GeometrySpec)
     events: EventFilters = field(default_factory=EventFilters)
+    random_seed: int = DEFAULT_RANDOM_SEED
 
     def __post_init__(self) -> None:
         if not self.members:

--- a/climate_risk/config/schema.py
+++ b/climate_risk/config/schema.py
@@ -48,13 +48,14 @@ class EventFilters:
     Parameters
     ----------
     start_year : int
-        First year of the study window, included. Default 1970.
+        First year of the study window, included. Default 1981.
     end_year : int, optional
         Last year, included. Default None, meaning the newest event in the workbook.
     min_total_affected : int
         An event must affect more than this many people to count. Default 1000.
-    min_deaths : int
-        An event must kill more than this many people to count. Default 100.
+    min_deaths : int, optional
+        An event must kill more than this many people to count. Default None, which counts an event
+        on its reach alone.
 
     Raises
     ------
@@ -62,10 +63,10 @@ class EventFilters:
         If the window ends before it starts.
     """
 
-    start_year: int = 1970
+    start_year: int = 1981
     end_year: int | None = None
     min_total_affected: int = 1000
-    min_deaths: int = 100
+    min_deaths: int | None = None
 
     def __post_init__(self) -> None:
         if self.end_year is not None and self.end_year < self.start_year:

--- a/climate_risk/config/schema.py
+++ b/climate_risk/config/schema.py
@@ -7,8 +7,9 @@ from climate_risk.geo.crs import GEOGRAPHIC_CRS, PROJECTED_CRS
 # An ISO 3166-1 alpha-3 code, which is what every frame in the project keys countries on.
 ISO3_LENGTH = 3
 
-# Seeded so a run reproduces. Places may override it to draw a different sample.
-DEFAULT_RANDOM_SEED = sum(map(ord, "Laos GGGI Climate Adaptation"))
+# Seeded so a run reproduces. Places may override it to draw a different sample; changing this
+# value resamples every synthetic control in the project.
+DEFAULT_RANDOM_SEED = 2513
 
 
 def _validate_iso3(code: str, described_as: str) -> None:

--- a/climate_risk/data/cache.py
+++ b/climate_risk/data/cache.py
@@ -90,7 +90,7 @@ def cache_key(name: str, params: Mapping[str, object] | None = None) -> str:
     Returns
     -------
     str
-        A filename stem, such as ``points__grid_size=400__region=laos``.
+        A filename stem, such as ``points__grid_size=400__region=sea``.
 
     Raises
     ------

--- a/climate_risk/data_functions/disaster_point_data.py
+++ b/climate_risk/data_functions/disaster_point_data.py
@@ -51,7 +51,6 @@ def _load_disaster_point_data(cache_dir: Path) -> gpd.GeoDataFrame:
 def load_disaster_point_data(cache_dir: Path):
     modified_data = False
 
-    # Load Laos shapefile
     events = load_emdat_data(cache_dir)["df_raw_filtered_adj"].to_pandas().set_index("emdat_index")
     data = _load_disaster_point_data(cache_dir)
 

--- a/climate_risk/data_functions/disaster_point_data.py
+++ b/climate_risk/data_functions/disaster_point_data.py
@@ -19,9 +19,6 @@ from climate_risk.geo.island_countries import ISLAND_COUNTRY_ISO3
 
 _log = logging.getLogger(__name__)
 
-# The default generator is seeded so a run reproduces, which is why callers may pass their own.
-SAMPLING_SEED = sum(map(ord, "Laos GGGI Climate Adaptation"))
-
 
 def disaster_points_path(cache_dir: Path) -> Path:
     return cache_dir / "disaster_locations_gpt_repaired_w_features.csv"
@@ -257,19 +254,43 @@ SAMPLING_STRATEGIES = tuple(SAMPLERS)
 
 def load_synthetic_non_disaster_points(
     cache_dir: Path,
-    countries,
-    list_name: str,
+    place: Place,
     *,
-    rng=None,
-    force_generate=False,
-    by="region",
-    multiplier=1,
-):
+    rng: np.random.Generator | None = None,
+    force_generate: bool = False,
+    by: str = "region",
+    multiplier: int = 1,
+) -> gpd.GeoDataFrame:
+    """
+    Sample non-disaster points to stand against the disasters a place recorded, and cache them.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the shapefile, river and point caches live under.
+    place : CountryConfig or RegionConfig
+        The place to sample within. Its ``random_seed`` seeds the default generator.
+    rng : numpy.random.Generator, optional
+        Generator to draw with. Default None, meaning one seeded from the place.
+    force_generate : bool, optional
+        Resample even when the cache is warm. Default False.
+    by : str, optional
+        Sampling strategy, one of ``SAMPLING_STRATEGIES``. Default ``"region"``.
+    multiplier : int, optional
+        How many non-disasters to sample per recorded disaster. Default 1.
+
+    Returns
+    -------
+    GeoDataFrame
+        One row per sampled point, with distances to river and coastline and a drawn start year.
+    """
     if by not in SAMPLING_STRATEGIES:
         raise ValueError(f"by should be one of {sorted(SAMPLING_STRATEGIES)}, got {by}")
 
     if rng is None:
-        rng = np.random.default_rng(SAMPLING_SEED)
+        rng = np.random.default_rng(place.random_seed)
+
+    countries = resolve_isos(place)
 
     def build() -> gpd.GeoDataFrame:
         world = load_shapefile("world", cache_dir)
@@ -316,7 +337,7 @@ def load_synthetic_non_disaster_points(
         "synthetic_non_disasters",
         build,
         geo_parquet(),
-        params={"by": by, "times": multiplier, "list_name": list_name},
+        params={"by": by, "times": multiplier, "list_name": place_key(place)},
         force=force_generate,
     )
 

--- a/climate_risk/data_functions/disaster_point_data.py
+++ b/climate_risk/data_functions/disaster_point_data.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 
 from pathlib import Path
@@ -18,6 +17,9 @@ from climate_risk.geo.distance import MIN_DISTANCE_METRES, get_distance_to
 from climate_risk.geo.island_countries import ISLAND_COUNTRY_ISO3
 
 _log = logging.getLogger(__name__)
+
+# Every grid point is stamped with this year, so the non-disaster controls sit at one point in time.
+CONTROL_YEAR = pd.Timestamp("1984-01-01")
 
 
 def disaster_points_path(cache_dir: Path) -> Path:
@@ -347,41 +349,33 @@ def load_non_disaster_grid(
     grid_name: str,
     *,
     force_generate: bool = False,
-    three_dimensioal_grid: bool = False,
-):
+) -> gpd.GeoDataFrame:
+    """
+    Label a point grid with the country each point falls in, and cache it as non-disaster controls.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the shapefile and grid caches live under.
+    grid : GeoDataFrame, optional
+        Points to label. Read only when the cache is cold, so a warm call may pass None.
+    grid_name : str
+        Name the result is cached under.
+    force_generate : bool, optional
+        Rebuild even when the cache is warm. Default False.
+
+    Returns
+    -------
+    GeoDataFrame
+        One row per point, with ``ISO``, ``is_disaster`` of zero, and ``Start_Year``.
+    """
+
     def build() -> gpd.GeoDataFrame:
         world = load_shapefile("world", cache_dir)
 
-        # We merge the grid with the world shapefile to get the ISO
-        not_disasters = gpd.sjoin(
-            grid,
-            world[["geometry", "ISO_A3"]],
-            how="left",
-        ).rename(columns={"ISO_A3": "ISO"})
+        not_disasters = gpd.sjoin(grid, world[["geometry", "ISO_A3"]], how="left").rename(columns={"ISO_A3": "ISO"})
         not_disasters["is_disaster"] = 0
-
-        if three_dimensioal_grid:
-            # Obtain years and ISOs
-            years = load_disaster_point_data(cache_dir)["Start_Year"].unique()
-            country_ISOs = not_disasters["ISO"].unique()
-
-            # Create the Cartesian product of the two arrays
-            combinations = list(itertools.product(years, country_ISOs))
-            combinations_df = pd.DataFrame(combinations, columns=["Start_Date", "ISO"]).sort_values("ISO")
-
-            # Merge files and create not_disasters_grid
-            not_disasters = pd.merge(
-                not_disasters,
-                combinations_df,
-                left_on="ISO",
-                right_on="ISO",
-                how="left",
-            ).rename(columns={"Start_Date": "Start_Year"})
-
-        else:
-            not_disasters = not_disasters.rename(columns={"Start_Date": "Start_Year"})
-            not_disasters["Start_Year"] = "1984-01-01"
-            not_disasters["Start_Year"] = pd.to_datetime(not_disasters["Start_Year"])
+        not_disasters["Start_Year"] = CONTROL_YEAR
 
         return not_disasters
 

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import polars as pl
 
+from climate_risk.config.schema import EventFilters
+
 EM_DAT_COL_DICT = {
     "Start Year": "Start_Year",
     "Total Deaths": "Deaths",
@@ -173,10 +175,27 @@ def _damage_totals(events: pl.DataFrame, grid: pl.DataFrame, regions: pl.DataFra
     )
 
 
+def _selected_events(events: pl.DataFrame, filters: EventFilters) -> pl.DataFrame:
+    """Keep the events a place's thresholds count, dropping any whose severity is unrecorded."""
+    selected = events.filter(
+        (pl.col("Total_Affected") > filters.min_total_affected)
+        & (pl.col("Start_Year") >= pl.date(filters.start_year, 1, 1))
+    )
+
+    if filters.end_year is not None:
+        selected = selected.filter(pl.col("Start_Year") <= pl.date(filters.end_year, 12, 31))
+
+    if filters.min_deaths is not None:
+        selected = selected.filter(pl.col("Deaths") > filters.min_deaths)
+
+    return selected
+
+
 def load_emdat_data(
     cache_dir: Path,
     *,
     window_start: dt.date = EMDAT_WINDOW_START,
+    filters: EventFilters | None = None,
 ) -> dict[str, pl.DataFrame]:
     cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -194,9 +213,7 @@ def load_emdat_data(
     df_raw_filtered = df_raw.filter(
         (pl.col("Total_Affected") > 1000) & (pl.col("Deaths") > 100) & (pl.col("Start_Year") > dt.date(1970, 1, 1))
     )
-    df_raw_filtered_adj = df_raw.filter(
-        (pl.col("Total_Affected") > 1000) & (pl.col("Start_Year") > dt.date(1980, 1, 1))
-    )
+    df_raw_filtered_adj = _selected_events(df_raw, EventFilters() if filters is None else filters)
 
     grid = _country_years(df_raw, window_start)
     regions = _regions(df_raw)

--- a/climate_risk/data_functions/rivers_damage.py
+++ b/climate_risk/data_functions/rivers_damage.py
@@ -5,6 +5,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 
+from climate_risk.config.registry import all_event_location_overrides
 from climate_risk.data.cache import cached, geo_parquet
 from climate_risk.data_functions.emdat_processing import load_emdat_data
 from climate_risk.data_functions.rivers_data_loader import load_rivers_data
@@ -14,17 +15,6 @@ from climate_risk.geo.distance import get_distance_to_rivers
 
 DAMAGE_COLUMNS = ("ISO", "End Year", "Latitude", "Longitude", "River Basin", "Total_Damage", "Total_Affected", "Deaths")
 
-# Coordinates forced onto specific EM-DAT events whose recorded position is wrong. Despite the
-# name these are applied to every flood run, whichever country it covers.
-LAOS_LOCATION_DICTIONARY = {
-    "1971-0048-LAO": {"Latitude": 17.9757, "Longitude": 102.6331},
-    "2000-0583-LAO": {"Latitude": 19.0, "Longitude": 102.0},
-    "2013-0338-LAO": {"Latitude": 19.5, "Longitude": 103.5},
-    "2013-0417-LAO": {"Latitude": 16.5, "Longitude": 106.0},
-    "2015-0324-LAO": {"Latitude": 19.0, "Longitude": 104.0},
-    "2016-0316-LAO": {"Latitude": 19.9, "Longitude": 102.1},
-}
-
 
 def _create_rivers_damage(
     cache_dir: Path,
@@ -33,16 +23,16 @@ def _create_rivers_damage(
     total_suffix: str,
     log_suffix: str,
     extra_columns: Sequence[str] = (),
-    locations: dict[str, dict[str, float]] | None = None,
+    locations: dict[str, tuple[float, float]] | None = None,
 ) -> gpd.GeoDataFrame:
     """
-    Join EM-DAT damages to the nearest major river, caching the result as a shapefile.
+    Join EM-DAT damages to the nearest major river, and cache the result.
 
     Parameters
     ----------
     cache_dir : Path
         Directory holding the EM-DAT workbook, the shapefiles and the cached output.
-    filename : str
+    name : str
         Logical name the result is cached under.
     query : str
         Pandas query selecting the events, applied to the adjusted EM-DAT frame.
@@ -52,8 +42,8 @@ def _create_rivers_damage(
         Suffix for their logarithms, giving ``log_damage_{log_suffix}``.
     extra_columns : sequence of str, optional
         Columns to carry through beyond ``DAMAGE_COLUMNS``. Default empty.
-    locations : dict mapping str to dict, optional
-        Latitude and longitude to force onto specific ``DisNo.`` events. Default None, which forces
+    locations : dict mapping str to tuple of float, optional
+        Longitude and latitude to force onto specific ``DisNo.`` events. Default None, which forces
         nothing.
 
     Returns
@@ -71,10 +61,10 @@ def _create_rivers_damage(
         events = emdat.query(query)
 
         if locations is not None:
-            for disaster_number, coordinates in locations.items():
+            for disaster_number, (lon, lat) in locations.items():
                 matching = events[events["DisNo."] == disaster_number].index
-                events.loc[matching, "Latitude"] = coordinates["Latitude"]
-                events.loc[matching, "Longitude"] = coordinates["Longitude"]
+                events.loc[matching, "Latitude"] = lat
+                events.loc[matching, "Longitude"] = lon
 
         damage_df = gpd.GeoDataFrame(
             (
@@ -124,5 +114,5 @@ def create_floods_rivers_damage(cache_dir: Path) -> gpd.GeoDataFrame:
         total_suffix="Flood",
         log_suffix="floods",
         extra_columns=["Location"],
-        locations=LAOS_LOCATION_DICTIONARY,
+        locations=all_event_location_overrides(),
     )

--- a/climate_risk/data_functions/shapefiles_data_loader.py
+++ b/climate_risk/data_functions/shapefiles_data_loader.py
@@ -26,20 +26,6 @@ WORLD = DataSource(
     retrieved="2026-08-08",
 )
 
-LAOS = DataSource(
-    url=(
-        "https://data.humdata.org/dataset/9eb6aff1-9e3f-43d3-99a6-f415fe4b4dff"
-        "/resource/907a1b50-0d14-40ec-8b8a-f2d027d895aa/download/lao_admin_boundaries.shp.zip"
-    ),
-    filename="lao_admin_boundaries.shp.zip",
-    licence="CC BY 3.0 IGO",
-    citation=(
-        "National Geographic Department (NGD): Lao People's Democratic Republic subnational "
-        "administrative boundaries, via the Humanitarian Data Exchange."
-    ),
-    retrieved="2026-08-08",
-)
-
 COASTLINE = DataSource(
     url="https://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip",
     filename="gshhg-shp-2.3.7.zip",
@@ -54,9 +40,6 @@ COASTLINE = DataSource(
 
 SHAPEFILE_ARCHIVES = {
     "world": ShapefileArchive(WORLD, "WB_countries_Admin0_10m"),
-    # The Laos archive unpacks flat, one file per admin level. Level 2 is the district layer the
-    # point grid is built from.
-    "laos": ShapefileArchive(LAOS, "lao_admin2.shp"),
     "coastline": ShapefileArchive(COASTLINE, "GSHHS_shp/f"),
 }
 

--- a/climate_risk/models/predictions.py
+++ b/climate_risk/models/predictions.py
@@ -16,7 +16,6 @@ def prediction_to_gpd_df(
         predictions_dict[variable] = (
             prediction_idata.posterior_predictive.mean(dim=("chain", "draw"))[variable].to_dataframe().reset_index()
         )
-        # Merge predictions with Laos points
         predictions_dict[variable] = pd.merge(
             predictions_dict[variable],
             points,

--- a/climate_risk/sample.py
+++ b/climate_risk/sample.py
@@ -7,7 +7,7 @@ import pymc as pm
 import xarray as xr
 
 
-def drop_transformed(idata, model=None):
+def drop_transformed(idata: xr.DataTree, model: pm.Model | None = None) -> xr.DataTree:
     model = pm.modelcontext(model)
 
     value_var_names = [x.name for x in model.value_vars if x.name.endswith("__")]
@@ -58,6 +58,9 @@ def sample_or_load(
 
     # Create directory structure if necessary
     os.makedirs(_fp.parent, exist_ok=True)
+
+    # Declared up front: PyMC is untyped, so the sampling branch below infers Any without it.
+    idata: xr.DataTree
 
     if _fp.exists() and not force_resample:
         idata = xr.open_datatree(_fp)

--- a/climate_risk/sample.py
+++ b/climate_risk/sample.py
@@ -21,7 +21,7 @@ def drop_transformed(idata: xr.DataTree, model: pm.Model | None = None) -> xr.Da
 def sample_or_load(
     fp: str,
     *,
-    model: pm.Model = None,
+    model: pm.Model | None = None,
     force_resample: bool = False,
     sample_kwargs: dict | None = None,
     compile_kwargs: dict | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,16 +153,25 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-# An include list that only grows. A package joins it when it is typed, and never leaves.
+# An include list that only grows. A package joins it when it is typed, and never leaves. A module
+# absent from this list is unchecked, so check the ones that are missing before assuming they fail.
 files = [
+    "climate_risk/__init__.py",
+    "climate_risk/_version.py",
     "climate_risk/config",
     "climate_risk/data",
+    "climate_risk/data_functions/__init__.py",
     "climate_risk/data_functions/combine_data.py",
-    "climate_risk/replication_data.py",
     "climate_risk/data_functions/emdat_processing.py",
+    "climate_risk/data_functions/rivers_damage.py",
+    "climate_risk/data_functions/rivers_data_loader.py",
+    "climate_risk/data_functions/shapefiles_data_loader.py",
+    "climate_risk/exceptions.py",
     "climate_risk/geo",
-    "climate_risk/stats",
     "climate_risk/models",
+    "climate_risk/replication_data.py",
+    "climate_risk/sample.py",
+    "climate_risk/stats",
     "tests",
 ]
 python_version = "3.12"

--- a/tests/config/test_places.py
+++ b/tests/config/test_places.py
@@ -4,7 +4,6 @@ from climate_risk.config.registry import CONFIG_ROOT, load_place, read_place, re
 from climate_risk.config.schema import CountryConfig, EventFilters, GeometrySpec, RegionConfig
 from climate_risk.data.world_bank import COUNTRY_CODE_BY_NAME
 from climate_risk.data_functions.rivers_damage import LAOS_LOCATION_DICTIONARY
-from climate_risk.data_functions.shapefiles_data_loader import SHAPEFILE_ARCHIVES
 
 # Walked rather than listed, so a place file that ships without a test still has to parse.
 SHIPPED_PLACES = sorted(CONFIG_ROOT.glob("*/*.toml"))
@@ -33,12 +32,14 @@ def test_a_place_is_filed_under_the_key_it_declares(path):
     assert path.stem == declared
 
 
-def test_laos_carries_the_boundary_the_loader_hardcodes():
-    """The config has to reproduce current behaviour exactly, or Laos results move when it is adopted."""
+def test_laos_carries_its_own_boundary_archive():
+    """Stated literally, because this file is the only record of the archive and the layer to read."""
     place = load_place("lao")
 
     assert isinstance(place, CountryConfig)
-    assert place.boundary == SHAPEFILE_ARCHIVES["laos"]
+    assert place.boundary is not None
+    assert place.boundary.source.filename == "lao_admin_boundaries.shp.zip"
+    assert place.boundary.member == "lao_admin2.shp"
 
 
 def test_laos_carries_the_coordinate_overrides_the_loader_hardcodes():

--- a/tests/config/test_places.py
+++ b/tests/config/test_places.py
@@ -3,7 +3,6 @@ import pytest
 from climate_risk.config.registry import CONFIG_ROOT, load_place, read_place, resolve_isos
 from climate_risk.config.schema import CountryConfig, EventFilters, GeometrySpec, RegionConfig
 from climate_risk.data.world_bank import COUNTRY_CODE_BY_NAME
-from climate_risk.data_functions.rivers_damage import LAOS_LOCATION_DICTIONARY
 
 # Walked rather than listed, so a place file that ships without a test still has to parse.
 SHIPPED_PLACES = sorted(CONFIG_ROOT.glob("*/*.toml"))
@@ -42,16 +41,19 @@ def test_laos_carries_its_own_boundary_archive():
     assert place.boundary.member == "lao_admin2.shp"
 
 
-def test_laos_carries_the_coordinate_overrides_the_loader_hardcodes():
-    """Same reason, and these six are the ones currently applied to every country."""
+def test_laos_carries_its_six_coordinate_overrides():
+    """Stated literally, because this file is the only record of which events are mispositioned."""
     place = load_place("lao")
 
     assert isinstance(place, CountryConfig)
-    expected = {
-        event: (coordinates["Longitude"], coordinates["Latitude"])
-        for event, coordinates in LAOS_LOCATION_DICTIONARY.items()
+    assert place.event_location_overrides == {
+        "1971-0048-LAO": (102.6331, 17.9757),
+        "2000-0583-LAO": (102.0, 19.0),
+        "2013-0338-LAO": (103.5, 19.5),
+        "2013-0417-LAO": (106.0, 16.5),
+        "2015-0324-LAO": (104.0, 19.0),
+        "2016-0316-LAO": (102.1, 19.9),
     }
-    assert place.event_location_overrides == expected
 
 
 def test_laos_takes_the_project_defaults_it_does_not_override():

--- a/tests/config/test_registry.py
+++ b/tests/config/test_registry.py
@@ -1,7 +1,7 @@
 import pytest
 
 from climate_risk.config.registry import load_place, read_place, resolve_isos
-from climate_risk.config.schema import DEFAULT_RANDOM_SEED, CountryConfig, RegionConfig
+from climate_risk.config.schema import DEFAULT_RANDOM_SEED, CountryConfig, EventFilters, RegionConfig
 
 
 @pytest.fixture
@@ -39,8 +39,7 @@ def test_a_sub_table_becomes_the_object_the_schema_declares(config_root):
     place = load_place("lao", root=root)
 
     assert place.geometry.grid_size == 200
-    assert place.events.end_year == 2024
-    assert place.events.min_deaths == 100
+    assert place.events == EventFilters(start_year=1970, end_year=2024)
 
 
 def test_event_overrides_arrive_as_coordinate_pairs(config_root):

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -12,7 +12,7 @@ from climate_risk.data.hadcrut import HADCRUT
 from climate_risk.data.ocean_heat import OCEAN_HEAT
 from climate_risk.data.source import DataSource, ShapefileArchive
 from climate_risk.data_functions.rivers_data_loader import RIVERS
-from climate_risk.data_functions.shapefiles_data_loader import COASTLINE, LAOS, WORLD
+from climate_risk.data_functions.shapefiles_data_loader import COASTLINE, WORLD
 
 FIELDS = {
     "url": "https://example.org/co2.csv",
@@ -81,7 +81,6 @@ SOURCES = (
         "OCEAN_HEAT": OCEAN_HEAT,
         "HADCRUT": HADCRUT,
         "WORLD": WORLD,
-        "LAOS": LAOS,
         "COASTLINE": COASTLINE,
         "RIVERS": RIVERS,
     }

--- a/tests/data_functions/test_disaster_point_data.py
+++ b/tests/data_functions/test_disaster_point_data.py
@@ -1,7 +1,5 @@
 import re
 
-from typing import Any
-
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -40,7 +38,7 @@ def test_missing_geocoded_locations_names_the_file_it_looked_for(tmp_path):
 def test_unknown_sampling_strategy_is_rejected(tmp_path):
     """An unknown `by` once fell through both branches and failed on an unbound name."""
     with pytest.raises(ValueError, match="by should be one of"):
-        load_synthetic_non_disaster_points(tmp_path, ["LAO"], "sea", by="continent")
+        load_synthetic_non_disaster_points(tmp_path, france(), by="continent")
 
 
 @pytest.fixture
@@ -141,13 +139,13 @@ def test_a_warm_synthetic_cache_is_reused(tmp_path):
     the socket guard fails the test.
     """
     # Stated literally, so a changed key fails rather than agreeing with the loader.
-    cache = tmp_path / "synthetic_non_disasters__by=region__list_name=sea__times=1.parquet"
+    cache = tmp_path / "synthetic_non_disasters__by=region__list_name=lao__times=1.parquet"
     gpd.GeoDataFrame(
         {"ISO": ["LAO"], "Start_Year": [pd.Timestamp("1990-01-01")], "geometry": [Point(102.5, 18.5)]},
         crs=GEOGRAPHIC_CRS,
     ).to_parquet(cache)
 
-    points = load_synthetic_non_disaster_points(tmp_path, ["LAO"], "sea")
+    points = load_synthetic_non_disaster_points(tmp_path, CountryConfig(iso3="LAO", name="Lao PDR"))
 
     assert points["ISO"].tolist() == ["LAO"]
 
@@ -168,10 +166,10 @@ def test_a_warm_non_disaster_grid_is_reused(tmp_path):
 def test_the_sampled_years_come_from_the_generator_the_caller_passed(write_synthetic_source_cache, by):
     """Every other draw honours `rng`, so a caller seeding it gets reproducibility for all but this one."""
     cache_dir = write_synthetic_source_cache()
-    kwargs: dict[str, Any] = {"countries": ["FRA"], "list_name": "toy", "by": by}
-
-    first = load_synthetic_non_disaster_points(cache_dir, rng=np.random.default_rng(0), **kwargs)
-    second = load_synthetic_non_disaster_points(cache_dir, rng=np.random.default_rng(0), force_generate=True, **kwargs)
+    first = load_synthetic_non_disaster_points(cache_dir, france(), rng=np.random.default_rng(0), by=by)
+    second = load_synthetic_non_disaster_points(
+        cache_dir, france(), rng=np.random.default_rng(0), force_generate=True, by=by
+    )
 
     # Without these the comparison holds vacuously when the country filter matches nothing.
     assert len(first) == SYNTHETIC_SOURCE_EVENTS
@@ -180,13 +178,33 @@ def test_the_sampled_years_come_from_the_generator_the_caller_passed(write_synth
     assert_geodataframe_equal(first, second)
 
 
+def test_a_place_reproduces_its_own_sample_without_being_handed_a_generator(write_synthetic_source_cache):
+    """`random_seed` is the place's, so a run with no `rng` still has to repeat exactly."""
+    cache_dir = write_synthetic_source_cache()
+
+    first = load_synthetic_non_disaster_points(cache_dir, france())
+    second = load_synthetic_non_disaster_points(cache_dir, france(), force_generate=True)
+
+    assert len(first) == SYNTHETIC_SOURCE_EVENTS
+    assert_geodataframe_equal(first, second)
+
+
+def test_two_places_seeded_differently_draw_differently(write_synthetic_source_cache):
+    """One seed for every place would make the synthetic controls correlated across countries."""
+    cache_dir = write_synthetic_source_cache()
+    other = CountryConfig(iso3="FRA", name="France", random_seed=1234, geometry=GeometrySpec(grid_size=3))
+
+    default = load_synthetic_non_disaster_points(cache_dir, france())
+    reseeded = load_synthetic_non_disaster_points(cache_dir, other, force_generate=True)
+
+    assert not default.geometry.geom_equals(reseeded.geometry).all()
+
+
 def test_the_multiplier_scales_how_many_points_are_sampled(write_synthetic_source_cache):
     """It sets how many non-disasters stand against each disaster, and it keys the cache entry."""
     cache_dir = write_synthetic_source_cache()
-    kwargs: dict[str, Any] = {"countries": ["FRA"], "list_name": "toy", "rng": np.random.default_rng(0)}
-
-    single = load_synthetic_non_disaster_points(cache_dir, multiplier=1, **kwargs)
-    tripled = load_synthetic_non_disaster_points(cache_dir, multiplier=3, **kwargs)
+    single = load_synthetic_non_disaster_points(cache_dir, france(), rng=np.random.default_rng(0), multiplier=1)
+    tripled = load_synthetic_non_disaster_points(cache_dir, france(), rng=np.random.default_rng(0), multiplier=3)
 
     assert len(single) == SYNTHETIC_SOURCE_EVENTS
     assert len(tripled) == SYNTHETIC_SOURCE_EVENTS * 3

--- a/tests/data_functions/test_disaster_point_data.py
+++ b/tests/data_functions/test_disaster_point_data.py
@@ -17,7 +17,7 @@ from climate_risk.data_functions.disaster_point_data import (
     load_non_disaster_grid,
 )
 from climate_risk.geo.crs import GEOGRAPHIC_CRS
-from tests.conftest import SYNTHETIC_SOURCE_EVENTS
+from tests.conftest import SYNTHETIC_SOURCE_EVENTS, toy_world_needing_repair
 
 # A legacy cache spells longitude `long`; the value under `lon` is the one to keep.
 STALE_LON = 9.9
@@ -160,6 +160,25 @@ def test_a_warm_non_disaster_grid_is_reused(tmp_path):
     grid = load_non_disaster_grid(tmp_path, grid=None, grid_name="laos")
 
     assert grid["ISO"].tolist() == ["LAO"]
+
+
+def test_a_cold_non_disaster_grid_labels_each_point_with_its_country(write_shapefile_cache):
+    """The spatial join is the only thing assigning ISO, and a point can silently land in no country.
+
+    France and the Netherlands sit at opposite ends of the toy world, so a join that matched by row
+    order rather than geometry would swap them.
+    """
+    cache_dir = write_shapefile_cache("world", toy_world_needing_repair())
+    # The last point is open ocean: a control there is unlabelled, not discarded.
+    points = gpd.GeoDataFrame(geometry=[Point(12.25, 0.5), Point(0.25, 0.5), Point(50.0, 50.0)], crs=GEOGRAPHIC_CRS)
+
+    grid = load_non_disaster_grid(cache_dir, points, "toy")
+
+    assert grid["ISO"].tolist()[:2] == ["NLD", "FRA"]
+    assert pd.isna(grid["ISO"].tolist()[2])
+    assert grid["is_disaster"].tolist() == [0, 0, 0]
+    # The literal date, not CONTROL_YEAR, which would move with the code it is checking.
+    assert set(grid["Start_Year"]) == {pd.Timestamp("1984-01-01")}
 
 
 @pytest.mark.parametrize("by", ["region", "country"])

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -4,6 +4,7 @@ import polars as pl
 import pytest
 
 from climate_risk import load_emdat_data
+from climate_risk.config.schema import EventFilters
 from climate_risk.data_functions.emdat_processing import DISASTER_TYPES
 from tests.conftest import emdat_event
 
@@ -129,16 +130,78 @@ def test_unadjusted_filter_drops_low_casualty_events(write_emdat_cache):
 
 
 def test_adjusted_filter_ignores_deaths_but_starts_in_1981(write_emdat_cache):
+    """1980 itself is excluded, so the boundary is pinned on both sides rather than approximately."""
     cache_dir = write_emdat_cache(
         [
             emdat_event({"DisNo.": "kept-no-deaths", "Start Year": 1990, "Total Deaths": 0}),
+            emdat_event({"DisNo.": "first-year", "Start Year": 1981}),
+            emdat_event({"DisNo.": "boundary-year", "Start Year": 1980}),
             emdat_event({"DisNo.": "too-early", "Start Year": 1975}),
         ]
     )
 
     kept = load_emdat_data(cache_dir)["df_raw_filtered_adj"]["DisNo."]
 
-    assert kept.to_list() == ["kept-no-deaths"]
+    assert sorted(kept.to_list()) == ["first-year", "kept-no-deaths"]
+
+
+def test_an_event_exactly_on_the_affected_threshold_does_not_count(write_emdat_cache):
+    """The threshold is strict, and an event sitting on it is the only way to tell that apart."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "over", "Start Year": 1995, "Total Affected": 1_001}),
+            emdat_event({"DisNo.": "exactly-on-it", "Start Year": 1995, "Total Affected": 1_000}),
+        ]
+    )
+
+    kept = load_emdat_data(cache_dir)["df_raw_filtered_adj"]["DisNo."]
+
+    assert kept.to_list() == ["over"]
+
+
+def test_the_adjusted_view_follows_the_filters_it_is_given(write_emdat_cache):
+    """The window is a place's setting, so a place with a shorter one must get a shorter panel."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "in-window", "Start Year": 1995}),
+            emdat_event({"DisNo.": "before-window", "Start Year": 1985}),
+        ]
+    )
+
+    kept = load_emdat_data(cache_dir, filters=EventFilters(start_year=1990))["df_raw_filtered_adj"]["DisNo."]
+
+    assert kept.to_list() == ["in-window"]
+
+
+def test_a_deaths_threshold_applies_only_when_a_place_sets_one(write_emdat_cache):
+    """The default counts an event on reach alone, so a deadly-but-small event needs an explicit floor."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "deadly", "Start Year": 1995, "Total Deaths": 500}),
+            emdat_event({"DisNo.": "harmless", "Start Year": 1995, "Total Deaths": 0}),
+        ]
+    )
+
+    by_default = load_emdat_data(cache_dir)["df_raw_filtered_adj"]["DisNo."]
+    with_a_floor = load_emdat_data(cache_dir, filters=EventFilters(min_deaths=100))["df_raw_filtered_adj"]["DisNo."]
+
+    assert by_default.to_list() == ["deadly", "harmless"]
+    assert with_a_floor.to_list() == ["deadly"]
+
+
+def test_a_place_can_close_its_window_before_the_newest_event(write_emdat_cache):
+    """`end_year` is the only filter that trims the recent end, and it counts its own year."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "in-window", "Start Year": 1995}),
+            emdat_event({"DisNo.": "last-year", "Start Year": 2000}),
+            emdat_event({"DisNo.": "after-window", "Start Year": 2005}),
+        ]
+    )
+
+    kept = load_emdat_data(cache_dir, filters=EventFilters(end_year=2000))["df_raw_filtered_adj"]["DisNo."]
+
+    assert kept.to_list() == ["in-window", "last-year"]
 
 
 def test_the_window_extends_to_the_newest_event(write_emdat_cache):

--- a/tests/data_functions/test_shapefiles_data_loader.py
+++ b/tests/data_functions/test_shapefiles_data_loader.py
@@ -5,12 +5,9 @@ import pandas as pd
 import pytest
 
 from climate_risk import load_shapefile
+from climate_risk.config.registry import load_place
 from climate_risk.config.schema import CountryConfig, RegionConfig
-from climate_risk.data_functions.shapefiles_data_loader import (
-    SHAPEFILE_ARCHIVES,
-    load_place_boundary,
-    repair_iso_codes,
-)
+from climate_risk.data_functions.shapefiles_data_loader import load_place_boundary, repair_iso_codes
 from climate_risk.exceptions import DataValidationError, ISOCodeValidationError
 from tests.conftest import toy_world, toy_world_needing_repair
 
@@ -49,16 +46,6 @@ def test_the_repair_does_not_depend_on_how_the_caller_capitalised_it(write_shape
 
     assert world.loc[world["WB_NAME"] == "France", "ISO_A3"].tolist() == ["FRA"]
     assert "-99" not in set(world["ISO_A3"])
-
-
-def test_laos_reads_the_district_layer_from_a_flat_archive(write_shapefile_cache):
-    """The archive unpacks flat, so reading the wrong admin level means reading a different file."""
-    cache_dir = write_shapefile_cache("laos", toy_world())
-    (cache_dir / "shapefiles" / "lao_admin0.shp").write_text("not a shapefile")
-
-    laos = load_shapefile("laos", cache_dir, repair_ISO_codes=False)
-
-    assert sorted(laos["ISO_A3"]) == ["AAA", "BBB", "CCC"]
 
 
 def test_repair_supplies_the_missing_sovereign_codes():
@@ -114,12 +101,15 @@ def test_duplicate_iso_codes_are_an_error():
         repair_iso_codes(doubled)
 
 
-def test_a_place_with_its_own_boundary_reads_that_archive(write_shapefile_cache):
-    """Its own file defines its extent, so nothing about the world shapefile should narrow it."""
-    cache_dir = write_shapefile_cache("laos", toy_world())
-    place = CountryConfig(iso3="AAA", name="Aland", boundary=SHAPEFILE_ARCHIVES["laos"])
+def test_a_place_reads_the_boundary_layer_its_config_names(write_shapefile_cache):
+    """The archive unpacks flat, so reading the wrong admin level means reading a different file.
 
-    boundary = load_place_boundary(place, cache_dir)
+    Only the boundary archive is cached here, so falling back to the world slice cannot quietly work.
+    """
+    cache_dir = write_shapefile_cache("laos", toy_world())
+    (cache_dir / "shapefiles" / "lao_admin0.shp").write_text("not a shapefile")
+
+    boundary = load_place_boundary(load_place("lao"), cache_dir)
 
     assert sorted(boundary["ISO_A3"]) == ["AAA", "BBB", "CCC"]
 


### PR DESCRIPTION
The loaders take their boundary, event window, sampler seed, and coordinate corrections from the place config now, so nothing in `climate_risk/` names a country. Two things to look at: `EventFilters` defaults to `start_year=1981` because the old `> 1980-01-01` on a Jan-1 date column already excluded 1980, and the overrides are collected across all place files rather than scoped to one place, since `_create_rivers_damage` returns a global frame and the override keys are country-specific event ids that can't match anything else.
