### PR TITLE
Add Geo-Disasters as a source of sub-national event geography

### DIFF
--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -56,6 +56,45 @@ def _chunks(values: list[str], size: int) -> Iterator[list[str]]:
         yield values[start : start + size]
 
 
+def load_units_in_country(iso: str, level: int, cache_dir: Path, *, layer: str = GADM_LAYER) -> gpd.GeoDataFrame:
+    """
+    Read every GADM unit one country holds at one administrative level.
+
+    Where :func:`load_admin_units` answers "which polygon is this id", this answers "what units are
+    there", which is what a search by geometry needs.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to read.
+    level : int
+        Administrative level, 1 or 2.
+    cache_dir : Path
+        Directory the caches live under.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    GeoDataFrame
+        Columns ``gid``, ``name``, ``admin_level`` and ``geometry``, one row per unit.
+    """
+    if level not in GID_COLUMNS:
+        raise DataValidationError(f"Units are read at levels {sorted(GID_COLUMNS)}, not {level}")
+
+    gid_column, name_column = GID_COLUMNS[level]
+    rows = gpd.read_file(gadm_path(cache_dir), layer=layer, columns=[gid_column, name_column], where=f"GID_0 = '{iso}'")
+    if rows.empty:
+        return _no_units(gadm_path(cache_dir), layer)
+
+    # The table stores the finest level, so a unit above it spans several rows.
+    units = rows.dissolve(by=gid_column, aggfunc="first", as_index=False)
+
+    return units.rename(columns={gid_column: "gid", name_column: "name"}).assign(admin_level=level)[
+        ["gid", "name", "admin_level", "geometry"]
+    ]
+
+
 def _units_at_level(gids: list[str], level: int, path: Path, layer: str) -> gpd.GeoDataFrame | None:
     gid_column, name_column = GID_COLUMNS[level]
     read = []

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -1,3 +1,6 @@
+import unicodedata
+
+from collections.abc import Mapping
 from pathlib import Path
 
 import geopandas as gpd
@@ -107,3 +110,105 @@ def unit_names(locations: pd.DataFrame) -> pd.Series:
         named[at_level] = locations.loc[at_level, column]
 
     return named
+
+
+def normalise_unit_name(name: str) -> str:
+    """
+    Reduce an administrative unit's name to what two gazetteers can be expected to agree on.
+
+    GADM and GAUL romanise the same unit differently — accents, hyphens and casing all drift — so a
+    literal comparison reports spelling as disagreement.
+
+    Parameters
+    ----------
+    name : str
+        A unit name as either source publishes it.
+
+    Returns
+    -------
+    str
+        Casefolded, stripped of accents and of everything that is not a letter or digit.
+    """
+    decomposed = unicodedata.normalize("NFKD", name)
+    return "".join(character for character in decomposed if character.isalnum()).casefold()
+
+
+def event_unit_names(locations: pd.DataFrame) -> dict[str, set[str]]:
+    """
+    Collect the unit names Geo-Disasters records, keyed on the EM-DAT event id.
+
+    Parameters
+    ----------
+    locations : DataFrame
+        Rows as :func:`load_event_locations` returns them.
+
+    Returns
+    -------
+    dict mapping str to set of str
+        One entry per event, holding every unit it was geocoded to, named as published.
+    """
+    named = locations.assign(unit=unit_names(locations))
+
+    return {str(disno): set(group) for disno, group in named.groupby("DisNo.")["unit"]}
+
+
+AGREEMENT_LEVELS = ("exact", "partial", "disjoint", "gained", "unmatched")
+
+AGREEMENT_COLUMNS = ["DisNo.", "agreement", "em_dat_units", "geo_disasters_units", "shared_units"]
+
+
+def _classify(em_dat: set[str], geo_disasters: set[str]) -> str:
+    if not em_dat:
+        return "gained"
+    if not geo_disasters:
+        return "unmatched"
+    if em_dat == geo_disasters:
+        return "exact"
+
+    return "partial" if em_dat & geo_disasters else "disjoint"
+
+
+def compare_event_units(em_dat: Mapping[str, set[str]], geo_disasters: Mapping[str, set[str]]) -> pd.DataFrame:
+    """
+    Report how EM-DAT's own geocoding and Geo-Disasters' agree, event by event.
+
+    The two are keyed on ``DisNo.`` and nothing else: EM-DAT names GADM units and Geo-Disasters names
+    GAUL ones, and the two gazetteers share no identifier, so units are matched on their names, put
+    through :func:`normalise_unit_name` here rather than by either caller.
+
+    Each event is classified as ``exact`` when both name the same units, ``partial`` when they
+    overlap, ``disjoint`` when both name units and none is shared, ``gained`` when only
+    Geo-Disasters has any, and ``unmatched`` when only EM-DAT does. An event neither has is absent.
+
+    Parameters
+    ----------
+    em_dat : mapping of str to set of str
+        Unit names EM-DAT records, keyed on event id.
+    geo_disasters : mapping of str to set of str
+        The same from Geo-Disasters, as :func:`event_unit_names` returns it.
+
+    Returns
+    -------
+    DataFrame
+        Columns ``DisNo.``, ``agreement`` and the three counts, one row per event either source
+        geocoded, ordered by event id.
+    """
+    rows = []
+
+    for disno in sorted(em_dat.keys() | geo_disasters.keys()):
+        recorded = {normalise_unit_name(name) for name in em_dat.get(disno, ()) if name}
+        published = {normalise_unit_name(name) for name in geo_disasters.get(disno, ()) if name}
+        if not recorded and not published:
+            continue
+
+        rows.append(
+            {
+                "DisNo.": disno,
+                "agreement": _classify(recorded, published),
+                "em_dat_units": len(recorded),
+                "geo_disasters_units": len(published),
+                "shared_units": len(recorded & published),
+            }
+        )
+
+    return pd.DataFrame(rows, columns=AGREEMENT_COLUMNS)

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -1,3 +1,4 @@
+import logging
 import unicodedata
 
 from collections.abc import Mapping
@@ -6,7 +7,11 @@ from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 
+from climate_risk.data.gadm import load_units_in_country
 from climate_risk.data.source import ManualSource
+from climate_risk.exceptions import DataValidationError
+
+_log = logging.getLogger(__name__)
 
 # The geometries are a GAUL 2015 derivative and non-commercial, so the archive is placed by hand
 # and never appears in the fetchable registry. The attribute table is CC-BY-4.0.
@@ -110,6 +115,112 @@ def unit_names(locations: pd.DataFrame) -> pd.Series:
         named[at_level] = locations.loc[at_level, column]
 
     return named
+
+
+def load_event_footprints(cache_dir: Path, *, iso: str, layer: str = GEO_DISASTERS_LAYER) -> gpd.GeoDataFrame:
+    """
+    Read one country's geocoded locations with the polygons attached.
+
+    These polygons are the non-commercial half of the licence, and :data:`GAUL_ATTRIBUTION` has to
+    appear on anything derived from them. :func:`load_event_locations` reads the same rows without
+    geometry where the attributes alone will do.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+    iso : str
+        ISO 3166-1 alpha-3 country code to read.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GEO_DISASTERS_LAYER``.
+
+    Returns
+    -------
+    GeoDataFrame
+        The columns of :func:`load_event_locations` and the footprint of each location.
+    """
+    footprints = gpd.read_file(geo_disasters_path(cache_dir), layer=layer, where=f"ISO = '{iso}'")
+
+    return footprints.reset_index(drop=True)
+
+
+EQUAL_AREA_CRS = "ESRI:54009"
+
+RESOLVED_COLUMNS = ["DisNo.", "ISO", "geometry_source", "gid", "name", "admin_level", "geocoding_q", "overlap"]
+
+
+def _best_unit_per_footprint(footprints: gpd.GeoDataFrame, units: gpd.GeoDataFrame) -> pd.DataFrame:
+    """Pair each footprint with the single unit covering most of it, dropping any that meet none."""
+    located = footprints[["DisNo.", "ISO", "geocoding_q", "geometry"]].reset_index(names="footprint")
+    pieces = gpd.overlay(located, units, how="intersection", keep_geom_type=False)
+    if pieces.empty:
+        return pd.DataFrame(columns=RESOLVED_COLUMNS)
+
+    pieces = pieces.assign(covered=pieces.geometry.area)
+    best = pieces.sort_values("covered").groupby("footprint").tail(1).set_index("footprint")
+    shares = best["covered"] / footprints.geometry.area.reindex(best.index)
+
+    return best.assign(overlap=shares).drop(columns=["geometry", "covered"])
+
+
+def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFrame:
+    """
+    Name each Geo-Disasters footprint as the GADM unit it covers, so it can join EM-DAT's own units.
+
+    The two gazetteers share no identifier and spell the same unit differently, so a footprint is
+    placed by where it is rather than what it is called, and the largest overlap wins outright. No
+    minimum share applies: the published polygons are simplified to 0.005°, roughly 550 m, which
+    costs a small municipality a third of its area and a province almost none, so the same share
+    means different things at different sizes.
+
+    A footprint covering no unit at all is dropped and logged.
+
+    Parameters
+    ----------
+    footprints : GeoDataFrame
+        Locations for one country, as :func:`load_event_footprints` returns them.
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    DataFrame
+        ``DisNo.``, ``ISO``, ``geometry_source``, the GADM unit that was matched, the location's
+        ``geocoding_q``, and ``overlap``, the share of the footprint the unit covers.
+    """
+    if footprints.empty:
+        return pd.DataFrame(columns=RESOLVED_COLUMNS)
+
+    countries = set(footprints["ISO"])
+    if len(countries) > 1:
+        raise DataValidationError(
+            f"resolve_to_gadm reads one country's units at a time, but these footprints span "
+            f"{sorted(countries)}. Call it once per country."
+        )
+
+    iso = countries.pop()
+    matched = []
+
+    for level in sorted(set(footprints["admin_level"]) & set(NAME_COLUMNS)):
+        at_level = footprints[footprints["admin_level"] == level].to_crs(EQUAL_AREA_CRS)
+        units = load_units_in_country(iso, level, cache_dir).to_crs(EQUAL_AREA_CRS)
+        if units.empty:
+            _log.warning("GADM holds no level-%d unit for %s, so %d footprints go unplaced", level, iso, len(at_level))
+            continue
+
+        matched.append(_best_unit_per_footprint(at_level, units))
+
+    resolved = pd.concat(matched) if matched else pd.DataFrame(columns=RESOLVED_COLUMNS)
+    unplaced = len(footprints) - len(resolved)
+    if unplaced:
+        _log.warning("%d of %d %s footprints cover no GADM unit and were dropped", unplaced, len(footprints), iso)
+
+    return (
+        pd.DataFrame(resolved)
+        .assign(geometry_source="geo_disasters")[RESOLVED_COLUMNS]
+        .sort_values(["DisNo.", "gid"])
+        .reset_index(drop=True)
+    )
 
 
 def normalise_unit_name(name: str) -> str:

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+
+from climate_risk.data.source import ManualSource
+
+# The geometries are a GAUL 2015 derivative and non-commercial, so the archive is placed by hand
+# and never appears in the fetchable registry. The attribute table is CC-BY-4.0.
+GEO_DISASTERS = ManualSource(
+    filename="disaster_subnational_90_23.gpkg",
+    homepage="https://doi.org/10.5281/zenodo.15487667",
+    licence=(
+        "Spatial geometries are © FAO 2015 under the GAUL 2015 Data Licence, non-commercial with "
+        "attribution required. All non-spatial attributes are CC-BY-4.0."
+    ),
+    citation=(
+        "Teber, K., Weynants, M., Gans, F., & Mahecha, M. D. (2025). Geo-Disasters v1.0.0: geocoded "
+        "EM-DAT climate-disaster footprints (1990-2023). https://doi.org/10.5281/zenodo.15487667"
+    ),
+    retrieved="2026-08-09",
+)
+
+GEO_DISASTERS_LAYER = "disaster_subnational_90_23"
+
+# What a location is keyed and named by, per admin level.
+NAME_COLUMNS = {1: "ADM1_NAME", 2: "ADM2_NAME"}
+
+LOCATION_COLUMNS = ["DisNo.", "ISO", "admin_level", "geocoding_q", "ADM1_NAME", "ADM2_NAME"]
+
+# Attribution required by the GAUL 2015 Data Licence, clause 2(a), verbatim.
+GAUL_ATTRIBUTION = (
+    "Source of Administrative boundaries: The Global Administrative Unit Layers (GAUL) dataset, "
+    "implemented by FAO within the CountrySTAT and Agricultural Market Information System (AMIS) "
+    "projects"
+)
+
+
+def geo_disasters_dir(cache_dir: Path) -> Path:
+    return cache_dir / "geo_disasters"
+
+
+def geo_disasters_path(cache_dir: Path) -> Path:
+    """
+    Return the path to the Geo-Disasters GeoPackage, raising if it has not been placed in the cache.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    Path
+        Location of ``disaster_subnational_90_23.gpkg``.
+    """
+    return GEO_DISASTERS.require(geo_disasters_dir(cache_dir))
+
+
+def load_event_locations(cache_dir: Path, *, iso: str | None = None, layer: str = GEO_DISASTERS_LAYER) -> pd.DataFrame:
+    """
+    Read the geocoded locations Geo-Disasters records, one row per affected administrative unit.
+
+    Geometry is left on disk. The polygons carry the non-commercial GAUL licence while the attribute
+    table is CC-BY-4.0, and the attributes are what a comparison against EM-DAT needs.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+    iso : str, optional
+        Restrict to one ISO 3166-1 alpha-3 country code. Default None, meaning every country.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GEO_DISASTERS_LAYER``.
+
+    Returns
+    -------
+    DataFrame
+        Columns ``DisNo.``, ``ISO``, ``admin_level``, ``geocoding_q``, ``ADM1_NAME`` and
+        ``ADM2_NAME``, one row per location.
+    """
+    path = geo_disasters_path(cache_dir)
+    where = f"ISO = '{iso}'" if iso is not None else None
+
+    locations = gpd.read_file(path, layer=layer, columns=LOCATION_COLUMNS, where=where, ignore_geometry=True)
+
+    return pd.DataFrame(locations).reset_index(drop=True)
+
+
+def unit_names(locations: pd.DataFrame) -> pd.Series:
+    """
+    Name each location at the level it was geocoded to.
+
+    Parameters
+    ----------
+    locations : DataFrame
+        Rows as :func:`load_event_locations` returns them.
+
+    Returns
+    -------
+    Series
+        One name per row, taken from the column its ``admin_level`` points at.
+    """
+    named = pd.Series(pd.NA, index=locations.index, dtype="object")
+    for level, column in NAME_COLUMNS.items():
+        at_level = locations["admin_level"] == level
+        named[at_level] = locations.loc[at_level, column]
+
+    return named

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -312,7 +312,7 @@ def event_units(events: pl.DataFrame) -> pl.DataFrame:
 
 # Where an event's geometry comes from, best first. Nothing is filtered on this: the column records
 # what the source holds, and a model chooses which tiers it will accept.
-GEOMETRY_SOURCES = ("gadm", "emdat_point", "country")
+GEOMETRY_SOURCES = ("gadm", "geo_disasters", "emdat_point", "country")
 
 EVENT_GEOGRAPHY_COLUMNS = (
     "DisNo.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ markers = [
     "slow: PyMC sampling or other multi-second work",
     "requires_emdat: needs the licensed EM-DAT workbook, absent from CI",
     "requires_gadm: needs the GADM GeoPackage, which is non-commercial and absent from CI",
+    "requires_geo_disasters: needs the Geo-Disasters GeoPackage, non-commercial and absent from CI",
 ]
 filterwarnings = [
     "error",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,6 +407,39 @@ def write_gadm_cache(tmp_path):
     return write
 
 
+def toy_geo_disasters() -> gpd.GeoDataFrame:
+    """A GeoPackage shaped like Geo-Disasters: one row per affected unit, keyed on ``DisNo.``.
+
+    Two Laos events, one geocoded to provinces and one to districts, so a reader taking the name
+    from a fixed column returns nothing for half the rows. The Zambian event is there for the ISO
+    filter to exclude.
+    """
+    rows = [
+        ("1991-0761-LAO", "LAO", 1, 2, "Savannakhet", None, box(0, 0, 1, 1)),
+        ("1991-0761-LAO", "LAO", 1, 2, "Khammouan", None, box(1, 0, 2, 1)),
+        ("2018-0339-LAO", "LAO", 2, 1, "Attapu", "Sanamxay", box(2, 0, 3, 1)),
+        ("2007-0225-ZMB", "ZMB", 1, 1, "Central", None, box(6, 0, 7, 1)),
+    ]
+    columns = ("DisNo.", "ISO", "admin_level", "geocoding_q", "ADM1_NAME", "ADM2_NAME", "geometry")
+
+    return gpd.GeoDataFrame(dict(zip(columns, zip(*rows, strict=True), strict=True)), crs="EPSG:4326")
+
+
+@pytest.fixture
+def write_geo_disasters_cache(tmp_path):
+    """Return a callable writing a Geo-Disasters-shaped GeoPackage into the cache."""
+
+    def write(locations=None):
+        directory = tmp_path / "geo_disasters"
+        directory.mkdir(exist_ok=True)
+        frame = locations if locations is not None else toy_geo_disasters()
+        frame.to_file(directory / "disaster_subnational_90_23.gpkg", layer="disaster_subnational_90_23")
+
+        return tmp_path
+
+    return write
+
+
 @pytest.fixture
 def write_rivers_cache(tmp_path):
     """Return a callable writing the processed river network a warm cache would hold."""

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from climate_risk.data.gadm import GADM, gadm_dir, gadm_path, load_admin_units
+from climate_risk.data.gadm import GADM, gadm_dir, gadm_path, load_admin_units, load_units_in_country
 from climate_risk.data_functions.emdat_processing import load_emdat_events
 from climate_risk.exceptions import DataValidationError
 
@@ -90,6 +90,57 @@ def test_the_same_id_asked_for_twice_is_read_once(write_gadm_cache):
     units = load_admin_units([("LAO.1_1", 1), ("LAO.1_1", 1)], cache_dir)
 
     assert len(units) == 1
+
+
+def test_a_country_reads_back_every_unit_it_holds_at_a_level(write_gadm_cache):
+    """A search by geometry needs the candidates, which is the opposite question to `by id`."""
+    cache_dir = write_gadm_cache()
+
+    provinces = load_units_in_country("LAO", 1, cache_dir)
+
+    assert sorted(provinces["gid"]) == ["LAO.1_1", "LAO.2_1"]
+    assert set(provinces["admin_level"]) == {1}
+
+
+def test_a_country_reads_back_its_districts(write_gadm_cache):
+    """Level decides which column is read, and reading the wrong one returns the wrong geography."""
+    cache_dir = write_gadm_cache()
+
+    districts = load_units_in_country("LAO", 2, cache_dir)
+
+    assert sorted(districts["name"]) == ["Houayxay", "Samakhixay", "Sanamxay"]
+
+
+def test_a_province_spanning_several_districts_is_one_row(write_gadm_cache):
+    """The table stores districts, so Attapu is two rows that have to become one polygon."""
+    cache_dir = write_gadm_cache()
+
+    attapu = load_units_in_country("LAO", 1, cache_dir).set_index("gid").loc["LAO.1_1"]
+
+    assert attapu["geometry"].bounds == (0.0, 0.0, 2.0, 1.0)
+
+
+def test_only_the_country_asked_for_comes_back(write_gadm_cache):
+    """Matching a footprint against another country's units places it somewhere else entirely."""
+    cache_dir = write_gadm_cache()
+
+    assert load_units_in_country("ZMB", 1, cache_dir)["gid"].tolist() == ["ZMB.1_1"]
+
+
+def test_a_country_gadm_does_not_hold_is_empty_but_still_carries_the_crs(write_gadm_cache):
+    cache_dir = write_gadm_cache()
+
+    units = load_units_in_country("CRI", 1, cache_dir)
+
+    assert units.empty
+    assert units.crs == "EPSG:4326"
+
+
+def test_a_level_gadm_is_not_read_at_is_rejected_for_a_country(write_gadm_cache):
+    cache_dir = write_gadm_cache()
+
+    with pytest.raises(DataValidationError, match="read at levels"):
+        load_units_in_country("LAO", 0, cache_dir)
 
 
 # The GeoPackage is non-commercial and hand-placed, so it is absent on CI and on a fresh clone.

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -3,10 +3,14 @@ from pathlib import Path
 import pytest
 
 from climate_risk.data.geo_disasters import (
+    AGREEMENT_LEVELS,
     GEO_DISASTERS,
+    compare_event_units,
+    event_unit_names,
     geo_disasters_dir,
     geo_disasters_path,
     load_event_locations,
+    normalise_unit_name,
     unit_names,
 )
 
@@ -87,9 +91,99 @@ def test_geometry_is_left_on_disk(write_geo_disasters_cache):
     assert "geometry" not in locations.columns
 
 
+@pytest.mark.parametrize(
+    ("published", "other"),
+    [("Attapu", "attapu"), ("Bolikhamxai", "Bolikhamxai "), ("Xekong", "Xékong"), ("Xai-somboun", "Xaisomboun")],
+    ids=["casing", "whitespace", "accent", "hyphen"],
+)
+def test_the_same_unit_spelled_two_ways_normalises_alike(published, other):
+    """GADM and GAUL differ in casing, spacing, accents and hyphens for units that are the same one,
+    and a literal comparison would report every one of these as the sources disagreeing."""
+    assert normalise_unit_name(published) == normalise_unit_name(other)
+
+
+def test_units_that_are_genuinely_different_stay_different():
+    """Normalisation that collapses too far reports agreement everywhere and validates nothing."""
+    assert normalise_unit_name("Savannakhet") != normalise_unit_name("Khammouan")
+
+
+def test_a_different_romanisation_is_not_reconciled():
+    """Normalisation handles typography, not spelling. `Xiangkhouang` and `Xiangkhoang` are one
+    province under two romanisations, and they compare as different units — so a `partial` in the
+    report is an upper bound on real disagreement, not a measurement of it."""
+    assert normalise_unit_name("Xiangkhouang") != normalise_unit_name("Xiangkhoang")
+
+
+def test_geo_disasters_names_are_collected_per_event(write_geo_disasters_cache):
+    cache_dir = write_geo_disasters_cache()
+
+    names = event_unit_names(load_event_locations(cache_dir, iso="LAO"))
+
+    assert names == {"1991-0761-LAO": {"Savannakhet", "Khammouan"}, "2018-0339-LAO": {"Sanamxay"}}
+
+
+@pytest.mark.parametrize(
+    ("em_dat", "geo_disasters", "expected"),
+    [
+        ({"Savannakhet", "Khammouan"}, {"Savannakhet", "Khammouan"}, "exact"),
+        ({"Vientiane", "Xaisomboun"}, {"Vientiane"}, "partial"),
+        ({"Vientiane"}, {"Attapu"}, "disjoint"),
+        (set(), {"Xekong", "Attapu"}, "gained"),
+        ({"Bokeo"}, set(), "unmatched"),
+    ],
+    ids=["exact", "partial", "disjoint", "gained", "unmatched"],
+)
+def test_an_event_is_classified_by_how_the_two_geocodings_overlap(em_dat, geo_disasters, expected):
+    report = compare_event_units({"E": em_dat}, {"E": geo_disasters})
+
+    assert report["agreement"].tolist() == [expected]
+
+
+def test_an_event_neither_source_geocoded_is_left_out():
+    """Two thirds of EM-DAT carries no units at all; reporting them would bury the comparison."""
+    report = compare_event_units({"E": set()}, {"E": set()})
+
+    assert report.empty
+    assert list(report.columns) == ["DisNo.", "agreement", "em_dat_units", "geo_disasters_units", "shared_units"]
+
+
+def test_agreement_is_judged_after_normalisation():
+    """The whole point of normalising: Xekong and Xékong are one province, not a disjoint pair."""
+    report = compare_event_units({"E": {"Xékong"}}, {"E": {"Xekong"}})
+
+    assert report["agreement"].tolist() == ["exact"]
+    assert report["shared_units"].tolist() == [1]
+
+
+def test_the_counts_describe_each_side_and_the_overlap():
+    report = compare_event_units({"E": {"Vientiane", "Xaisomboun"}}, {"E": {"Vientiane", "Attapu"}})
+
+    assert report.loc[0, "em_dat_units"] == 2
+    assert report.loc[0, "geo_disasters_units"] == 2
+    assert report.loc[0, "shared_units"] == 1
+
+
+def test_every_event_either_source_geocoded_appears_once():
+    """A join done the wrong way round silently drops whichever side is absent."""
+    report = compare_event_units({"A": {"x"}, "B": {"y"}}, {"B": {"y"}, "C": {"z"}})
+
+    assert report["DisNo."].tolist() == ["A", "B", "C"]
+
+
 # The GeoPackage is non-commercial and hand-placed, so it is absent on CI and on a fresh clone.
 REAL_CACHE_DIR = Path(__file__).parents[2] / "data"
 REAL_GEOPACKAGE = REAL_CACHE_DIR / "geo_disasters" / "disaster_subnational_90_23.gpkg"
+
+
+def test_every_classification_is_one_of_the_declared_levels():
+    """`AGREEMENT_LEVELS` is the published vocabulary; a verdict outside it is one no caller can
+    branch on."""
+    report = compare_event_units(
+        {"exact": {"a"}, "partial": {"a", "b"}, "disjoint": {"a"}, "unmatched": {"a"}},
+        {"exact": {"a"}, "partial": {"a"}, "disjoint": {"z"}, "gained": {"a"}},
+    )
+
+    assert set(report["agreement"]) == set(AGREEMENT_LEVELS)
 
 
 @pytest.mark.requires_geo_disasters

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -1,3 +1,5 @@
+import re
+
 from pathlib import Path
 
 import pytest
@@ -5,14 +7,19 @@ import pytest
 from climate_risk.data.geo_disasters import (
     AGREEMENT_LEVELS,
     GEO_DISASTERS,
+    RESOLVED_COLUMNS,
     compare_event_units,
     event_unit_names,
     geo_disasters_dir,
     geo_disasters_path,
+    load_event_footprints,
     load_event_locations,
     normalise_unit_name,
+    resolve_to_gadm,
     unit_names,
 )
+from climate_risk.exceptions import DataValidationError
+from tests.conftest import toy_geo_disasters
 
 
 def test_the_geopackage_is_looked_for_under_the_cache(tmp_path):
@@ -175,6 +182,33 @@ REAL_CACHE_DIR = Path(__file__).parents[2] / "data"
 REAL_GEOPACKAGE = REAL_CACHE_DIR / "geo_disasters" / "disaster_subnational_90_23.gpkg"
 
 
+def test_footprints_spanning_two_countries_are_refused(tmp_path):
+    """Only the first country's units would be read, and every other country's footprint would be
+    placed against them — wrong geography, with nothing to show for it."""
+    with pytest.raises(DataValidationError, match=re.escape("['LAO', 'ZMB']")):
+        resolve_to_gadm(toy_geo_disasters(), tmp_path)
+
+
+def test_no_footprints_resolve_to_an_empty_frame_of_the_right_shape(tmp_path):
+    """A country Geo-Disasters never geocoded is ordinary, and the caller concatenates the result."""
+    empty = toy_geo_disasters().iloc[:0]
+
+    resolved = resolve_to_gadm(empty, tmp_path)
+
+    assert resolved.empty
+    assert list(resolved.columns) == RESOLVED_COLUMNS
+
+
+def test_footprints_come_back_with_their_geometry(write_geo_disasters_cache):
+    """The counterpart to the attribute-only read: resolving needs the polygons."""
+    cache_dir = write_geo_disasters_cache()
+
+    footprints = load_event_footprints(cache_dir, iso="LAO")
+
+    assert not footprints.geometry.isna().any()
+    assert footprints.crs == "EPSG:4326"
+
+
 def test_every_classification_is_one_of_the_declared_levels():
     """`AGREEMENT_LEVELS` is the published vocabulary; a verdict outside it is one no caller can
     branch on."""
@@ -184,6 +218,59 @@ def test_every_classification_is_one_of_the_declared_levels():
     )
 
     assert set(report["agreement"]) == set(AGREEMENT_LEVELS)
+
+
+REAL_GADM = REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg"
+
+needs_both = pytest.mark.skipif(
+    not (REAL_GEOPACKAGE.exists() and REAL_GADM.exists()), reason="needs the Geo-Disasters and GADM GeoPackages"
+)
+
+
+@pytest.mark.requires_geo_disasters
+@pytest.mark.requires_gadm
+@needs_both
+def test_a_footprint_resolves_to_the_gadm_unit_it_covers():
+    """The two gazetteers share no identifier and spell the same province differently, so a
+    footprint is placed by where it is. Laos is small enough to check every row."""
+    footprints = load_event_footprints(REAL_CACHE_DIR, iso="LAO")
+
+    resolved = resolve_to_gadm(footprints, REAL_CACHE_DIR)
+
+    assert len(resolved) == len(footprints), "every Laos footprint sits on a GADM unit"
+    assert set(resolved["geometry_source"]) == {"geo_disasters"}
+    assert resolved["gid"].str.startswith("LAO").all()
+
+
+@pytest.mark.requires_geo_disasters
+@pytest.mark.requires_gadm
+@needs_both
+def test_a_footprint_is_matched_at_its_own_admin_level():
+    """Matching a district against provinces returns the province containing it, which silently
+    coarsens the footprint to something several times its size."""
+    footprints = load_event_footprints(REAL_CACHE_DIR, iso="LAO")
+
+    resolved = resolve_to_gadm(footprints, REAL_CACHE_DIR).set_index("DisNo.")
+
+    at_level_2 = resolved[resolved["admin_level"] == 2]
+    assert not at_level_2.empty, "Laos has district-level footprints to match"
+    assert at_level_2["gid"].str.count(r"\.").eq(2).all(), "a level-2 gid names a district"
+
+
+@pytest.mark.requires_geo_disasters
+@pytest.mark.requires_gadm
+@needs_both
+def test_the_names_corroborate_the_geometry():
+    """Geometry decides the match, so nothing checks the names — and a systematic mis-join would
+    look perfectly healthy. Most matched pairs should still agree on the name."""
+    footprints = load_event_footprints(REAL_CACHE_DIR, iso="LAO")
+
+    resolved = resolve_to_gadm(footprints, REAL_CACHE_DIR)
+
+    published = unit_names(footprints).map(normalise_unit_name)
+    matched = resolved["name"].map(normalise_unit_name)
+    agreeing = sum(name in set(published) for name in matched)
+    assert agreeing / len(matched) > 0.8, f"only {agreeing} of {len(matched)} matched units kept their name"
 
 
 @pytest.mark.requires_geo_disasters

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+import pytest
+
+from climate_risk.data.geo_disasters import (
+    GEO_DISASTERS,
+    geo_disasters_dir,
+    geo_disasters_path,
+    load_event_locations,
+    unit_names,
+)
+
+
+def test_the_geopackage_is_looked_for_under_the_cache(tmp_path):
+    assert geo_disasters_dir(tmp_path) == tmp_path / "geo_disasters"
+
+
+def test_an_absent_geopackage_names_the_path_and_where_to_get_it(tmp_path):
+    """Nothing may fetch this, so the error is the user's only instruction."""
+    with pytest.raises(NotImplementedError) as raised:
+        geo_disasters_path(tmp_path)
+
+    message = str(raised.value)
+    assert str(tmp_path / "geo_disasters" / "disaster_subnational_90_23.gpkg") in message
+    assert "10.5281/zenodo.15487667" in message
+
+
+def test_the_declaration_splits_the_licence_by_what_it_covers():
+    """The geometry is non-commercial and the attributes are not; a figure built from one is
+    constrained where the other is free, so both halves have to survive in the declaration."""
+    licence = GEO_DISASTERS.licence.lower()
+
+    assert "non-commercial" in licence
+    assert "cc-by-4.0" in licence
+    assert "zenodo.15487667" in GEO_DISASTERS.citation
+
+
+def test_locations_come_back_keyed_on_the_em_dat_id(write_geo_disasters_cache):
+    """`DisNo.` is the only key shared with EM-DAT, and one event spans several rows."""
+    cache_dir = write_geo_disasters_cache()
+
+    locations = load_event_locations(cache_dir)
+
+    assert sorted(locations["DisNo."].unique()) == ["1991-0761-LAO", "2007-0225-ZMB", "2018-0339-LAO"]
+    assert (locations["DisNo."] == "1991-0761-LAO").sum() == 2
+
+
+def test_one_country_can_be_read_without_the_rest(write_geo_disasters_cache):
+    """The real table is 45,000 rows across 206 countries, and a comparison wants one of them."""
+    cache_dir = write_geo_disasters_cache()
+
+    locations = load_event_locations(cache_dir, iso="LAO")
+
+    assert set(locations["ISO"]) == {"LAO"}
+    assert len(locations) == 3
+
+
+def test_an_iso_the_table_does_not_hold_reads_back_empty(write_geo_disasters_cache):
+    """A country with no geocoded events is the normal case, not an error."""
+    cache_dir = write_geo_disasters_cache()
+
+    locations = load_event_locations(cache_dir, iso="CRI")
+
+    assert locations.empty
+    assert list(locations.columns) == ["DisNo.", "ISO", "admin_level", "geocoding_q", "ADM1_NAME", "ADM2_NAME"]
+
+
+def test_a_unit_is_named_at_the_level_it_was_geocoded_to(write_geo_disasters_cache):
+    """A district row carries its province name too, so reading ADM1_NAME everywhere silently
+    coarsens every level-2 location to the province containing it."""
+    cache_dir = write_geo_disasters_cache()
+    locations = load_event_locations(cache_dir, iso="LAO")
+
+    named = unit_names(locations)
+
+    by_event = dict(zip(locations["DisNo."], named, strict=True))
+    assert by_event["2018-0339-LAO"] == "Sanamxay"
+    assert set(named) == {"Savannakhet", "Khammouan", "Sanamxay"}
+
+
+def test_geometry_is_left_on_disk(write_geo_disasters_cache):
+    """The polygons are the non-commercial half of the licence, and nothing here needs them."""
+    cache_dir = write_geo_disasters_cache()
+
+    locations = load_event_locations(cache_dir)
+
+    assert "geometry" not in locations.columns
+
+
+# The GeoPackage is non-commercial and hand-placed, so it is absent on CI and on a fresh clone.
+REAL_CACHE_DIR = Path(__file__).parents[2] / "data"
+REAL_GEOPACKAGE = REAL_CACHE_DIR / "geo_disasters" / "disaster_subnational_90_23.gpkg"
+
+
+@pytest.mark.requires_geo_disasters
+@pytest.mark.skipif(not REAL_GEOPACKAGE.exists(), reason="needs the Geo-Disasters GeoPackage")
+def test_the_published_table_is_the_one_the_loader_expects():
+    """A synthetic fixture agrees with the loader by construction. This is the only check that the
+    real archive still has the schema and the scale the paper describes."""
+    locations = load_event_locations(REAL_CACHE_DIR)
+
+    assert len(locations) == 45_121
+    assert locations["DisNo."].nunique() == 9_217
+    assert set(locations["admin_level"]) == {1, 2}
+    assert locations["geocoding_q"].between(1, 4).all()
+    assert unit_names(locations).notna().all(), "every location must be named at its own level"

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -508,7 +508,10 @@ def test_no_tier_silently_swallows_the_others():
     assert geography["DisNo."].n_unique() == len(events)
 
     per_source = dict(geography.group_by("geometry_source").len().iter_rows())
-    assert set(per_source) == set(GEOMETRY_SOURCES)
+    # The workbook supplies these three. `geo_disasters` is resolved from a separate archive and
+    # cannot appear here.
+    assert set(per_source) == {"gadm", "emdat_point", "country"}
+    assert set(per_source) < set(GEOMETRY_SOURCES)
     assert all(count > 1_000 for count in per_source.values())
     # Coded events carry several units each, so the gadm tier is the longest despite being a
     # minority of events.


### PR DESCRIPTION
EM-DAT geocodes 7,842 of its 27,758 events; Geo-Disasters covers 2,267 more, a 29% gain concentrated in the 1990s. Its footprints are matched onto GADM units by polygon overlap rather than by name — the two gazetteers share no identifier and spell the same province differently, and no similarity threshold works globally, since Omsk and Tomsk are closer than Saravan and Salavan.

Nothing consumes the resolved rows yet. The tests that touch the real archives need both GeoPackages and skip on CI.
