### PR TITLE
Fix distance-to-coastline and grid distance units

### DIFF
--- a/climate_risk/data_functions/disaster_point_data.py
+++ b/climate_risk/data_functions/disaster_point_data.py
@@ -166,14 +166,20 @@ def load_grid_point_data(
 
         points = pd.merge(points, distances_coastlines, left_index=True, right_index=True, how="left")
 
-        # Assign is_island column
         points["is_island"] = False
 
-        # Create log of distances
+        # Kilometres, as every other frame carrying these column names reports them.
         points = points.assign(
-            log_distance_to_river=lambda x: np.log(x.distance_to_river.clip(lower=MIN_DISTANCE_METRES)),
-            log_distance_to_coastline=lambda x: np.log(x.distance_to_coastline.clip(lower=MIN_DISTANCE_METRES)),
+            distance_to_river=lambda x: to_km(x.distance_to_river),
+            distance_to_coastline=lambda x: to_km(x.distance_to_coastline),
         )
+
+        floor = to_km(MIN_DISTANCE_METRES)
+        points = points.assign(
+            log_distance_to_river=lambda x: np.log(x.distance_to_river.clip(lower=floor)),
+            log_distance_to_coastline=lambda x: np.log(x.distance_to_coastline.clip(lower=floor)),
+        )
+
         return points
 
     return cached(

--- a/climate_risk/data_functions/shapefiles_data_loader.py
+++ b/climate_risk/data_functions/shapefiles_data_loader.py
@@ -40,7 +40,9 @@ COASTLINE = DataSource(
 
 SHAPEFILE_ARCHIVES = {
     "world": ShapefileArchive(WORLD, "WB_countries_Admin0_10m"),
-    "coastline": ShapefileArchive(COASTLINE, "GSHHS_shp/f"),
+    # The archive holds six layers and the driver does not enumerate them in order, so the
+    # continental shoreline is named outright. L2-L6 are lakes, islands and Antarctic ice.
+    "coastline": ShapefileArchive(COASTLINE, "GSHHS_shp/f/GSHHS_f_L1.shp"),
 }
 
 VALID_CHOICES = list(SHAPEFILE_ARCHIVES)

--- a/tests/data_functions/test_disaster_point_data.py
+++ b/tests/data_functions/test_disaster_point_data.py
@@ -26,6 +26,8 @@ from tests.conftest import SYNTHETIC_SOURCE_EVENTS, toy_world_needing_repair, to
 # here rather than read from the fixture, so a country sliced out of the wrong box fails.
 COUNTRY_BOUNDS = [("lao", 20.0, 21.0), ("zmb", 23.0, 24.0), ("cri", 29.5, 30.5)]
 
+EARTH_CIRCUMFERENCE_KM = 40_075
+
 # A legacy cache spells longitude `long`; the value under `lon` is the one to keep.
 STALE_LON = 9.9
 CURRENT_LON = 102.5
@@ -65,6 +67,16 @@ def test_grid_carries_its_distance_features(grid):
     assert (grid["distance_to_river"] > 0).all()
 
 
+@pytest.mark.parametrize("column", ["distance_to_river", "distance_to_coastline"])
+def test_grid_distances_are_in_kilometres(grid, column):
+    """Two other loaders write these same column names in kilometres, and the frames get merged.
+
+    Bounded by the circumference rather than by a value read off the fixture, so the assertion says
+    what it means: no distance on Earth is larger, and the same figure in metres would be.
+    """
+    assert grid[column].max() < EARTH_CIRCUMFERENCE_KM
+
+
 def test_zero_distances_do_not_become_infinite_logs(write_point_grid_cache, rivers_through_the_grid):
     """The grid is written to disk, so a -inf from log(0) persists into every later run."""
     cache_dir = write_point_grid_cache(rivers_through_the_grid)
@@ -75,7 +87,8 @@ def test_zero_distances_do_not_become_infinite_logs(write_point_grid_cache, rive
 
     assert len(on_a_river) > 0
     assert np.isfinite(grid[["log_distance_to_river", "log_distance_to_coastline"]]).all().all()
-    assert on_a_river["log_distance_to_river"].eq(0.0).all()
+    # The floor is one metre, which is 0.001 in the kilometres the column reports.
+    assert on_a_river["log_distance_to_river"].eq(np.log(0.001)).all()
 
     clear_of_a_river = grid[grid["distance_to_river"] > 0]
 

--- a/tests/data_functions/test_shapefiles_data_loader.py
+++ b/tests/data_functions/test_shapefiles_data_loader.py
@@ -1,15 +1,19 @@
 import re
 import shutil
 
+import geopandas as gpd
 import pandas as pd
 import pytest
+
+from shapely.geometry import box
 
 from climate_risk import load_shapefile
 from climate_risk.config.registry import load_place
 from climate_risk.config.schema import CountryConfig, RegionConfig
 from climate_risk.data_functions.shapefiles_data_loader import load_place_boundary, repair_iso_codes
 from climate_risk.exceptions import DataValidationError, ISOCodeValidationError
-from tests.conftest import toy_world, toy_world_needing_repair
+from climate_risk.geo.crs import GEOGRAPHIC_CRS
+from tests.conftest import toy_coastline, toy_world, toy_world_needing_repair
 
 
 def test_unknown_shapefile_is_rejected(tmp_path):
@@ -46,6 +50,21 @@ def test_the_repair_does_not_depend_on_how_the_caller_capitalised_it(write_shape
 
     assert world.loc[world["WB_NAME"] == "France", "ISO_A3"].tolist() == ["FRA"]
     assert "-99" not in set(world["ISO_A3"])
+
+
+def test_the_coastline_reads_the_continental_layer_not_whichever_comes_first(write_shapefile_cache):
+    """The real archive ships six layers and the driver enumerates the Antarctic one first.
+
+    A single-layer cache cannot show this: with one file in the directory, any layer index finds it.
+    """
+    cache_dir = write_shapefile_cache("coastline", toy_coastline())
+    antarctic_ice = gpd.GeoDataFrame(geometry=[box(-180, -90, 180, -63)], crs=GEOGRAPHIC_CRS)
+    antarctic_ice.to_file(cache_dir / "shapefiles" / "GSHHS_shp" / "f" / "GSHHS_f_L6.shp")
+
+    coast = load_shapefile("coastline", cache_dir)
+
+    _, southernmost, _, _ = coast.total_bounds
+    assert southernmost > -60.0, "read an Antarctic layer instead of the shoreline"
 
 
 def test_repair_supplies_the_missing_sovereign_codes():


### PR DESCRIPTION
Two bugs that move published numbers. `distance_to_coastline` was measuring to the Antarctic grounding line — the GSHHS archive holds six layers and the loader took whichever the driver listed first, so Vientiane read 11,623 km from the sea instead of 356. Separately, the grid loader never converted to kilometres while the other two loaders did, so the same column name meant metres or kilometres depending on which frame it came from.
