### PR TITLE
Take EM-DAT's own GADM units as the primary geography

### DIFF
--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -80,6 +80,20 @@ def _units_at_level(gids: list[str], level: int, path: Path, layer: str) -> gpd.
     return found.rename(columns={gid_column: "gid", name_column: "name"}).assign(admin_level=level)
 
 
+def _no_units(path: Path, layer: str) -> gpd.GeoDataFrame:
+    """
+    An empty result carrying the layer's CRS, read without any of its rows.
+
+    A CRS-less frame concatenates with projected geometry without complaint and reprojects to the
+    wrong place, so the empty case has to match the populated one.
+    """
+    return gpd.GeoDataFrame(
+        {"gid": [], "name": [], "admin_level": pd.Series([], dtype="int64")},
+        geometry=[],
+        crs=gpd.read_file(path, layer=layer, where="0=1").crs,
+    )
+
+
 def load_admin_units(
     units: Collection[tuple[str, int]], cache_dir: Path, *, layer: str = GADM_LAYER
 ) -> gpd.GeoDataFrame:
@@ -131,9 +145,7 @@ def load_admin_units(
         if (frame := _units_at_level(gids_at_level, level, path, layer)) is not None
     ]
     resolved = (
-        gpd.GeoDataFrame(pd.concat(frames, ignore_index=True), crs=frames[0].crs)
-        if frames
-        else gpd.GeoDataFrame({"gid": [], "name": [], "admin_level": []}, geometry=[])
+        gpd.GeoDataFrame(pd.concat(frames, ignore_index=True), crs=frames[0].crs) if frames else _no_units(path, layer)
     )
 
     missing = sorted({gid for gid, _ in requested} - set(resolved["gid"]))

--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from climate_risk.data.source import ManualSource
+
+# GADM's terms exclude redistribution and automated download, so it is declared as a manual source
+# and never appears in the fetchable registry.
+GADM = ManualSource(
+    filename="gadm_410.gpkg",
+    homepage="https://gadm.org/download_world.html",
+    licence=(
+        "Academic use and other non-commercial use only. Redistribution, and use as part of a "
+        "commercial product or service, require prior written permission."
+    ),
+    citation="GADM, Database of Global Administrative Areas, version 4.1. https://gadm.org",
+    retrieved="2026-08-09",
+)
+
+# The GeoPackage carries every level in one table, so a query names the level it wants.
+GADM_LAYER = "gadm_410"
+
+
+def gadm_dir(cache_dir: Path) -> Path:
+    return cache_dir / "gadm"
+
+
+def gadm_path(cache_dir: Path) -> Path:
+    """
+    Return the path to the GADM GeoPackage, raising if it has not been placed in the cache.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    Path
+        Location of ``gadm_410.gpkg``.
+
+    Raises
+    ------
+    NotImplementedError
+        If the GeoPackage is absent. Its licence forbids downloading it automatically.
+    """
+    return GADM.require(gadm_dir(cache_dir))

--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -1,6 +1,11 @@
+from collections.abc import Collection, Iterator
 from pathlib import Path
 
+import geopandas as gpd
+import pandas as pd
+
 from climate_risk.data.source import ManualSource
+from climate_risk.exceptions import DataValidationError
 
 # GADM's terms exclude redistribution and automated download, so it is declared as a manual source
 # and never appears in the fetchable registry.
@@ -15,8 +20,14 @@ GADM = ManualSource(
     retrieved="2026-08-09",
 )
 
-# The GeoPackage carries every level in one table, so a query names the level it wants.
+# One table holds every country at its finest level, so a unit above that is the union of its rows.
 GADM_LAYER = "gadm_410"
+
+GID_COLUMNS = {1: ("GID_1", "NAME_1"), 2: ("GID_2", "NAME_2")}
+
+# SQLite caps how many terms an IN list may carry, and a long WHERE also costs more to parse than
+# the extra passes cost to run.
+GID_CHUNK = 400
 
 
 def gadm_dir(cache_dir: Path) -> Path:
@@ -43,3 +54,86 @@ def gadm_path(cache_dir: Path) -> Path:
         If the GeoPackage is absent. Its licence forbids downloading it automatically.
     """
     return GADM.require(gadm_dir(cache_dir))
+
+
+def _chunks(values: list[str], size: int) -> Iterator[list[str]]:
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+def _units_at_level(gids: list[str], level: int, path: Path, layer: str) -> list[gpd.GeoDataFrame]:
+    gid_column, name_column = GID_COLUMNS[level]
+    read = []
+
+    for chunk in _chunks(gids, GID_CHUNK):
+        quoted = ",".join(f"'{gid}'" for gid in chunk)
+        rows = gpd.read_file(path, layer=layer, columns=[gid_column, name_column], where=f"{gid_column} IN ({quoted})")
+        if not rows.empty:
+            # The table stores the finest level, so a unit above it spans several rows.
+            read.append(rows.dissolve(by=gid_column, aggfunc="first", as_index=False))
+
+    return [frame.rename(columns={gid_column: "gid", name_column: "name"}).assign(admin_level=level) for frame in read]
+
+
+def load_admin_units(
+    units: Collection[tuple[str, int]], cache_dir: Path, *, layer: str = GADM_LAYER
+) -> gpd.GeoDataFrame:
+    """
+    Read one polygon per GADM unit named.
+
+    The level comes from the caller because a GADM id does not reliably state it: most countries are
+    numbered ``LAO.11_1`` and ``LAO.11.3_1``, but Ghana's provinces are ``GHA11_2`` and its districts
+    ``GHA7.13_2``. EM-DAT records the level in the key it files each unit under.
+
+    Parameters
+    ----------
+    units : collection of tuple of (str, int)
+        Each a GADM identifier and its administrative level, 1 or 2. Duplicates are read once.
+    cache_dir : Path
+        Directory the caches live under.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    GeoDataFrame
+        Columns ``gid``, ``name``, ``admin_level`` and ``geometry``, one row per distinct id.
+
+    Raises
+    ------
+    NotImplementedError
+        If the GeoPackage is absent.
+    DataValidationError
+        If GADM holds no unit for one of the ids, or a level is one GADM is not read at.
+    """
+    path = gadm_path(cache_dir)
+    requested = set(units)
+
+    by_level: dict[int, list[str]] = {}
+    for gid, level in sorted(requested):
+        by_level.setdefault(level, []).append(gid)
+
+    unsupported = sorted(set(by_level) - set(GID_COLUMNS))
+    if unsupported:
+        raise DataValidationError(
+            f"Units are read at levels {sorted(GID_COLUMNS)}, but these were asked for at "
+            f"{unsupported}: {[gid for level in unsupported for gid in by_level[level][:3]]}"
+        )
+
+    frames = [
+        frame for level, gids_here in by_level.items() for frame in _units_at_level(gids_here, level, path, layer)
+    ]
+    resolved = (
+        gpd.GeoDataFrame(pd.concat(frames, ignore_index=True), crs=frames[0].crs)
+        if frames
+        else gpd.GeoDataFrame({"gid": [], "name": [], "admin_level": []}, geometry=[])
+    )
+
+    missing = sorted({gid for gid, _ in requested} - set(resolved["gid"]))
+    if missing:
+        raise DataValidationError(
+            f"GADM holds no unit for {len(missing)} of {len(requested)} ids, starting {missing[:5]}. "
+            f"The GeoPackage version may not match the one the ids were coded against."
+        )
+
+    return resolved[["gid", "name", "admin_level", "geometry"]]

--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -25,8 +25,8 @@ GADM_LAYER = "gadm_410"
 
 GID_COLUMNS = {1: ("GID_1", "NAME_1"), 2: ("GID_2", "NAME_2")}
 
-# SQLite caps how many terms an IN list may carry, and a long WHERE also costs more to parse than
-# the extra passes cost to run.
+# A WHERE clause naming every id at once grows past what the driver will parse, and costs more to
+# plan than the extra passes cost to run.
 GID_CHUNK = 400
 
 
@@ -61,7 +61,7 @@ def _chunks(values: list[str], size: int) -> Iterator[list[str]]:
         yield values[start : start + size]
 
 
-def _units_at_level(gids: list[str], level: int, path: Path, layer: str) -> list[gpd.GeoDataFrame]:
+def _units_at_level(gids: list[str], level: int, path: Path, layer: str) -> gpd.GeoDataFrame | None:
     gid_column, name_column = GID_COLUMNS[level]
     read = []
 
@@ -72,7 +72,12 @@ def _units_at_level(gids: list[str], level: int, path: Path, layer: str) -> list
             # The table stores the finest level, so a unit above it spans several rows.
             read.append(rows.dissolve(by=gid_column, aggfunc="first", as_index=False))
 
-    return [frame.rename(columns={gid_column: "gid", name_column: "name"}).assign(admin_level=level) for frame in read]
+    if not read:
+        return None
+
+    found = pd.concat(read, ignore_index=True) if len(read) > 1 else read[0]
+
+    return found.rename(columns={gid_column: "gid", name_column: "name"}).assign(admin_level=level)
 
 
 def load_admin_units(
@@ -121,7 +126,9 @@ def load_admin_units(
         )
 
     frames = [
-        frame for level, gids_here in by_level.items() for frame in _units_at_level(gids_here, level, path, layer)
+        frame
+        for level, gids_at_level in by_level.items()
+        if (frame := _units_at_level(gids_at_level, level, path, layer)) is not None
     ]
     resolved = (
         gpd.GeoDataFrame(pd.concat(frames, ignore_index=True), crs=frames[0].crs)

--- a/climate_risk/data/source.py
+++ b/climate_risk/data/source.py
@@ -109,7 +109,8 @@ class ManualSource:
         path = self.path(directory)
         if not path.exists():
             raise NotImplementedError(
-                f"No {self.filename} was found at `{path}`. It is licensed as: {self.licence} "
+                f"No {self.filename} was found at `{path}`.\n"
+                f"Licence: {self.licence}\n"
                 f"Obtain it from {self.homepage} and place it at `{path}`."
             )
 

--- a/climate_risk/data/source.py
+++ b/climate_risk/data/source.py
@@ -47,6 +47,76 @@ class DataSource:
 
 
 @dataclass(frozen=True, slots=True)
+class ManualSource:
+    """
+    One upstream file the user has to place in the cache by hand.
+
+    Carries no URL: these are published under terms that forbid automated download, so there is
+    nothing for :func:`climate_risk.data.fetch.fetch` to consume and no way to register one for the
+    reachability check.
+
+    Parameters
+    ----------
+    filename : str
+        Name the file is stored under, inside its cache directory. A bare name, never a path.
+    homepage : str
+        Where a person goes to obtain the file.
+    licence : str
+        Terms the data is published under, including any restriction on redistribution.
+    citation : str
+        How to credit the publisher.
+    retrieved : str
+        ISO date this declaration was last checked against the publisher.
+
+    Raises
+    ------
+    ValueError
+        If ``filename`` carries a path, ``homepage`` is not http(s), or ``retrieved`` is not an ISO
+        date.
+    """
+
+    filename: str
+    homepage: str
+    licence: str
+    citation: str
+    retrieved: str
+
+    def __post_init__(self) -> None:
+        if not self.filename or Path(self.filename).name != self.filename:
+            raise ValueError(f"{self.homepage}: filename must be a bare name, got {self.filename!r}")
+
+        if not self.homepage.startswith(("http://", "https://")):
+            raise ValueError(f"{self.filename}: homepage must be http(s), got {self.homepage!r}")
+
+        try:
+            date.fromisoformat(self.retrieved)
+        except ValueError as err:
+            raise ValueError(f"{self.filename}: retrieved must be an ISO date, got {self.retrieved!r}") from err
+
+    def path(self, directory: Path) -> Path:
+        """Return where this source is stored inside ``directory``."""
+        return directory / self.filename
+
+    def require(self, directory: Path) -> Path:
+        """
+        Return the path to the file, raising if nobody has put it there.
+
+        Raises
+        ------
+        NotImplementedError
+            If the file is absent. It cannot be downloaded on the user's behalf.
+        """
+        path = self.path(directory)
+        if not path.exists():
+            raise NotImplementedError(
+                f"No {self.filename} was found at `{path}`. It is licensed as: {self.licence} "
+                f"Obtain it from {self.homepage} and place it at `{path}`."
+            )
+
+        return path
+
+
+@dataclass(frozen=True, slots=True)
 class ShapefileArchive:
     """
     A zipped shapefile, together with the layer inside it to read.

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -61,7 +61,7 @@ DISASTER_TYPES = tuple(c for c in PROB_COLS if c not in {"Country", "ISO", "Star
 
 # Columns read before any rename. Nothing detects upstream schema drift, so this check is the
 # earliest point a changed export becomes a named error rather than a missing attribute.
-REQUIRED_EMDAT_COLUMNS = {"ISO", "Region", "Subregion", "Disaster Type"} | set(EM_DAT_COL_DICT)
+REQUIRED_EMDAT_COLUMNS = {"ISO", "Region", "Subregion", "Disaster Type", "GADM Admin Units"} | set(EM_DAT_COL_DICT)
 
 # Misspelled on the wire. Correcting it would invalidate every cached CSV on every machine, so the
 # literal stays and the constants are how code should refer to it.
@@ -315,6 +315,67 @@ def event_units(events: pl.DataFrame) -> pl.DataFrame:
             )
 
     return pl.DataFrame(rows, schema=EVENT_UNIT_SCHEMA)
+
+
+# Where an event's geometry comes from, best first. Nothing is filtered on this: the column records
+# what the source holds, and a model chooses which tiers it will accept.
+GEOMETRY_SOURCES = ("gadm", "emdat_point", "country")
+
+EVENT_GEOGRAPHY_SCHEMA = {
+    "DisNo.": pl.String,
+    "ISO": pl.String,
+    "geometry_source": pl.String,
+    "gid": pl.String,
+    "name": pl.String,
+    "admin_level": pl.Int8,
+    "migration_method": pl.String,
+    "Latitude": pl.Float64,
+    "Longitude": pl.Float64,
+}
+
+
+def event_geography(events: pl.DataFrame) -> pl.DataFrame:
+    """
+    Say where every event's geometry comes from, one row per event-unit and one per event otherwise.
+
+    An event coded to administrative units contributes a row per unit; one with only a coordinate,
+    or with nothing, contributes a single row. Every event in ``events`` appears, so an absence of
+    geography is stated rather than implied by a missing row.
+
+    ``Latitude`` and ``Longitude`` are carried wherever EM-DAT supplies them, including on ``gadm``
+    rows, so the two claims stay visible side by side rather than one being discarded.
+
+    Parameters
+    ----------
+    events : DataFrame
+        The workbook, as :func:`load_emdat_events` returns it.
+
+    Returns
+    -------
+    DataFrame
+        ``DisNo.``, ``ISO``, ``geometry_source`` from ``GEOMETRY_SOURCES``, the unit columns of
+        :func:`event_units` where one applies, and the event's coordinate where it has one.
+    """
+    units = event_units(events)
+    located = events.select("DisNo.", "ISO", "Latitude", "Longitude")
+
+    from_units = units.join(located, on="DisNo.", how="left").with_columns(pl.lit("gadm").alias("geometry_source"))
+
+    coded = set(units["DisNo."])
+    rest = located.filter(~pl.col("DisNo.").is_in(coded)).with_columns(
+        pl.when(pl.col("Latitude").is_not_null())
+        .then(pl.lit("emdat_point"))
+        .otherwise(pl.lit("country"))
+        .alias("geometry_source"),
+        pl.lit(None, dtype=pl.String).alias("gid"),
+        pl.lit(None, dtype=pl.String).alias("name"),
+        pl.lit(None, dtype=pl.Int8).alias("admin_level"),
+        pl.lit(None, dtype=pl.String).alias("migration_method"),
+    )
+
+    columns = list(EVENT_GEOGRAPHY_SCHEMA)
+
+    return pl.concat([from_units.select(columns), rest.select(columns)]).sort("DisNo.", "gid", nulls_last=True)
 
 
 def event_filter(filters: EventFilters) -> pl.Expr:

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -331,17 +331,17 @@ def event_units(events: pl.DataFrame) -> pl.DataFrame:
 # what the source holds, and a model chooses which tiers it will accept.
 GEOMETRY_SOURCES = ("gadm", "emdat_point", "country")
 
-EVENT_GEOGRAPHY_SCHEMA = {
-    "DisNo.": pl.String,
-    "ISO": pl.String,
-    "geometry_source": pl.String,
-    "gid": pl.String,
-    "name": pl.String,
-    "admin_level": pl.Int8,
-    "migration_method": pl.String,
-    "Latitude": pl.Float64,
-    "Longitude": pl.Float64,
-}
+EVENT_GEOGRAPHY_COLUMNS = (
+    "DisNo.",
+    "ISO",
+    "geometry_source",
+    "gid",
+    "name",
+    "admin_level",
+    "migration_method",
+    "Latitude",
+    "Longitude",
+)
 
 
 def event_geography(events: pl.DataFrame) -> pl.DataFrame:
@@ -371,8 +371,7 @@ def event_geography(events: pl.DataFrame) -> pl.DataFrame:
 
     from_units = units.join(located, on="DisNo.", how="left").with_columns(pl.lit("gadm").alias("geometry_source"))
 
-    coded = set(units["DisNo."])
-    rest = located.filter(~pl.col("DisNo.").is_in(coded)).with_columns(
+    rest = located.join(units.select("DisNo.").unique(), on="DisNo.", how="anti").with_columns(
         pl.when(pl.col("Latitude").is_not_null())
         .then(pl.lit("emdat_point"))
         .otherwise(pl.lit("country"))
@@ -383,9 +382,9 @@ def event_geography(events: pl.DataFrame) -> pl.DataFrame:
         pl.lit(None, dtype=pl.String).alias("migration_method"),
     )
 
-    columns = list(EVENT_GEOGRAPHY_SCHEMA)
-
-    return pl.concat([from_units.select(columns), rest.select(columns)]).sort("DisNo.", "gid", nulls_last=True)
+    return pl.concat([from_units.select(EVENT_GEOGRAPHY_COLUMNS), rest.select(EVENT_GEOGRAPHY_COLUMNS)]).sort(
+        "DisNo.", "gid", nulls_last=True
+    )
 
 
 def event_filter(filters: EventFilters) -> pl.Expr:

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -6,6 +6,23 @@ from pathlib import Path
 import polars as pl
 
 from climate_risk.config.schema import EventFilters
+from climate_risk.data.source import ManualSource
+
+# EM-DAT requires an account and forbids redistribution, so it is fetched by a person, not by code.
+EMDAT = ManualSource(
+    filename="emdat.xlsx",
+    homepage="https://public.emdat.be/",
+    licence=(
+        "Free for non-commercial use with attribution. Redistribution of the database is not "
+        "permitted; users must download it themselves after registering."
+    ),
+    citation=(
+        "EM-DAT, CRED / UCLouvain, Brussels, Belgium. Delforge, D. et al. (2025), EM-DAT: the "
+        "Emergency Events Database. International Journal of Disaster Risk Reduction 124, 105509. "
+        "https://doi.org/10.1016/j.ijdrr.2025.105509"
+    ),
+    retrieved="2026-08-03",
+)
 
 EM_DAT_COL_DICT = {
     "Start Year": "Start_Year",
@@ -247,14 +264,7 @@ def load_emdat_events(cache_dir: Path) -> pl.DataFrame:
     """
     cache_dir.mkdir(parents=True, exist_ok=True)
 
-    emdat_path = cache_dir / "emdat.xlsx"
-    if not emdat_path.exists():
-        raise NotImplementedError(
-            f"No EM-DAT data was found at `{emdat_path}`. Please make an account at https://public.emdat.be/, "
-            f"download the database, and place it at `{emdat_path}`"
-        )
-
-    return _read_workbook(emdat_path)
+    return _read_workbook(EMDAT.require(cache_dir))
 
 
 GADM_UNITS_COLUMN = "GADM Admin Units"

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import json
 
 from pathlib import Path
 
@@ -254,6 +255,66 @@ def load_emdat_events(cache_dir: Path) -> pl.DataFrame:
         )
 
     return _read_workbook(emdat_path)
+
+
+GADM_UNITS_COLUMN = "GADM Admin Units"
+
+# One row per affected administrative unit. `name` and `migration_method` are absent on some units:
+# EM-DAT omits the name where GADM has none, and the method where the unit was never migrated.
+EVENT_UNIT_SCHEMA = {
+    "DisNo.": pl.String,
+    "gid": pl.String,
+    "name": pl.String,
+    "admin_level": pl.Int8,
+    "migration_method": pl.String,
+}
+
+
+def event_units(events: pl.DataFrame) -> pl.DataFrame:
+    """
+    Explode each event's GADM administrative units into one row per event-unit.
+
+    The level comes from the key EM-DAT files a unit under, ``gid_1`` or ``gid_2``, because a GADM
+    identifier does not reliably state it: Ghana's are numbered ``GHA11_2`` and ``GHA7.13_2``.
+
+    Parameters
+    ----------
+    events : DataFrame
+        The workbook, as :func:`load_emdat_events` returns it.
+
+    Returns
+    -------
+    DataFrame
+        ``DisNo.``, ``gid``, ``name``, ``admin_level`` and ``migration_method``. An event carrying no
+        units contributes no rows, so this is narrower than ``events``.
+
+    Raises
+    ------
+    ValueError
+        If a unit carries neither ``gid_1`` nor ``gid_2``, which would leave it unidentifiable.
+    """
+    rows = []
+
+    for disno, raw in zip(events["DisNo."], events[GADM_UNITS_COLUMN], strict=True):
+        if not str(raw or "").strip():
+            continue
+
+        for unit in json.loads(raw):
+            level = 2 if "gid_2" in unit else 1
+            if f"gid_{level}" not in unit:
+                raise ValueError(f"{disno}: an administrative unit carries no gid_1 or gid_2: {unit}")
+
+            rows.append(
+                {
+                    "DisNo.": disno,
+                    "gid": unit[f"gid_{level}"],
+                    "name": unit.get(f"name_{level}"),
+                    "admin_level": level,
+                    "migration_method": unit.get("migration_method"),
+                }
+            )
+
+    return pl.DataFrame(rows, schema=EVENT_UNIT_SCHEMA)
 
 
 def event_filter(filters: EventFilters) -> pl.Expr:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ markers = [
     "network: hits the real network; deselected by default, run nightly",
     "slow: PyMC sampling or other multi-second work",
     "requires_emdat: needs the licensed EM-DAT workbook, absent from CI",
+    "requires_gadm: needs the GADM GeoPackage, which is non-commercial and absent from CI",
 ]
 filterwarnings = [
     "error",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,17 +385,9 @@ def toy_gadm() -> gpd.GeoDataFrame:
         ("ZMB", "ZMB.1_1", "Central", "ZMB.1.1_1", "Kabwe", box(6, 0, 7, 1)),
         ("GHA", "GHA11_2", "Savannah", "GHA7.13_2", "Ga Central", box(8, 0, 9, 1)),
     ]
-    return gpd.GeoDataFrame(
-        {
-            "GID_0": [country for country, *_ in rows],
-            "GID_1": [gid_1 for _, gid_1, *_ in rows],
-            "NAME_1": [name_1 for _, _, name_1, *_ in rows],
-            "GID_2": [gid_2 for *_, gid_2, _, _ in rows],
-            "NAME_2": [name_2 for *_, name_2, _ in rows],
-            "geometry": [geometry for *_, geometry in rows],
-        },
-        crs="EPSG:4326",
-    )
+    columns = ("GID_0", "GID_1", "NAME_1", "GID_2", "NAME_2", "geometry")
+
+    return gpd.GeoDataFrame(dict(zip(columns, zip(*rows, strict=True), strict=True)), crs="EPSG:4326")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,8 @@ EMDAT_EVENT_DEFAULTS = {
     "Longitude": 102.0,
     "River Basin": "Mekong",
     "Location": "Somewhere",
+    # Present on every real row, empty on the two thirds EM-DAT never geocoded.
+    "GADM Admin Units": "",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,6 +366,50 @@ def write_shapefile_cache(tmp_path):
     return write
 
 
+def toy_gadm() -> gpd.GeoDataFrame:
+    """A GeoPackage shaped like GADM: one row per finest unit, coarser levels spanning several rows.
+
+    `LAO.1_1` is split across two districts, so reading it back as one polygon exercises the union
+    rather than returning whichever row came first.
+
+    Ghana is included because GADM numbers it unlike everywhere else — `GHA11_2` for a province and
+    `GHA7.13_2` for a district, with no dot after the country code. Any code inferring the level
+    from the shape of the id gets Ghana wrong.
+    """
+    rows = [
+        ("LAO", "LAO.1_1", "Attapu", "LAO.1.1_1", "Sanamxay", box(0, 0, 1, 1)),
+        ("LAO", "LAO.1_1", "Attapu", "LAO.1.2_1", "Samakhixay", box(1, 0, 2, 1)),
+        ("LAO", "LAO.2_1", "Bokeo", "LAO.2.1_1", "Houayxay", box(3, 0, 4, 1)),
+        ("ZMB", "ZMB.1_1", "Central", "ZMB.1.1_1", "Kabwe", box(6, 0, 7, 1)),
+        ("GHA", "GHA11_2", "Savannah", "GHA7.13_2", "Ga Central", box(8, 0, 9, 1)),
+    ]
+    return gpd.GeoDataFrame(
+        {
+            "GID_0": [country for country, *_ in rows],
+            "GID_1": [gid_1 for _, gid_1, *_ in rows],
+            "NAME_1": [name_1 for _, _, name_1, *_ in rows],
+            "GID_2": [gid_2 for *_, gid_2, _, _ in rows],
+            "NAME_2": [name_2 for *_, name_2, _ in rows],
+            "geometry": [geometry for *_, geometry in rows],
+        },
+        crs="EPSG:4326",
+    )
+
+
+@pytest.fixture
+def write_gadm_cache(tmp_path):
+    """Return a callable writing a GADM-shaped GeoPackage into the cache, and giving back the root."""
+
+    def write(units=None):
+        directory = tmp_path / "gadm"
+        directory.mkdir(exist_ok=True)
+        (units if units is not None else toy_gadm()).to_file(directory / "gadm_410.gpkg", layer="gadm_410")
+
+        return tmp_path
+
+    return write
+
+
 # Enough sampled points that an unseeded year draw cannot match a seeded one by luck.
 SYNTHETIC_SOURCE_EVENTS = 30
 

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -158,3 +158,17 @@ def test_the_units_carry_the_geopackage_crs(write_gadm_cache):
     units = load_admin_units([("LAO.1_1", 1)], cache_dir)
 
     assert units.crs == "EPSG:4326"
+
+
+def test_an_empty_request_still_carries_the_crs(write_gadm_cache):
+    """A CRS-less frame concatenates with projected geometry silently and reprojects it wrongly.
+
+    The empty result has to be usable in the same places the populated one is.
+    """
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([], cache_dir)
+
+    assert units.empty
+    assert units.crs == "EPSG:4326"
+    assert list(units.columns) == ["gid", "name", "admin_level", "geometry"]

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -1,0 +1,48 @@
+import re
+
+import pytest
+
+from climate_risk.data.gadm import GADM, gadm_dir, gadm_path
+from climate_risk.data.source import ManualSource
+
+
+def test_the_geopackage_is_looked_for_under_the_cache(tmp_path):
+    assert gadm_dir(tmp_path) == tmp_path / "gadm"
+
+
+def test_an_absent_geopackage_names_the_path_and_where_to_get_it(tmp_path):
+    """The licence forbids fetching it, so the error is the user's only instruction."""
+    with pytest.raises(NotImplementedError) as raised:
+        gadm_path(tmp_path)
+
+    message = str(raised.value)
+    assert str(tmp_path / "gadm" / "gadm_410.gpkg") in message
+    assert "https://gadm.org" in message
+
+
+def test_a_placed_geopackage_is_returned(tmp_path):
+    placed = tmp_path / "gadm" / "gadm_410.gpkg"
+    placed.parent.mkdir()
+    placed.touch()
+
+    assert gadm_path(tmp_path) == placed
+
+
+def test_the_declaration_states_its_licence_and_citation():
+    """Non-commercial terms bind every figure built from these boundaries, so they are recorded here.
+
+    Asserted on content rather than mere non-emptiness: a placeholder would satisfy `!= ""`.
+    """
+    assert "non-commercial" in GADM.licence.lower()
+    assert "gadm.org" in GADM.citation
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", GADM.retrieved)
+
+
+def test_gadm_is_not_a_fetchable_source():
+    """Its terms forbid automated download, so it must not reach `fetch` or the reachability check.
+
+    `ManualSource` carries no url, and this pins that: growing one would make the registry able to
+    download a file the licence says a person must obtain.
+    """
+    assert isinstance(GADM, ManualSource)
+    assert not hasattr(GADM, "url")

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -138,3 +138,23 @@ def test_an_id_that_does_not_state_its_own_level_still_resolves(write_gadm_cache
 
     assert units["name"].tolist() == [name]
     assert units["admin_level"].tolist() == [level]
+
+
+def test_a_request_spanning_several_chunks_returns_all_of_them(write_gadm_cache, monkeypatch):
+    """A real request names thousands of ids and is split across reads; only the last would survive
+    a concat that overwrote rather than appended, and no fixture is large enough to notice."""
+    monkeypatch.setattr("climate_risk.data.gadm.GID_CHUNK", 1)
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([("LAO.1_1", 1), ("LAO.2_1", 1), ("GHA11_2", 1)], cache_dir)
+
+    assert sorted(units["gid"]) == ["GHA11_2", "LAO.1_1", "LAO.2_1"]
+
+
+def test_the_units_carry_the_geopackage_crs(write_gadm_cache):
+    """Geometry with no CRS reprojects silently to the wrong place when joined to anything else."""
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([("LAO.1_1", 1)], cache_dir)
+
+    assert units.crs == "EPSG:4326"

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -1,9 +1,16 @@
+import json
 import re
+import sqlite3
 
+from pathlib import Path
+
+import polars as pl
 import pytest
 
-from climate_risk.data.gadm import GADM, gadm_dir, gadm_path
+from climate_risk.data.gadm import GADM, gadm_dir, gadm_path, load_admin_units
 from climate_risk.data.source import ManualSource
+from climate_risk.data_functions.emdat_processing import load_emdat_events
+from climate_risk.exceptions import DataValidationError
 
 
 def test_the_geopackage_is_looked_for_under_the_cache(tmp_path):
@@ -46,3 +53,102 @@ def test_gadm_is_not_a_fetchable_source():
     """
     assert isinstance(GADM, ManualSource)
     assert not hasattr(GADM, "url")
+
+
+def test_a_unit_above_the_finest_level_is_read_as_one_polygon(write_gadm_cache):
+    """GADM stores one row per district, so a province is the union of several rows.
+
+    Attapu spans two districts in the fixture; taking the first row would return half its area.
+    """
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([("LAO.1_1", 1)], cache_dir)
+
+    assert units["gid"].tolist() == ["LAO.1_1"]
+    assert units["name"].tolist() == ["Attapu"]
+    assert units["admin_level"].tolist() == [1]
+    # The two district boxes span x 0..2; either row alone would be half of it.
+    assert units.geometry.iloc[0].bounds == (0.0, 0.0, 2.0, 1.0)
+
+
+def test_levels_may_be_mixed_in_one_request(write_gadm_cache):
+    """EM-DAT codes some events to provinces and others to districts, often within one country."""
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([("LAO.2_1", 1), ("LAO.1.1_1", 2)], cache_dir).set_index("gid")
+
+    assert units.loc["LAO.2_1", "admin_level"] == 1
+    assert units.loc["LAO.1.1_1", "admin_level"] == 2
+    assert units.loc["LAO.1.1_1", "name"] == "Sanamxay"
+
+
+def test_an_id_gadm_does_not_hold_is_an_error_not_a_dropped_row(write_gadm_cache):
+    """Returning fewer rows than asked for would quietly shrink an event's footprint."""
+    cache_dir = write_gadm_cache()
+
+    with pytest.raises(DataValidationError, match=re.escape("LAO.99_1")):
+        load_admin_units([("LAO.1_1", 1), ("LAO.99_1", 1)], cache_dir)
+
+
+def test_a_level_gadm_is_not_read_at_is_rejected(write_gadm_cache):
+    """Units are read at level 1 and 2; anything else would silently match nothing."""
+    cache_dir = write_gadm_cache()
+
+    with pytest.raises(DataValidationError, match="read at levels"):
+        load_admin_units([("LAO", 0)], cache_dir)
+
+
+def test_the_same_id_asked_for_twice_is_read_once(write_gadm_cache):
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([("LAO.1_1", 1), ("LAO.1_1", 1)], cache_dir)
+
+    assert len(units) == 1
+
+
+# The GeoPackage is non-commercial and hand-placed, so it is absent on CI and on a fresh clone.
+REAL_CACHE_DIR = Path(__file__).parents[2] / "data"
+
+
+@pytest.mark.requires_gadm
+@pytest.mark.requires_emdat
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg").exists(), reason="needs the GADM GeoPackage")
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "emdat.xlsx").exists(), reason="needs the licensed EM-DAT workbook")
+def test_every_gid_em_dat_references_resolves_against_gadm():
+    """The whole event-unit table rests on this: a gid that does not resolve is a lost footprint.
+
+    Synthetic fixtures cannot catch a version mismatch, because they are written to agree. This is
+    the only check that the GeoPackage on disk is the one EM-DAT coded against.
+    """
+    events = load_emdat_events(REAL_CACHE_DIR).filter(pl.col("GADM Admin Units").str.strip_chars().str.len_chars() > 2)
+    referenced = {
+        (unit["gid_2"], 2) if "gid_2" in unit else (unit["gid_1"], 1)
+        for raw in events["GADM Admin Units"]
+        for unit in json.loads(raw)
+    }
+    assert len(referenced) > 10_000, "the workbook should reference thousands of units"
+
+    # Set membership, not geometry: the claim is that the ids exist, and assembling twelve thousand
+    # polygons to answer it turns a two-second check into a four-minute one.
+    with sqlite3.connect(REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg") as gadm:
+        held = {
+            (gid, level)
+            for level, column in ((1, "GID_1"), (2, "GID_2"))
+            for (gid,) in gadm.execute(f"SELECT DISTINCT {column} FROM gadm_410 WHERE {column} IS NOT NULL")
+        }
+
+    assert referenced <= held, f"GADM holds no unit for {sorted(referenced - held)[:5]}"
+
+
+@pytest.mark.parametrize(("gid", "level", "name"), [("GHA11_2", 1, "Savannah"), ("GHA7.13_2", 2, "Ga Central")])
+def test_an_id_that_does_not_state_its_own_level_still_resolves(write_gadm_cache, gid, level, name):
+    """GADM numbers Ghana without the dot every other country has, so the id cannot imply the level.
+
+    Inferring it from the string reads `GHA11_2` as a country and drops a real province.
+    """
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([(gid, level)], cache_dir)
+
+    assert units["name"].tolist() == [name]
+    assert units["admin_level"].tolist() == [level]

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -8,7 +8,6 @@ import polars as pl
 import pytest
 
 from climate_risk.data.gadm import GADM, gadm_dir, gadm_path, load_admin_units
-from climate_risk.data.source import ManualSource
 from climate_risk.data_functions.emdat_processing import load_emdat_events
 from climate_risk.exceptions import DataValidationError
 
@@ -35,24 +34,11 @@ def test_a_placed_geopackage_is_returned(tmp_path):
     assert gadm_path(tmp_path) == placed
 
 
-def test_the_declaration_states_its_licence_and_citation():
-    """Non-commercial terms bind every figure built from these boundaries, so they are recorded here.
-
-    Asserted on content rather than mere non-emptiness: a placeholder would satisfy `!= ""`.
-    """
+def test_the_declaration_carries_the_non_commercial_restriction():
+    """Generic checks live in test_source; what is specific here is the restriction itself, which
+    binds every figure built from these boundaries."""
     assert "non-commercial" in GADM.licence.lower()
     assert "gadm.org" in GADM.citation
-    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", GADM.retrieved)
-
-
-def test_gadm_is_not_a_fetchable_source():
-    """Its terms forbid automated download, so it must not reach `fetch` or the reachability check.
-
-    `ManualSource` carries no url, and this pins that: growing one would make the registry able to
-    download a file the licence says a person must obtain.
-    """
-    assert isinstance(GADM, ManualSource)
-    assert not hasattr(GADM, "url")
 
 
 def test_a_unit_above_the_finest_level_is_read_as_one_polygon(write_gadm_cache):

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -7,10 +7,12 @@ from climate_risk.config.registry import CONFIG_ROOT, read_place
 from climate_risk.config.schema import CountryConfig
 from climate_risk.data.co2 import CO2
 from climate_risk.data.fetch import USER_AGENT
+from climate_risk.data.gadm import GADM
 from climate_risk.data.gpcc import FULL_DATA, MONITORING
 from climate_risk.data.hadcrut import HADCRUT
 from climate_risk.data.ocean_heat import OCEAN_HEAT
 from climate_risk.data.source import DataSource, ManualSource, ShapefileArchive
+from climate_risk.data_functions.emdat_processing import EMDAT
 from climate_risk.data_functions.rivers_data_loader import RIVERS
 from climate_risk.data_functions.shapefiles_data_loader import COASTLINE, WORLD
 
@@ -86,6 +88,25 @@ def test_a_manual_source_reports_its_licence_when_the_file_is_missing(tmp_path):
     """A user hitting this has to know the terms before going to fetch the file."""
     with pytest.raises(NotImplementedError, match="non-commercial use only"):
         manual().require(tmp_path)
+
+
+# Every file a person has to place in the cache themselves. A loader that raises for a missing
+# hand-placed file belongs here, so the terms it is held under are recorded in one place.
+MANUAL_SOURCES = {"EMDAT": EMDAT, "GADM": GADM}
+
+
+@pytest.mark.parametrize("declared", MANUAL_SOURCES.values(), ids=MANUAL_SOURCES.keys())
+def test_every_manual_source_says_where_to_get_it_and_on_what_terms(declared):
+    """These declarations are the only record of terms binding data the repo cannot ship."""
+    assert declared.homepage.startswith("https://")
+    assert declared.licence.strip()
+    assert declared.citation.strip()
+
+
+@pytest.mark.parametrize("declared", MANUAL_SOURCES.values(), ids=MANUAL_SOURCES.keys())
+def test_a_manual_source_is_never_fetchable(declared):
+    """Both forbid redistribution or automated download; a url would let `fetch` take one anyway."""
+    assert not hasattr(declared, "url")
 
 
 def test_an_unparseable_retrieved_date_is_rejected():

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -10,7 +10,7 @@ from climate_risk.data.fetch import USER_AGENT
 from climate_risk.data.gpcc import FULL_DATA, MONITORING
 from climate_risk.data.hadcrut import HADCRUT
 from climate_risk.data.ocean_heat import OCEAN_HEAT
-from climate_risk.data.source import DataSource, ShapefileArchive
+from climate_risk.data.source import DataSource, ManualSource, ShapefileArchive
 from climate_risk.data_functions.rivers_data_loader import RIVERS
 from climate_risk.data_functions.shapefiles_data_loader import COASTLINE, WORLD
 
@@ -53,6 +53,39 @@ def test_an_archive_layer_outside_the_archive_is_rejected(member):
     """`extracted_path` joins onto the cache directory, so an escaping member reads outside it."""
     with pytest.raises(ValueError, match="member must"):
         ShapefileArchive(source(), member)
+
+
+MANUAL_FIELDS = {
+    "filename": "gadm_410.gpkg",
+    "homepage": "https://gadm.org/download_world.html",
+    "licence": "non-commercial use only",
+    "citation": "GADM 4.1",
+    "retrieved": "2026-08-09",
+}
+
+
+def manual(**overrides) -> ManualSource:
+    return ManualSource(**(MANUAL_FIELDS | overrides))
+
+
+@pytest.mark.parametrize("filename", ["../escape.gpkg", "nested/f.gpkg", "/absolute.gpkg", ""], ids=repr)
+def test_a_manual_filename_carrying_a_path_is_rejected(filename):
+    """`path()` joins onto the cache directory, so a directory component reads outside it."""
+    with pytest.raises(ValueError, match="bare name"):
+        manual(filename=filename)
+
+
+@pytest.mark.parametrize("homepage", ["ftp://gadm.org", "gadm.org", ""], ids=repr)
+def test_a_manual_homepage_that_is_not_a_web_page_is_rejected(homepage):
+    """It goes into an error message a user is expected to follow."""
+    with pytest.raises(ValueError, match="homepage must be http"):
+        manual(homepage=homepage)
+
+
+def test_a_manual_source_reports_its_licence_when_the_file_is_missing(tmp_path):
+    """A user hitting this has to know the terms before going to fetch the file."""
+    with pytest.raises(NotImplementedError, match="non-commercial use only"):
+        manual().require(tmp_path)
 
 
 def test_an_unparseable_retrieved_date_is_rejected():

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -11,9 +11,11 @@ from climate_risk.config.schema import EventFilters
 from climate_risk.data_functions.emdat_processing import (
     DISASTER_TYPES,
     EMDAT_WINDOW_START,
+    GEOMETRY_SOURCES,
     count_events_by_type,
     country_year_grid,
     event_filter,
+    event_geography,
     event_units,
     load_emdat_events,
     total_damage,
@@ -410,3 +412,104 @@ def test_the_unit_table_keeps_every_event_that_has_geography():
     per_event = units.group_by("DisNo.").len()
     assert per_event.filter(pl.col("len") > 1).height > per_event.height / 2
     assert per_event.filter(pl.col("len") > 100).height > 0
+
+
+def test_every_event_appears_with_a_known_source(write_emdat_cache):
+    """An event missing from the table would read as having no geography rather than saying so."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "LAO.1_1", "name_1": "Attapu"})}),
+            emdat_event({"DisNo.": "point-only", "Latitude": 18.0, "Longitude": 102.0}),
+            emdat_event({"DisNo.": "nothing", "Latitude": None, "Longitude": None}),
+        ]
+    )
+
+    geography = event_geography(load_emdat_events(cache_dir))
+
+    assert set(geography["DisNo."]) == {"coded", "point-only", "nothing"}
+    assert set(geography["geometry_source"]) <= set(GEOMETRY_SOURCES)
+    assert geography["geometry_source"].null_count() == 0
+    assert dict(zip(geography["DisNo."], geography["geometry_source"], strict=True)) == {
+        "coded": "gadm",
+        "point-only": "emdat_point",
+        "nothing": "country",
+    }
+
+
+def test_a_coded_event_keeps_one_row_per_unit(write_emdat_cache):
+    """The footprint is the reason the table exists; one row per event would discard it."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event(
+                {
+                    "DisNo.": "many",
+                    "GADM Admin Units": units_json(
+                        {"gid_1": "LAO.1_1", "name_1": "Attapu"}, {"gid_2": "LAO.2.1_1", "name_2": "Houayxay"}
+                    ),
+                }
+            )
+        ]
+    )
+
+    geography = event_geography(load_emdat_events(cache_dir))
+
+    assert len(geography) == 2
+    assert geography["gid"].to_list() == ["LAO.1_1", "LAO.2.1_1"]
+    assert geography["admin_level"].to_list() == [1, 2]
+    assert set(geography["geometry_source"]) == {"gadm"}
+
+
+def test_a_coded_event_that_also_has_a_point_keeps_both(write_emdat_cache):
+    """Units and a coordinate are different claims; dropping either decides something this does not.
+
+    The event is `gadm` because the polygon is the better geometry, but the point stays visible.
+    """
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event(
+                {
+                    "DisNo.": "both",
+                    "Latitude": 18.0,
+                    "Longitude": 102.0,
+                    "GADM Admin Units": units_json({"gid_1": "LAO.1_1", "name_1": "Attapu"}),
+                }
+            )
+        ]
+    )
+
+    geography = event_geography(load_emdat_events(cache_dir))
+
+    assert geography["geometry_source"].to_list() == ["gadm"]
+    assert geography["Latitude"].to_list() == [18.0]
+
+
+def test_the_unit_columns_are_empty_outside_the_gadm_tier(write_emdat_cache):
+    """A stale gid on a country row would let a join attach geometry the event never had."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "nothing", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(load_emdat_events(cache_dir))
+
+    assert geography["gid"].null_count() == 1
+    assert geography["admin_level"].null_count() == 1
+    assert geography["migration_method"].null_count() == 1
+
+
+@pytest.mark.requires_emdat
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "emdat.xlsx").exists(), reason="needs the licensed EM-DAT workbook")
+def test_no_tier_silently_swallows_the_others():
+    """A bug collapsing everything to `country` still produces a full, plausible-looking table.
+
+    Bounds rather than counts, which move on re-download; what must not change is that all three
+    tiers stay populated and `gadm` stays the biggest by row count.
+    """
+    events = load_emdat_events(REAL_CACHE_DIR)
+    geography = event_geography(events)
+
+    assert geography["DisNo."].n_unique() == len(events)
+
+    per_source = dict(geography.group_by("geometry_source").len().iter_rows())
+    assert set(per_source) == set(GEOMETRY_SOURCES)
+    assert all(count > 1_000 for count in per_source.values())
+    # Coded events carry several units each, so the gadm tier is the longest despite being a
+    # minority of events.
+    assert per_source["gadm"] > per_source["country"]

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -1,3 +1,5 @@
+import json
+
 from datetime import date
 from pathlib import Path
 
@@ -12,6 +14,7 @@ from climate_risk.data_functions.emdat_processing import (
     count_events_by_type,
     country_year_grid,
     event_filter,
+    event_units,
     load_emdat_events,
     total_damage,
 )
@@ -289,3 +292,121 @@ def test_every_shipped_country_has_events_clearing_its_own_filters(key):
     events = selected_events(REAL_CACHE_DIR, filters=place.events)
 
     assert len(events.filter(pl.col("ISO").is_in(resolve_isos(place)))) > 0
+
+
+def units_json(*units) -> str:
+    """The `GADM Admin Units` column as EM-DAT writes it: a JSON array of per-unit objects."""
+    return json.dumps(list(units))
+
+
+def test_an_event_with_no_units_contributes_no_rows(write_emdat_cache):
+    """Half the workbook has no geography; those events must not appear with an empty unit."""
+    cache_dir = write_emdat_cache([emdat_event({"GADM Admin Units": ""}), emdat_event({"DisNo.": "b"})])
+
+    units = event_units(load_emdat_events(cache_dir))
+
+    assert units.is_empty()
+    assert units.columns == ["DisNo.", "gid", "name", "admin_level", "migration_method"]
+
+
+def test_an_event_naming_several_units_yields_a_row_for_each(write_emdat_cache):
+    """73% of located events name more than one unit; collapsing them loses the footprint."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event(
+                {
+                    "DisNo.": "many",
+                    "GADM Admin Units": units_json(
+                        {"gid_1": "LAO.1_1", "name_1": "Attapu", "migration_method": "jaccard1"},
+                        {"gid_1": "LAO.2_1", "name_1": "Bokeo", "migration_method": "jaccard1"},
+                        {"gid_1": "LAO.4_1", "name_1": "Champasak", "migration_method": "puzzle1_1"},
+                    ),
+                }
+            ),
+            emdat_event({"DisNo.": "one", "GADM Admin Units": units_json({"gid_1": "ZMB.1_1", "name_1": "Central"})}),
+        ]
+    )
+
+    units = event_units(load_emdat_events(cache_dir))
+
+    assert units.group_by("DisNo.").len().sort("DisNo.")["len"].to_list() == [3, 1]
+    assert units.filter(pl.col("DisNo.") == "many")["gid"].to_list() == ["LAO.1_1", "LAO.2_1", "LAO.4_1"]
+
+
+def test_the_level_comes_from_the_key_not_the_shape_of_the_id(write_emdat_cache):
+    """GADM numbers Ghana `GHA11_2` and `GHA7.13_2`, so the id cannot be parsed for its level."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event(
+                {
+                    "GADM Admin Units": units_json(
+                        {"gid_1": "GHA11_2", "name_1": "Savannah", "migration_method": "puzzle1_1"},
+                        {"gid_2": "GHA7.13_2", "name_2": "Ga Central", "migration_method": "jaccard2"},
+                        {"gid_2": "LAO.1.1_1", "name_2": "Sanamxay", "migration_method": "jaccard2"},
+                    )
+                }
+            )
+        ]
+    )
+
+    units = event_units(load_emdat_events(cache_dir))
+
+    assert units["admin_level"].to_list() == [1, 2, 2]
+
+
+def test_a_unit_with_no_name_or_no_method_still_yields_a_row(write_emdat_cache):
+    """EM-DAT omits the name where GADM has none, and the method where nothing was migrated.
+
+    Requiring either would silently drop 1,370 native-GADM units and 574 unnamed ones.
+    """
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event(
+                {
+                    "GADM Admin Units": units_json(
+                        {"gid_2": "GBR.1.26_1", "migration_method": "jaccard2"},
+                        {"gid_1": "COL.27_1", "name_1": "San Andrés y Providencia"},
+                    )
+                }
+            )
+        ]
+    )
+
+    units = event_units(load_emdat_events(cache_dir))
+
+    assert units["gid"].to_list() == ["GBR.1.26_1", "COL.27_1"]
+    assert units["name"].to_list() == [None, "San Andrés y Providencia"]
+    assert units["migration_method"].to_list() == ["jaccard2", None]
+
+
+def test_a_unit_carrying_no_gid_names_the_event_it_came_from(write_emdat_cache):
+    """An unidentifiable unit is a schema change upstream, and the error has to be findable."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "broken", "GADM Admin Units": units_json({"name_1": "Nowhere"})})]
+    )
+
+    with pytest.raises(ValueError, match="broken"):
+        event_units(load_emdat_events(cache_dir))
+
+
+@pytest.mark.requires_emdat
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "emdat.xlsx").exists(), reason="needs the licensed EM-DAT workbook")
+def test_the_unit_table_keeps_every_event_that_has_geography():
+    """Synthetic fixtures hold whatever the author wrote; only the workbook shows the real shape.
+
+    Counts are asserted as properties rather than literals, because a re-download moves them.
+    """
+    events = load_emdat_events(REAL_CACHE_DIR)
+    units = event_units(events)
+
+    with_geography = events.filter(pl.col("GADM Admin Units").str.strip_chars().str.len_chars() > 2)
+    assert units["DisNo."].n_unique() == len(with_geography)
+
+    assert units["gid"].null_count() == 0
+    assert set(units["admin_level"].unique()) == {1, 2}
+
+    # Most located events name several units, which is why the table is long rather than one row
+    # per event. A collapse to one unit each would leave both of these at zero.
+    per_event = units.group_by("DisNo.").len()
+    assert per_event.filter(pl.col("len") > 1).height > per_event.height / 2
+    assert per_event.filter(pl.col("len") > 100).height > 0


### PR DESCRIPTION
EM-DAT already codes 7,842 events to GADM units, so `event_geography` reads those instead of geocoding anything, and tags every event with where its geometry comes from — `gadm`, `emdat_point`, or `country`. It records rather than filters: every event gets a row, coded events get one per unit, and an event with both units and a coordinate keeps both. Which tiers a model accepts is a choice for the modeling stage.

The admin level is passed to the GADM reader rather than parsed out of the id, because GADM numbers Ghana `GHA11_2` and `GHA7.13_2` with no dot after the country code — inferring it from the string reads a province as a country. EM-DAT states the level in the key it files each unit under.

GADM and EM-DAT are both `ManualSource` now: no URL field, so a licence forbidding automated download is enforced by construction rather than by discipline.
