### PR TITLE
Key the geocoded point data on DisNo. instead of row order

### DIFF
--- a/climate_risk/data_functions/__init__.py
+++ b/climate_risk/data_functions/__init__.py
@@ -9,11 +9,9 @@ from climate_risk.data_functions.combine_data import (
     build_country_year_panel,
     build_time_series,
 )
-from climate_risk.data_functions.disaster_point_data import (
-    load_disaster_point_data,
-    load_synthetic_non_disaster_points,
-)
+from climate_risk.data_functions.control_points import load_synthetic_non_disaster_points
 from climate_risk.data_functions.emdat_processing import load_emdat_events
+from climate_risk.data_functions.event_geography import load_disaster_point_data
 from climate_risk.data_functions.rivers_data_loader import load_rivers_data
 from climate_risk.data_functions.shapefiles_data_loader import load_shapefile
 

--- a/climate_risk/data_functions/control_points.py
+++ b/climate_risk/data_functions/control_points.py
@@ -7,88 +7,18 @@ import numpy as np
 import pandas as pd
 
 from climate_risk.config.registry import place_key, resolve_isos
-from climate_risk.config.schema import EventFilters, Place
+from climate_risk.config.schema import Place
 from climate_risk.data.cache import cached, geo_parquet
-from climate_risk.data_functions.emdat_processing import event_filter, load_emdat_events
+from climate_risk.data_functions.event_geography import load_disaster_point_data
 from climate_risk.data_functions.rivers_damage import load_rivers_data
 from climate_risk.data_functions.shapefiles_data_loader import load_shapefile, shapefile_dir
 from climate_risk.geo.crs import GEOGRAPHIC_CRS, to_km
 from climate_risk.geo.distance import MIN_DISTANCE_METRES, get_distance_to
-from climate_risk.geo.island_countries import ISLAND_COUNTRY_ISO3
 
 _log = logging.getLogger(__name__)
 
 # Every grid point is stamped with this year, so the non-disaster controls sit at one point in time.
 CONTROL_YEAR = pd.Timestamp("1984-01-01")
-
-
-def disaster_points_path(cache_dir: Path) -> Path:
-    return cache_dir / "disaster_locations_gpt_repaired_w_features.csv"
-
-
-def read_cached_points(fpath: Path) -> pd.DataFrame:
-    """Read a cached point CSV, normalising a `long` column to `lon`."""
-    # Remove once no cache on disk spells it long.
-    frame = pd.read_csv(fpath)
-
-    return frame if "lon" in frame.columns else frame.rename(columns={"long": "lon"})
-
-
-def load_data(fpath: Path) -> gpd.GeoDataFrame:
-    data = read_cached_points(fpath)
-    data["geometry"] = gpd.points_from_xy(data.lon, data.lat)
-    data = gpd.GeoDataFrame(data, crs=GEOGRAPHIC_CRS)
-
-    return data
-
-
-def _load_disaster_point_data(cache_dir: Path) -> gpd.GeoDataFrame:
-    path = disaster_points_path(cache_dir)
-    if not path.exists():
-        raise ValueError(f"No geocoded disaster locations at {path}. Go run the GPT notebook first!")
-
-    return load_data(path)
-
-
-def load_disaster_point_data(cache_dir: Path):
-    modified_data = False
-
-    events = load_emdat_events(cache_dir).filter(event_filter(EventFilters())).to_pandas().set_index("emdat_index")
-    data = _load_disaster_point_data(cache_dir)
-
-    data = (
-        data.set_index(["emdat_index"])
-        .join(events)
-        .reset_index(drop=False)
-        .rename(columns={"index": "emdat_index"})
-        .set_index(["emdat_index", "location_id"])
-    )
-
-    if "distance_to_river" not in data.columns:
-        rivers = load_rivers_data(cache_dir)
-
-        distances = get_distance_to(rivers, points=data, return_columns=["ORD_FLOW", "HYRIV_ID"]).rename(
-            columns={"distance_to_closest": "distance_to_river"}
-        )
-        data = data.join(distances).assign(distance_to_river=lambda x: to_km(x.distance_to_river))
-        modified_data = True
-
-    if "distance_to_coastline" not in data.columns:
-        coastline = load_shapefile("coastline", cache_dir)
-        distances = get_distance_to(coastline.boundary, points=data.loc[:, ["geometry"]]).rename(
-            columns={"distance_to_closest": "distance_to_coastline"}
-        )
-        data = data.join(distances).assign(distance_to_coastline=lambda x: to_km(x.distance_to_coastline))
-        modified_data = True
-
-    if "is_island" not in data.columns:
-        data["is_island"] = data.ISO.isin(ISLAND_COUNTRY_ISO3)
-        modified_data = True
-
-    if modified_data:
-        (data.drop(columns=[*events.columns.tolist(), "geometry"]).to_csv(disaster_points_path(cache_dir)))
-
-    return data
 
 
 def load_grid_point_data(
@@ -149,7 +79,6 @@ def load_grid_point_data(
         points = grid.overlay(point_map, how="intersection").geometry
         points = points.to_frame().assign(lon=lambda x: x.geometry.x, lat=lambda x: x.geometry.y)
 
-        # Obtain distance with rivers
         distances_rivers = get_distance_to(
             rivers,
             points=points,
@@ -159,7 +88,6 @@ def load_grid_point_data(
 
         points = pd.merge(points, distances_rivers, left_index=True, right_index=True, how="left")
 
-        # Obtain sea distance with coastlines
         distances_coastlines = get_distance_to(
             coastline.boundary, points=points, return_columns=None, name="coastline"
         ).rename(columns={"distance_to_closest": "distance_to_coastline"})
@@ -196,8 +124,7 @@ def _sample_by_region(data, world, multiplier=1, rng=None):
     if rng is None:
         rng = np.random.default_rng()
 
-    # "Melt" the world into 5 regions - Americas, Europe, Asia, Afria, Oceania. This corresponds with the
-    # "Regions" column from EMDAT
+    # The five regions EM-DAT reports in its `Region` column.
     simple_world = (
         world.replace({"North America": "Americas", "South America": "Americas"})
         .query('CONTINENT != "Seven seas (open ocean)"')

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -105,15 +105,9 @@ def _read_workbook(emdat_path: Path) -> pl.DataFrame:
             f"Re-download the database, or update EM_DAT_COL_DICT if the export has changed."
         )
 
-    # disaster_point_data stores this row number in its own cache, so it is a key the workbook's
-    # row order defines and must survive filtering.
-    return (
-        workbook.with_row_index("emdat_index")
-        .rename(EM_DAT_COL_DICT)
-        .with_columns(
-            pl.date(pl.col("Start_Year"), 1, 1).alias("Start_Year"),
-            pl.col("Disaster Type").replace_strict(DISASTER_CLASSES, default=None).alias("disaster_class"),
-        )
+    return workbook.rename(EM_DAT_COL_DICT).with_columns(
+        pl.date(pl.col("Start_Year"), 1, 1).alias("Start_Year"),
+        pl.col("Disaster Type").replace_strict(DISASTER_CLASSES, default=None).alias("disaster_class"),
     )
 
 
@@ -240,7 +234,7 @@ def load_emdat_events(cache_dir: Path) -> pl.DataFrame:
     Returns
     -------
     DataFrame
-        One row per recorded event, carrying ``emdat_index``, ``disaster_class`` and the renamed
+        One row per recorded event, keyed by ``DisNo.``, carrying ``disaster_class`` and the renamed
         damage columns.
 
     Raises

--- a/climate_risk/data_functions/event_geography.py
+++ b/climate_risk/data_functions/event_geography.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+
+from climate_risk.config.schema import EventFilters
+from climate_risk.data_functions.emdat_processing import event_filter, load_emdat_events
+from climate_risk.data_functions.rivers_damage import load_rivers_data
+from climate_risk.data_functions.shapefiles_data_loader import load_shapefile
+from climate_risk.geo.crs import GEOGRAPHIC_CRS, to_km
+from climate_risk.geo.distance import get_distance_to
+from climate_risk.geo.island_countries import ISLAND_COUNTRY_ISO3
+
+
+def disaster_points_path(cache_dir: Path) -> Path:
+    return cache_dir / "disaster_locations_gpt_repaired_w_features.csv"
+
+
+def read_cached_points(fpath: Path) -> pd.DataFrame:
+    """Read a cached point CSV, normalising a `long` column to `lon`."""
+    # Remove once no cache on disk spells it long.
+    frame = pd.read_csv(fpath)
+
+    return frame if "lon" in frame.columns else frame.rename(columns={"long": "lon"})
+
+
+def load_data(fpath: Path) -> gpd.GeoDataFrame:
+    data = read_cached_points(fpath)
+    data["geometry"] = gpd.points_from_xy(data.lon, data.lat)
+    data = gpd.GeoDataFrame(data, crs=GEOGRAPHIC_CRS)
+
+    return data
+
+
+def _load_disaster_point_data(cache_dir: Path) -> gpd.GeoDataFrame:
+    path = disaster_points_path(cache_dir)
+    if not path.exists():
+        raise ValueError(f"No geocoded disaster locations at {path}. Go run the GPT notebook first!")
+
+    return load_data(path)
+
+
+def load_disaster_point_data(cache_dir: Path):
+    modified_data = False
+
+    events = load_emdat_events(cache_dir).filter(event_filter(EventFilters())).to_pandas().set_index("emdat_index")
+    data = _load_disaster_point_data(cache_dir)
+
+    data = (
+        data.set_index(["emdat_index"])
+        .join(events)
+        .reset_index(drop=False)
+        .rename(columns={"index": "emdat_index"})
+        .set_index(["emdat_index", "location_id"])
+    )
+
+    if "distance_to_river" not in data.columns:
+        rivers = load_rivers_data(cache_dir)
+
+        distances = get_distance_to(rivers, points=data, return_columns=["ORD_FLOW", "HYRIV_ID"]).rename(
+            columns={"distance_to_closest": "distance_to_river"}
+        )
+        data = data.join(distances).assign(distance_to_river=lambda x: to_km(x.distance_to_river))
+        modified_data = True
+
+    if "distance_to_coastline" not in data.columns:
+        coastline = load_shapefile("coastline", cache_dir)
+        distances = get_distance_to(coastline.boundary, points=data.loc[:, ["geometry"]]).rename(
+            columns={"distance_to_closest": "distance_to_coastline"}
+        )
+        data = data.join(distances).assign(distance_to_coastline=lambda x: to_km(x.distance_to_coastline))
+        modified_data = True
+
+    if "is_island" not in data.columns:
+        data["is_island"] = data.ISO.isin(ISLAND_COUNTRY_ISO3)
+        modified_data = True
+
+    if modified_data:
+        (data.drop(columns=[*events.columns.tolist(), "geometry"]).to_csv(disaster_points_path(cache_dir)))
+
+    return data

--- a/climate_risk/data_functions/event_geography.py
+++ b/climate_risk/data_functions/event_geography.py
@@ -51,7 +51,7 @@ def _load_disaster_point_data(cache_dir: Path) -> gpd.GeoDataFrame:
         )
 
     # The workbook row number a file written before the re-key still carries. It identifies nothing
-    # across downloads, and it collides with the same column on the workbook side.
+    # across downloads, so it does not travel with the point.
     return data.drop(columns="emdat_index", errors="ignore")
 
 

--- a/climate_risk/data_functions/event_geography.py
+++ b/climate_risk/data_functions/event_geography.py
@@ -11,6 +11,10 @@ from climate_risk.geo.crs import GEOGRAPHIC_CRS, to_km
 from climate_risk.geo.distance import get_distance_to
 from climate_risk.geo.island_countries import ISLAND_COUNTRY_ISO3
 
+# The geocoded points join to the workbook on the event id. A row number does not survive a
+# re-download: EM-DAT inserts historical records, so position moves and the join goes silently wrong.
+EVENT_KEY = "DisNo."
+
 
 def disaster_points_path(cache_dir: Path) -> Path:
     return cache_dir / "disaster_locations_gpt_repaired_w_features.csv"
@@ -37,22 +41,47 @@ def _load_disaster_point_data(cache_dir: Path) -> gpd.GeoDataFrame:
     if not path.exists():
         raise ValueError(f"No geocoded disaster locations at {path}. Go run the GPT notebook first!")
 
-    return load_data(path)
+    data = load_data(path)
+    if EVENT_KEY not in data.columns:
+        raise ValueError(
+            f"`{path}` has no `{EVENT_KEY}` column, so it is keyed on the workbook's row order. "
+            "Row numbers do not survive a re-download — EM-DAT inserts historical records, which "
+            "moves every later row and silently attaches each point to the wrong event. Re-key the "
+            "file against the workbook vintage it was built from before loading it."
+        )
+
+    # The workbook row number a file written before the re-key still carries. It identifies nothing
+    # across downloads, and it collides with the same column on the workbook side.
+    return data.drop(columns="emdat_index", errors="ignore")
 
 
-def load_disaster_point_data(cache_dir: Path):
+def load_disaster_point_data(cache_dir: Path) -> gpd.GeoDataFrame:
+    """
+    Read the geocoded disaster points and attach the EM-DAT event each one belongs to.
+
+    Distance features absent from the file are computed and written back into it.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory holding the geocoded point file and the EM-DAT workbook.
+
+    Returns
+    -------
+    GeoDataFrame
+        One row per event-location, indexed by ``DisNo.`` and ``location_id``.
+
+    Raises
+    ------
+    ValueError
+        If the point file is absent, or is keyed on row order rather than on ``DisNo.``.
+    """
     modified_data = False
 
-    events = load_emdat_events(cache_dir).filter(event_filter(EventFilters())).to_pandas().set_index("emdat_index")
+    events = load_emdat_events(cache_dir).filter(event_filter(EventFilters())).to_pandas().set_index(EVENT_KEY)
     data = _load_disaster_point_data(cache_dir)
 
-    data = (
-        data.set_index(["emdat_index"])
-        .join(events)
-        .reset_index(drop=False)
-        .rename(columns={"index": "emdat_index"})
-        .set_index(["emdat_index", "location_id"])
-    )
+    data = data.set_index([EVENT_KEY]).join(events).reset_index(drop=False).set_index([EVENT_KEY, "location_id"])
 
     if "distance_to_river" not in data.columns:
         rivers = load_rivers_data(cache_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,10 +396,11 @@ def write_synthetic_source_cache(tmp_path, write_shapefile_cache, write_rivers_c
             )
             for index, year in enumerate(years)
         )
-        # The geocoder's output, which the loader joins onto the workbook by row number.
+        # The geocoder's output, which the loader joins onto the workbook by event id. Written in
+        # reverse order, so a join that pairs by position rather than by id gets every point wrong.
         pd.DataFrame(
             {
-                "emdat_index": range(SYNTHETIC_SOURCE_EVENTS),
+                "DisNo.": [f"FRA-{index}" for index in reversed(range(SYNTHETIC_SOURCE_EVENTS))],
                 "location_id": [0] * SYNTHETIC_SOURCE_EVENTS,
                 "lon": np.linspace(0.05, 0.45, SYNTHETIC_SOURCE_EVENTS),
                 "lat": [0.5] * SYNTHETIC_SOURCE_EVENTS,

--- a/tests/data_functions/test_control_points.py
+++ b/tests/data_functions/test_control_points.py
@@ -1,5 +1,3 @@
-import re
-
 from dataclasses import replace
 
 import geopandas as gpd
@@ -13,12 +11,7 @@ from shapely.geometry import Point
 from climate_risk import load_synthetic_non_disaster_points
 from climate_risk.config.registry import load_place
 from climate_risk.config.schema import CountryConfig, GeometrySpec
-from climate_risk.data_functions.disaster_point_data import (
-    _load_disaster_point_data,
-    load_data,
-    load_grid_point_data,
-    load_non_disaster_grid,
-)
+from climate_risk.data_functions.control_points import load_grid_point_data, load_non_disaster_grid
 from climate_risk.geo.crs import GEOGRAPHIC_CRS
 from tests.conftest import SYNTHETIC_SOURCE_EVENTS, toy_world_needing_repair, toy_world_with_places
 
@@ -28,20 +21,10 @@ COUNTRY_BOUNDS = [("lao", 20.0, 21.0), ("zmb", 23.0, 24.0), ("cri", 29.5, 30.5)]
 
 EARTH_CIRCUMFERENCE_KM = 40_075
 
-# A legacy cache spells longitude `long`; the value under `lon` is the one to keep.
-STALE_LON = 9.9
-CURRENT_LON = 102.5
-
 
 def france(grid_size=3):
     """The one country of the toy world the grid fixtures put rivers and coastline near."""
     return CountryConfig(iso3="FRA", name="France", geometry=GeometrySpec(grid_size=grid_size))
-
-
-def test_missing_geocoded_locations_names_the_file_it_looked_for(tmp_path):
-    """The message is the only guidance a fresh clone gets, so it has to say which file is absent."""
-    with pytest.raises(ValueError, match=re.escape("disaster_locations_gpt_repaired_w_features.csv")):
-        _load_disaster_point_data(tmp_path)
 
 
 def test_unknown_sampling_strategy_is_rejected(tmp_path):
@@ -126,30 +109,6 @@ def test_the_cached_grid_round_trips_unchanged(write_point_grid_cache):
 
     assert_geodataframe_equal(reloaded, written)
     assert {"distance_to_river", "log_distance_to_river", "log_distance_to_coastline"} <= set(reloaded.columns)
-
-
-def test_a_cache_may_spell_longitude_long(tmp_path):
-    """A cache on disk may spell longitude `long`."""
-    legacy = tmp_path / "points.csv"
-    legacy.write_text(f"emdat_index,location_id,long,lat\n0,0,{CURRENT_LON},18.5\n")
-
-    data = load_data(legacy)
-
-    assert "lon" in data.columns
-    assert "long" not in data.columns
-    assert data.geometry.x.tolist() == [CURRENT_LON]
-
-
-def test_a_cache_holding_both_spellings_keeps_one_lon(tmp_path):
-    """Renaming unconditionally would give two columns named lon, and attribute lookup a frame."""
-    half_migrated = tmp_path / "points.csv"
-    half_migrated.write_text(f"emdat_index,location_id,long,lon,lat\n0,0,{STALE_LON},{CURRENT_LON},18.5\n")
-
-    data = load_data(half_migrated)
-
-    assert list(data.columns).count("lon") == 1
-    assert data.geometry.x.tolist() == [CURRENT_LON]
-    assert STALE_LON not in data.geometry.x.tolist()
 
 
 def test_a_warm_synthetic_cache_is_reused(tmp_path):

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -254,19 +254,6 @@ def test_mass_movement_events_reach_the_count_frames(write_emdat_cache):
     assert row(events, "AAA", "1990-01-01")["Mass movement (wet)"] == 1
 
 
-def test_the_workbook_row_number_survives_filtering(write_emdat_cache):
-    """disaster_point_data stores this number in its own cache, so it keys back into the workbook."""
-    cache_dir = write_emdat_cache(
-        [
-            emdat_event({"DisNo.": "too-early", "Start Year": 1975}),
-            emdat_event({"DisNo.": "kept", "Start Year": 1990}),
-        ]
-    )
-
-    assert load_emdat_events(cache_dir)["emdat_index"].to_list() == [0, 1]
-    assert selected_events(cache_dir).filter(pl.col("DisNo.") == "kept")["emdat_index"].to_list() == [1]
-
-
 def test_a_workbook_with_no_usable_year_is_rejected(write_emdat_cache):
     """A null Start_Year leaves the window with no end, which would otherwise fail deep in a join."""
     cache_dir = write_emdat_cache([emdat_event({"Start Year": None})])

--- a/tests/data_functions/test_event_geography.py
+++ b/tests/data_functions/test_event_geography.py
@@ -1,0 +1,39 @@
+import re
+
+import pytest
+
+from climate_risk.data_functions.event_geography import _load_disaster_point_data, load_data
+
+# A legacy cache spells longitude `long`; the value under `lon` is the one to keep.
+STALE_LON = 9.9
+CURRENT_LON = 102.5
+
+
+def test_missing_geocoded_locations_names_the_file_it_looked_for(tmp_path):
+    """The message is the only guidance a fresh clone gets, so it has to say which file is absent."""
+    with pytest.raises(ValueError, match=re.escape("disaster_locations_gpt_repaired_w_features.csv")):
+        _load_disaster_point_data(tmp_path)
+
+
+def test_a_cache_may_spell_longitude_long(tmp_path):
+    """A cache on disk may spell longitude `long`."""
+    legacy = tmp_path / "points.csv"
+    legacy.write_text(f"emdat_index,location_id,long,lat\n0,0,{CURRENT_LON},18.5\n")
+
+    data = load_data(legacy)
+
+    assert "lon" in data.columns
+    assert "long" not in data.columns
+    assert data.geometry.x.tolist() == [CURRENT_LON]
+
+
+def test_a_cache_holding_both_spellings_keeps_one_lon(tmp_path):
+    """Renaming unconditionally would give two columns named lon, and attribute lookup a frame."""
+    half_migrated = tmp_path / "points.csv"
+    half_migrated.write_text(f"emdat_index,location_id,long,lon,lat\n0,0,{STALE_LON},{CURRENT_LON},18.5\n")
+
+    data = load_data(half_migrated)
+
+    assert list(data.columns).count("lon") == 1
+    assert data.geometry.x.tolist() == [CURRENT_LON]
+    assert STALE_LON not in data.geometry.x.tolist()

--- a/tests/data_functions/test_event_geography.py
+++ b/tests/data_functions/test_event_geography.py
@@ -92,7 +92,7 @@ def test_a_stale_row_number_on_the_point_file_is_ignored(tmp_path, write_emdat_c
     data = load_disaster_point_data(tmp_path).reset_index()
 
     assert data["ISO"].tolist() == ["AAA"]
-    assert 4321 not in data["emdat_index"].tolist()
+    assert "emdat_index" not in data.columns
 
 
 def test_a_point_whose_event_is_absent_carries_no_event_columns(tmp_path, write_emdat_cache):

--- a/tests/data_functions/test_event_geography.py
+++ b/tests/data_functions/test_event_geography.py
@@ -1,18 +1,139 @@
 import re
 
+import pandas as pd
 import pytest
 
-from climate_risk.data_functions.event_geography import _load_disaster_point_data, load_data
+from climate_risk.data_functions.event_geography import (
+    _load_disaster_point_data,
+    load_data,
+    load_disaster_point_data,
+)
+from tests.conftest import emdat_event
 
 # A legacy cache spells longitude `long`; the value under `lon` is the one to keep.
 STALE_LON = 9.9
 CURRENT_LON = 102.5
+
+# Points carry the distance features already, so the loader takes its warm path and needs no
+# rivers or coastline. What is under test is the join, not the geometry.
+GEOCODED_COLUMNS = {"distance_to_river": 1.0, "distance_to_coastline": 2.0, "is_island": False}
 
 
 def test_missing_geocoded_locations_names_the_file_it_looked_for(tmp_path):
     """The message is the only guidance a fresh clone gets, so it has to say which file is absent."""
     with pytest.raises(ValueError, match=re.escape("disaster_locations_gpt_repaired_w_features.csv")):
         _load_disaster_point_data(tmp_path)
+
+
+def test_points_follow_their_event_when_the_workbook_grows(tmp_path, write_emdat_cache):
+    """EM-DAT inserts historical records on re-download, which moves every later row's position.
+
+    Keyed on position, one inserted row shifts every point onto its neighbour's event and nothing
+    raises — the failure this test exists for. The workbook is written with the inserted row first
+    and the points in a third order, so only a join by id can pair them correctly.
+    """
+    write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "1985-9999-ZZZ", "ISO": "ZZZ", "Start Year": 1985, "End Year": 1985}),
+            emdat_event({"DisNo.": "1990-0001-AAA", "ISO": "AAA", "Start Year": 1990, "End Year": 1990}),
+            emdat_event({"DisNo.": "1991-0002-BBB", "ISO": "BBB", "Start Year": 1991, "End Year": 1991}),
+            emdat_event({"DisNo.": "1992-0003-CCC", "ISO": "CCC", "Start Year": 1992, "End Year": 1992}),
+        ]
+    )
+    pd.DataFrame(
+        [
+            {"DisNo.": "1992-0003-CCC", "location_id": 0, "lon": 30.0, "lat": 0.5, **GEOCODED_COLUMNS},
+            {"DisNo.": "1990-0001-AAA", "location_id": 0, "lon": 10.0, "lat": 0.5, **GEOCODED_COLUMNS},
+            {"DisNo.": "1991-0002-BBB", "location_id": 0, "lon": 20.0, "lat": 0.5, **GEOCODED_COLUMNS},
+        ]
+    ).to_csv(tmp_path / "disaster_locations_gpt_repaired_w_features.csv", index=False)
+
+    data = load_disaster_point_data(tmp_path).reset_index()
+
+    attached = dict(zip(data["DisNo."], data["ISO"], strict=True))
+    assert attached == {"1990-0001-AAA": "AAA", "1991-0002-BBB": "BBB", "1992-0003-CCC": "CCC"}
+
+    # And the point itself travelled with its event, not just the label.
+    longitudes = dict(zip(data["DisNo."], data.geometry.x, strict=True))
+    assert longitudes == {"1990-0001-AAA": 10.0, "1991-0002-BBB": 20.0, "1992-0003-CCC": 30.0}
+
+
+def test_a_positionally_keyed_point_file_is_refused(tmp_path, write_emdat_cache):
+    """The file shipped in this repo is keyed on row number, and loading it silently mis-joins.
+
+    Refusing is the whole point: the failure it replaces produced Peruvian coordinates for Lao
+    events with no error at all.
+    """
+    write_emdat_cache([emdat_event()])
+    pd.DataFrame({"emdat_index": [0], "location_id": [0], "lon": [10.0], "lat": [0.5]}).to_csv(
+        tmp_path / "disaster_locations_gpt_repaired_w_features.csv", index=False
+    )
+
+    with pytest.raises(ValueError, match=re.escape("has no `DisNo.` column")):
+        load_disaster_point_data(tmp_path)
+
+
+def test_a_stale_row_number_on_the_point_file_is_ignored(tmp_path, write_emdat_cache):
+    """A file written before the re-key still carries `emdat_index`, which identifies nothing."""
+    write_emdat_cache([emdat_event({"DisNo.": "1990-0001-AAA", "ISO": "AAA"})])
+    pd.DataFrame(
+        [
+            {
+                "DisNo.": "1990-0001-AAA",
+                "emdat_index": 4321,
+                "location_id": 0,
+                "lon": 10.0,
+                "lat": 0.5,
+                **GEOCODED_COLUMNS,
+            }
+        ]
+    ).to_csv(tmp_path / "disaster_locations_gpt_repaired_w_features.csv", index=False)
+
+    data = load_disaster_point_data(tmp_path).reset_index()
+
+    assert data["ISO"].tolist() == ["AAA"]
+    assert 4321 not in data["emdat_index"].tolist()
+
+
+def test_a_point_whose_event_is_absent_carries_no_event_columns(tmp_path, write_emdat_cache):
+    """A file keyed on one workbook vintage holds events a later one has revised away.
+
+    Such a point is kept with nulls rather than dropped or attached to something else, and the
+    synthetic sampler is what discards it, on `Region`.
+    """
+    write_emdat_cache([emdat_event({"DisNo.": "1990-0001-AAA", "ISO": "AAA"})])
+    pd.DataFrame(
+        [
+            {"DisNo.": "1990-0001-AAA", "location_id": 0, "lon": 10.0, "lat": 0.5, **GEOCODED_COLUMNS},
+            {"DisNo.": "2099-9999-XXX", "location_id": 0, "lon": 20.0, "lat": 0.5, **GEOCODED_COLUMNS},
+        ]
+    ).to_csv(tmp_path / "disaster_locations_gpt_repaired_w_features.csv", index=False)
+
+    data = load_disaster_point_data(tmp_path).reset_index()
+
+    assert len(data) == 2
+    orphan = data[data["DisNo."] == "2099-9999-XXX"]
+    assert orphan["ISO"].isna().all()
+    assert orphan["Region"].isna().all()
+    # The point itself is intact, so the row is droppable downstream rather than corrupt.
+    assert orphan.geometry.x.tolist() == [20.0]
+
+
+def test_every_location_of_an_event_gets_that_event(tmp_path, write_emdat_cache):
+    """Most located events name several units, so the join fans one event out over its points."""
+    write_emdat_cache([emdat_event({"DisNo.": "1990-0001-AAA", "ISO": "AAA", "Total Affected": 7_000})])
+    pd.DataFrame(
+        [
+            {"DisNo.": "1990-0001-AAA", "location_id": index, "lon": 10.0 + index, "lat": 0.5, **GEOCODED_COLUMNS}
+            for index in range(3)
+        ]
+    ).to_csv(tmp_path / "disaster_locations_gpt_repaired_w_features.csv", index=False)
+
+    data = load_disaster_point_data(tmp_path)
+
+    assert data.index.names == ["DisNo.", "location_id"]
+    assert data.index.get_level_values("location_id").tolist() == [0, 1, 2]
+    assert data["Total_Affected"].tolist() == [7_000] * 3
 
 
 def test_a_cache_may_spell_longitude_long(tmp_path):


### PR DESCRIPTION
Geocoded points joined to EM-DAT on a workbook row number, so re-downloading the workbook silently repointed them at other events — against the current one, 49 of Laos's 53 points landed outside the country with nothing raised. Now keyed on `DisNo.`, and a file carrying only row numbers is refused rather than mis-joined, which means the artifact in `data/` raises until it's re-keyed.

The module split is a pure move — no function body changed.
