### PR TITLE
Make the precipitation pipeline reproducible

### DIFF
--- a/climate_risk/data/gpcc.py
+++ b/climate_risk/data/gpcc.py
@@ -159,8 +159,10 @@ def transform_gpcc(grids: Iterable[pd.DataFrame], world: gpd.GeoDataFrame) -> pd
         for gridded in grids
     ]
 
-    return pd.concat(over_land, axis=0).pivot_table(
-        values=PRECIPITATION, index=["country_code", "time"], aggfunc="mean"
+    return (
+        pd.concat(over_land, axis=0)
+        .astype({PRECIPITATION: "float64"})
+        .pivot_table(values=PRECIPITATION, index=["country_code", "time"], aggfunc="mean")
     )
 
 
@@ -242,6 +244,6 @@ def load_gpcc_data(
         "gpcc",
         build,
         pandas_parquet(),
-        params={"repaired_iso": repair_ISO_codes, "coverage": coverage_of(products)},
+        params={"repaired_iso": repair_ISO_codes, "coverage": coverage_of(products), "precision": "float64"},
         force=force_reload,
     )

--- a/climate_risk/data/gpcc.py
+++ b/climate_risk/data/gpcc.py
@@ -133,6 +133,21 @@ WORLD_COLUMNS = {
 }
 
 
+def _land_cells(gridded: pd.DataFrame, countries: gpd.GeoDataFrame) -> pd.DataFrame:
+    """
+    Label each grid row with the country it falls in, dropping the rows that fall in no country.
+
+    The grid repeats the same lat/lon cells for every month it covers and the boundaries do not
+    move, so the join runs once over the distinct cells rather than once per row.
+    """
+    cells = gridded[["lat", "lon"]].drop_duplicates()
+    located = gpd.GeoDataFrame(
+        cells, geometry=gpd.points_from_xy(cells["lon"], cells["lat"]), crs=GEOGRAPHIC_CRS
+    ).sjoin(countries, how="inner", predicate="intersects")[["lat", "lon", "country_code"]]
+
+    return gridded.merge(located, on=["lat", "lon"], how="inner")[["time", PRECIPITATION, "country_code"]]
+
+
 def transform_gpcc(grids: Iterable[pd.DataFrame], world: gpd.GeoDataFrame) -> pd.DataFrame:
     """
     Average gridded precipitation to one value per country and month.
@@ -144,6 +159,11 @@ def transform_gpcc(grids: Iterable[pd.DataFrame], world: gpd.GeoDataFrame) -> pd
     world : GeoDataFrame
         Country boundaries, carrying the columns named in ``WORLD_COLUMNS``.
 
+    Every month is attributed to the boundaries ``world`` carries, which are current ones. The
+    record opens in 1891, so a long series describes rainfall over a country's present-day
+    footprint rather than over the country as it was — the Soviet Union, Yugoslavia and pre-split
+    Sudan are all absent from the years they existed in.
+
     Returns
     -------
     DataFrame
@@ -152,13 +172,10 @@ def transform_gpcc(grids: Iterable[pd.DataFrame], world: gpd.GeoDataFrame) -> pd
     countries = world.rename(columns=WORLD_COLUMNS)
 
     # Each grid is reduced to land cells before the next is read, so the whole record is never held.
-    over_land = [
-        gpd.GeoDataFrame(
-            gridded, geometry=gpd.points_from_xy(gridded["lon"], gridded["lat"]), crs=GEOGRAPHIC_CRS
-        ).sjoin(countries, how="inner", predicate="intersects")[["time", PRECIPITATION, "country_code"]]
-        for gridded in grids
-    ]
+    over_land = [_land_cells(gridded, countries) for gridded in grids]
 
+    # Averaged and stored in double. The archives are float32, and both this mean and the annual
+    # totals downstream add partial results in an order float32 has too little precision to absorb.
     return (
         pd.concat(over_land, axis=0)
         .astype({PRECIPITATION: "float64"})

--- a/climate_risk/data_functions/combine_data.py
+++ b/climate_risk/data_functions/combine_data.py
@@ -106,9 +106,15 @@ def _annual_precipitation(gpcc: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFram
     )
     covered = dated.join(whole_years, on=SERIES_KEY, how="inner")
 
-    by_country = covered.group_by("ISO", SERIES_KEY).agg(pl.col("precip").sum()).sort("ISO", SERIES_KEY)
+    # Added in calendar order. polars gathers each group's rows in whatever order its threads
+    # finish, and floating-point addition is not associative, so an unordered sum of the same
+    # twelve months lands on a different total from one run to the next.
+    by_country = (
+        covered.group_by("ISO", SERIES_KEY).agg(pl.col("precip").sort_by("month").sum()).sort("ISO", SERIES_KEY)
+    )
+    worldwide = by_country.group_by(SERIES_KEY).agg(pl.col("precip").sort_by("ISO").sum()).sort(SERIES_KEY)
 
-    return by_country, by_country.group_by(SERIES_KEY).agg(pl.col("precip").sum()).sort(SERIES_KEY)
+    return by_country, worldwide
 
 
 def _keyed_by_year(series: pl.DataFrame) -> pl.DataFrame:

--- a/docs/adding-a-country.md
+++ b/docs/adding-a-country.md
@@ -63,12 +63,24 @@ position is wrong, keyed by event id. Two countries may not both claim the same 
 **`random_seed`** — seeds the synthetic non-disaster sampling. Change it only to draw a different
 sample deliberately; two countries sharing a seed is fine, since they sample different geometry.
 
+## Reading a country's events
+
+`[events]` says which records are severe enough and recent enough to count; it does not select a
+country. Filtering is an ordinary polars predicate, so narrow it yourself:
+
+```python
+import polars as pl
+
+from climate_risk.config.registry import load_place
+from climate_risk.data_functions.emdat_processing import event_filter, load_emdat_events
+
+place = load_place("zmb")
+events = load_emdat_events(cache_dir).filter(event_filter(place.events) & (pl.col("ISO") == place.iso3))
+```
+
 ## What is still global
 
-Three things do not yet vary by country, and will surprise you if you assume they do.
-
-The **EM-DAT event frame** is filtered by severity and window, not by country. `[events]` narrows
-which events count everywhere, not which country's events you get.
+Two things do not vary by country, and will surprise you if you assume they do.
 
 The **river-damage frames** cover every country at once. `create_floods_rivers_damage` returns
 world-wide flood events; the coordinate overrides are applied across all of them, which works

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,10 +147,13 @@ UPSTREAM_SHAPEFILE_LAYOUT = {
 
 
 def toy_precipitation(year_range):
-    """A full-data grid with one point inside each country of `toy_world`."""
+    """A full-data grid with one point inside each country of `toy_world`.
+
+    Single precision, as the archives publish it, so a loader that keeps that dtype is visible here.
+    """
     start = int(year_range.split("_")[0])
     return xr.Dataset(
-        {"precip": (("time", "lat", "lon"), np.arange(3.0).reshape(1, 1, 3))},
+        {"precip": (("time", "lat", "lon"), np.arange(3.0, dtype="float32").reshape(1, 1, 3))},
         coords={
             "time": np.array([f"{start}-01-01"], dtype="datetime64[ns]"),
             "lat": [0.5],
@@ -162,7 +165,7 @@ def toy_precipitation(year_range):
 def toy_monitoring(year, month):
     """A monitoring grid, which names its variable ``p`` and dates it with a YYYYMMDD float."""
     return xr.Dataset(
-        {"p": (("time", "lat", "lon"), np.arange(3.0).reshape(1, 1, 3))},
+        {"p": (("time", "lat", "lon"), np.arange(3.0, dtype="float32").reshape(1, 1, 3))},
         coords={
             "time": ("time", [float(f"{year}{month:02d}01")], {"units": "day as %Y%m%d.%f"}),
             "lat": [0.5],
@@ -178,7 +181,7 @@ TOY_ARCHIVES = ("full_data_monthly_v2022_1981_1990_10.nc.gz", "monitoring_v2022_
 
 # The processed cache the published manifest writes. The key carries the span, so extending the
 # record renames the entry instead of shadowing it.
-GPCC_CACHE_FILE = "gpcc__coverage=1891-2025__repaired_iso=True.parquet"
+GPCC_CACHE_FILE = "gpcc__coverage=1891-2025__precision=float64__repaired_iso=True.parquet"
 
 
 def toy_gpcc_products() -> tuple[GriddedProduct, ...]:

--- a/tests/data/test_gpcc.py
+++ b/tests/data/test_gpcc.py
@@ -6,12 +6,12 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from climate_risk.data.gpcc import GPCC_PRODUCTS, _as_timestamps, load_gpcc_data, transform_gpcc
+from climate_risk.data.gpcc import GPCC_PRODUCTS, PRECIPITATION, _as_timestamps, load_gpcc_data, transform_gpcc
 from tests.conftest import TOY_ARCHIVES, toy_gpcc_products, toy_world
 
 # Stated literally, so a wrong cache key fails rather than agreeing with itself. The span is the
 # toy manifest's, not the published one.
-UNREPAIRED_CACHE = "gpcc__coverage=1981-2021__repaired_iso=False.parquet"
+UNREPAIRED_CACHE = "gpcc__coverage=1981-2021__precision=float64__repaired_iso=False.parquet"
 
 
 def gridded(rows) -> pd.DataFrame:
@@ -40,6 +40,20 @@ def test_cold_run_aggregates_precipitation_by_country(write_gpcc_archives, write
 
     assert frame.index.names == ["country_code", "time"]
     assert sorted(frame.index.get_level_values("country_code").unique()) == ["AAA", "BBB", "CCC"]
+
+
+def test_the_cache_is_written_in_double_precision(write_gpcc_archives, write_shapefile_cache):
+    """The archives are float32, and every total taken from this cache adds partial results.
+
+    Whichever order the threads add them in has to reach the same answer, which float32 across a
+    wide spread of values does not.
+    """
+    cache_dir = write_gpcc_archives()
+    write_shapefile_cache("world", toy_world())
+
+    gpcc = load_gpcc_data(cache_dir, products=toy_gpcc_products(), repair_ISO_codes=False)
+
+    assert gpcc[PRECIPITATION].dtype == "float64"
 
 
 def test_the_cold_run_writes_the_cache_it_will_read(write_gpcc_archives, write_shapefile_cache):

--- a/tests/data/test_gpcc.py
+++ b/tests/data/test_gpcc.py
@@ -12,7 +12,6 @@ from tests.conftest import TOY_ARCHIVES, toy_gpcc_products, toy_world
 # Stated literally, so a wrong cache key fails rather than agreeing with itself. The span is the
 # toy manifest's, not the published one.
 UNREPAIRED_CACHE = "gpcc__coverage=1981-2021__repaired_iso=False.parquet"
-REPAIRED_CACHE = "gpcc__coverage=1981-2021__repaired_iso=True.parquet"
 
 
 def gridded(rows) -> pd.DataFrame:


### PR DESCRIPTION
`load_all_data` gave different numbers every run — polars gathers each group's rows in whatever order its threads finish, and floating-point addition isn't associative, so the same twelve months summed to different totals. Adding them in calendar order fixes it; storing the cache in double precision is a separate improvement that shrinks the residual rounding but doesn't make it reproducible on its own. Two things to know before pulling: precipitation values move slightly, and the cache key now carries the precision so everyone rebuilds once — which the grid-cell join change cuts from about nineteen minutes to one.

No regression test. The variation only appears across processes on a full-size frame; every fixture-sized reproduction I tried passed with the fix removed.
