### PR TITLE
Add Zambia and Costa Rica with no code changes

### DIFF
--- a/climate_risk/config/places/cri.toml
+++ b/climate_risk/config/places/cri.toml
@@ -1,0 +1,2 @@
+iso3 = "CRI"
+name = "Costa Rica"

--- a/climate_risk/config/places/zmb.toml
+++ b/climate_risk/config/places/zmb.toml
@@ -1,0 +1,2 @@
+iso3 = "ZMB"
+name = "Zambia"

--- a/docs/adding-a-country.md
+++ b/docs/adding-a-country.md
@@ -1,0 +1,94 @@
+# Adding a country
+
+A country is one TOML file in `climate_risk/config/places/`, named after its ISO 3166-1 alpha-3
+code in lower case. Zambia needs two lines:
+
+```toml
+iso3 = "ZMB"
+name = "Zambia"
+```
+
+That is the whole minimum. The geometry comes from slicing the World Bank world shapefile by
+`iso3`, and everything else falls back to the project-wide defaults in `climate_risk/config/schema.py`.
+
+Nothing else has to change. If you find yourself editing a loader to make a country work, the
+loader is wrong, not the config.
+
+## What you get without asking
+
+The directory is walked, so a new file is picked up with no registration step. Its ISO codes are
+checked against the World Bank country table, and the file has to parse and match the schema —
+a typo in a key is an error, not a silently ignored default.
+
+Downstream, `load_place("zmb")` gives you a `CountryConfig` that the loaders accept directly:
+
+```python
+from climate_risk.config.registry import load_place
+from climate_risk.data_functions.disaster_point_data import load_grid_point_data
+
+grid = load_grid_point_data(cache_dir, load_place("zmb"))
+```
+
+## What you can override
+
+Every block below is optional.
+
+**`[geometry]`** — `grid_size` (points per side before land clipping, default 400), and the
+geographic and projected CRS.
+
+**`[events]`** — `start_year`, `end_year`, `min_total_affected`, `min_deaths`. The defaults describe
+the window the published panel uses. Lower them for a country with few recorded disasters, but
+check first: all three shipped countries clear the defaults comfortably, and an empty event frame
+is easy to mistake for a working pipeline.
+
+**`[boundary]`** — a country-specific admin boundary archive, when the world shapefile is too coarse.
+It needs `member` naming the layer to read inside the zip, alongside the usual source fields:
+
+```toml
+[boundary]
+member = "lao_admin2.shp"
+url = "https://…/lao_admin_boundaries.shp.zip"
+filename = "lao_admin_boundaries.shp.zip"
+licence = "CC BY 3.0 IGO"
+citation = "National Geographic Department (NGD), via the Humanitarian Data Exchange."
+retrieved = "2026-08-08"
+```
+
+A boundary declared here is fetched, cached and reachability-checked exactly like a source declared
+in code. `licence` and `citation` are not decorative — fill them in from the publisher's own page.
+
+**`[event_location_overrides]`** — longitude and latitude forced onto EM-DAT records whose published
+position is wrong, keyed by event id. Two countries may not both claim the same event.
+
+**`random_seed`** — seeds the synthetic non-disaster sampling. Change it only to draw a different
+sample deliberately; two countries sharing a seed is fine, since they sample different geometry.
+
+## What is still global
+
+Three things do not yet vary by country, and will surprise you if you assume they do.
+
+The **EM-DAT event frame** is filtered by severity and window, not by country. `[events]` narrows
+which events count everywhere, not which country's events you get.
+
+The **river-damage frames** cover every country at once. `create_floods_rivers_damage` returns
+world-wide flood events; the coordinate overrides are applied across all of them, which works
+because event ids are country-specific.
+
+The **point grid carries no country label**. Every point in it lies inside the place you asked for,
+but there is no `ISO` column until `load_non_disaster_grid` adds one.
+
+## Before you trust it
+
+The end-to-end tests run against synthetic fixtures, which are uniform in ways real countries are
+not — a landlocked and a coastal country are represented, and the paths are asserted to differ, but
+that is a weaker claim than a real run.
+
+The one test that uses real data is marked `requires_emdat` and skips wherever the licensed
+workbook is absent, which includes CI. Run it once on a machine that has the workbook:
+
+```
+pixi run pytest -m requires_emdat
+```
+
+It checks that your country actually has events clearing its own filters. A country that does not
+produces an empty panel, and every other test will pass on it.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,24 @@ def toy_world_needing_repair():
     )
 
 
+def toy_world_with_places():
+    """`toy_world_needing_repair` plus the three shipped countries, so a load can still be repaired.
+
+    Costa Rica straddles `toy_coastline`; Laos and Zambia sit well inland of it.
+    """
+    countries = gpd.GeoDataFrame(
+        {
+            "WB_NAME": ["Lao PDR", "Zambia", "Costa Rica"],
+            "ISO_A3": ["LAO", "ZMB", "CRI"],
+            "CONTINENT": ["Asia", "Africa", "North America"],
+            "geometry": [box(20, 0, 21, 1), box(23, 0, 24, 1), box(29.5, 0, 30.5, 1)],
+        },
+        crs="EPSG:4326",
+    )
+
+    return gpd.GeoDataFrame(pd.concat([toy_world_needing_repair(), countries], ignore_index=True), crs="EPSG:4326")
+
+
 def toy_coastline():
     return gpd.GeoDataFrame({"geometry": [LineString([(30, -1), (30, 2)])]}, crs="EPSG:4326")
 
@@ -394,10 +412,10 @@ def write_synthetic_source_cache(tmp_path, write_shapefile_cache, write_rivers_c
 def write_point_grid_cache(write_shapefile_cache, write_rivers_cache, rivers_clear_of_the_grid):
     """Seed the world, coastline and river caches `load_grid_point_data` reads."""
 
-    def write(rivers=None):
+    def write(rivers=None, world=None):
         if rivers is None:
             rivers = rivers_clear_of_the_grid
-        write_shapefile_cache("world", toy_world_needing_repair())
+        write_shapefile_cache("world", toy_world_needing_repair() if world is None else world)
         write_shapefile_cache("coastline", toy_coastline())
         write_rivers_cache(rivers.query("ORD_FLOW < 5"))
         return write_rivers_cache(rivers, include_medium=True)

--- a/tests/data_functions/test_disaster_point_data.py
+++ b/tests/data_functions/test_disaster_point_data.py
@@ -1,5 +1,7 @@
 import re
 
+from dataclasses import replace
+
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -9,6 +11,7 @@ from geopandas.testing import assert_geodataframe_equal
 from shapely.geometry import Point
 
 from climate_risk import load_synthetic_non_disaster_points
+from climate_risk.config.registry import load_place
 from climate_risk.config.schema import CountryConfig, GeometrySpec
 from climate_risk.data_functions.disaster_point_data import (
     _load_disaster_point_data,
@@ -17,7 +20,11 @@ from climate_risk.data_functions.disaster_point_data import (
     load_non_disaster_grid,
 )
 from climate_risk.geo.crs import GEOGRAPHIC_CRS
-from tests.conftest import SYNTHETIC_SOURCE_EVENTS, toy_world_needing_repair
+from tests.conftest import SYNTHETIC_SOURCE_EVENTS, toy_world_needing_repair, toy_world_with_places
+
+# Every shipped country, with the longitudes `toy_world_with_places` puts it between. Stated
+# here rather than read from the fixture, so a country sliced out of the wrong box fails.
+COUNTRY_BOUNDS = [("lao", 20.0, 21.0), ("zmb", 23.0, 24.0), ("cri", 29.5, 30.5)]
 
 # A legacy cache spells longitude `long`; the value under `lon` is the one to keep.
 STALE_LON = 9.9
@@ -227,3 +234,48 @@ def test_the_multiplier_scales_how_many_points_are_sampled(write_synthetic_sourc
 
     assert len(single) == SYNTHETIC_SOURCE_EVENTS
     assert len(tripled) == SYNTHETIC_SOURCE_EVENTS * 3
+
+
+@pytest.mark.parametrize(("key", "west", "east"), COUNTRY_BOUNDS, ids=[key for key, _, _ in COUNTRY_BOUNDS])
+def test_every_shipped_country_grids_from_its_config_alone(write_point_grid_cache, key, west, east):
+    """The step's whole claim: a country the loaders have never heard of grids from its config alone.
+
+    The bounds check is what makes it more than a smoke test — a place resolving to the wrong ISO
+    still produces a grid, just somewhere else.
+    """
+    cache_dir = write_point_grid_cache(world=toy_world_with_places())
+    place = replace(load_place(key), geometry=GeometrySpec(grid_size=4))
+
+    grid = load_grid_point_data(cache_dir, place)
+
+    assert len(grid) > 0
+    assert grid["lon"].between(west, east).all()
+    assert grid["lat"].between(0.0, 1.0).all()
+
+
+def test_the_coastal_country_grids_nearer_the_sea_than_a_landlocked_one(write_point_grid_cache):
+    """Landlocked and coastal must take genuinely different paths, not both return nulls."""
+    cache_dir = write_point_grid_cache(world=toy_world_with_places())
+    coastal = replace(load_place("cri"), geometry=GeometrySpec(grid_size=4))
+    landlocked = replace(load_place("zmb"), geometry=GeometrySpec(grid_size=4))
+
+    on_the_coast = load_grid_point_data(cache_dir, coastal)
+    inland = load_grid_point_data(cache_dir, landlocked)
+
+    assert on_the_coast["distance_to_coastline"].max() < inland["distance_to_coastline"].min()
+
+
+def test_a_grid_size_set_in_a_place_file_reaches_the_grid(write_point_grid_cache, tmp_path):
+    """Every other test hands the loader a `Place` it built; this one starts from a file on disk.
+
+    Without it the whole config layer could be inert and the suite would not notice.
+    """
+    cache_dir = write_point_grid_cache(world=toy_world_with_places())
+
+    def zambia_gridded_at(size: int) -> gpd.GeoDataFrame:
+        root = tmp_path / str(size)
+        (root / "places").mkdir(parents=True)
+        (root / "places" / "zmb.toml").write_text(f'iso3 = "ZMB"\nname = "Zambia"\n\n[geometry]\ngrid_size = {size}\n')
+        return load_grid_point_data(cache_dir, load_place("zmb", root=root))
+
+    assert len(zambia_gridded_at(9)) > len(zambia_gridded_at(3))

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -1,9 +1,11 @@
 from datetime import date
+from pathlib import Path
 
 import polars as pl
 import pytest
 
 from climate_risk import load_emdat_data
+from climate_risk.config.registry import CONFIG_ROOT, load_place, resolve_isos
 from climate_risk.config.schema import EventFilters
 from climate_risk.data_functions.emdat_processing import DISASTER_TYPES
 from tests.conftest import emdat_event
@@ -252,3 +254,23 @@ def test_every_disaster_type_gets_a_column_in_a_stable_order(write_emdat_cache):
     events = load_emdat_data(cache_dir)["df_prob_filtered_adjusted"]
 
     assert events.columns == ["ISO", "Start_Year", "Region", "Subregion", *DISASTER_TYPES]
+
+
+# The licensed workbook, which cannot be committed or fetched. Absent on CI and on a fresh clone.
+REAL_CACHE_DIR = Path(__file__).parents[2] / "data"
+
+SHIPPED_PLACE_KEYS = sorted(path.stem for path in (CONFIG_ROOT / "places").glob("*.toml"))
+
+
+@pytest.mark.requires_emdat
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "emdat.xlsx").exists(), reason="needs the licensed EM-DAT workbook")
+@pytest.mark.parametrize("key", SHIPPED_PLACE_KEYS)
+def test_every_shipped_country_has_events_clearing_its_own_filters(key):
+    """A country whose filters admit nothing yields an empty panel, and every later test passes on it.
+
+    Synthetic fixtures cannot catch this: they contain whatever events the fixture author wrote.
+    """
+    place = load_place(key)
+    events = load_emdat_data(REAL_CACHE_DIR, filters=place.events)["df_raw_filtered_adj"]
+
+    assert len(events.filter(pl.col("ISO").is_in(resolve_isos(place)))) > 0


### PR DESCRIPTION
Zambia and Costa Rica are two lines of TOML each and nothing else — no loader changed, which is the only thing worth checking in this diff. Costa Rica is there for the coastal path Zambia can't exercise. Both clear the default event thresholds comfortably against the real workbook, Zambia with more qualifying events than Laos, so neither needs filters of its own.
