### PR TITLE
Type and test plotting.py, the last unchecked module

### DIFF
--- a/climate_risk/plotting.py
+++ b/climate_risk/plotting.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 import arviz as az
 import matplotlib.pyplot as plt
@@ -11,25 +11,22 @@ from matplotlib.gridspec import GridSpec
 from matplotlib.offsetbox import AnchoredText
 from scipy import stats
 
-REGIONS = ["Asia", "Europe", "Africa", "Oceania", "Americas"]
+REGIONS = ("Asia", "Europe", "Africa", "Oceania", "Americas")
 
 
-def configure_plot_style(add_grid=False):
-    config = {
-        "figure.figsize": (14, 4),
-        "figure.constrained_layout.use": True,
-        "figure.facecolor": "w",
-        "axes.grid": add_grid,
-        "grid.linewidth": 0.5,
-        "grid.linestyle": "--",
-        "axes.spines.top": False,
-        "axes.spines.bottom": False,
-        "axes.spines.left": False,
-        "axes.spines.right": False,
-    }
-
+def configure_plot_style(add_grid: bool = False) -> None:
     pd.set_option("display.float_format", "{:.2f}".format)
-    plt.rcParams.update(config)
+
+    plt.rcParams["figure.figsize"] = (14, 4)
+    plt.rcParams["figure.constrained_layout.use"] = True
+    plt.rcParams["figure.facecolor"] = "w"
+    plt.rcParams["axes.grid"] = add_grid
+    plt.rcParams["grid.linewidth"] = 0.5
+    plt.rcParams["grid.linestyle"] = "--"
+    plt.rcParams["axes.spines.top"] = False
+    plt.rcParams["axes.spines.bottom"] = False
+    plt.rcParams["axes.spines.left"] = False
+    plt.rcParams["axes.spines.right"] = False
 
 
 def prepare_gridspec_figure(n_cols: int, n_plots: int, figure: plt.Figure | None = None) -> tuple[GridSpec, list]:
@@ -75,13 +72,13 @@ def prepare_gridspec_figure(n_cols: int, n_plots: int, figure: plt.Figure | None
 
 def _plot_single_kde(
     data: pd.Series,
-    axis=None,
-    bins=30,
-    color="tab:blue",
-    leg_loc="upper left",
+    axis: plt.Axes | None = None,
+    bins: int = 30,
+    color: str = "tab:blue",
+    leg_loc: str = "upper left",
     set_title: bool = True,
     add_sum_box: bool = True,
-):
+) -> plt.Axes:
     """
     Plot one series as a histogram with a kernel density estimate over it.
 
@@ -116,20 +113,21 @@ def _plot_single_kde(
     sns.kdeplot(data, ax=axis, lw=2, c="k", ls="--")
 
     if add_sum_box:
-        n, minmax, mean, var, skew, kurt = stats.describe(data.values.squeeze())
-        jb = stats.jarque_bera(data.values.squeeze())
+        observations = np.asarray(data.values).squeeze()
+        n, minmax, mean, var, skew, kurt = stats.describe(observations)
+        jb = stats.jarque_bera(observations)
 
         names = ["N", "Min", "Max", "Mean", "Std", "Skew", "Kurt", "JB"]
         values = [n, minmax[0], minmax[1], mean, np.sqrt(var), skew, kurt, jb.statistic]
 
         text = "\n".join(
-            f"{name:<5} = {' ' if value > 0 else ''}{value:<3.3f}" for name, value in zip(names, values, strict=False)
+            f"{name:<5} = {' ' if value > 0 else ''}{value:<3.3f}" for name, value in zip(names, values, strict=True)
         )
         box = AnchoredText(text, loc=leg_loc, prop={"fontfamily": "monospace"})
         box.patch.set_alpha(0.5)
         axis.add_artist(box)
     if set_title:
-        axis.set_title(data.name)
+        axis.set_title(str(data.name))
 
     return axis
 
@@ -139,11 +137,11 @@ def plot_descriptive(
     n_cols: int = 3,
     bins: int = 30,
     color: str = "tab:blue",
-    leg_loc="upper left",
+    leg_loc: str = "upper left",
     labels_size: int = 14,
     add_sum_box: bool = True,
-    **figure_kwargs,
-):
+    **figure_kwargs: Any,
+) -> plt.Figure | plt.Axes:
     """
     Plot one histogram and kernel density estimate per column.
 
@@ -186,7 +184,7 @@ def plot_descriptive(
     n_cols = min(n_cols, n_plots)
     gs, locs = prepare_gridspec_figure(n_cols=n_cols, n_plots=n_plots)
 
-    for name, loc in zip(df.columns, locs, strict=False):
+    for name, loc in zip(df.columns, locs, strict=True):
         axis = fig.add_subplot(gs[loc])
         axis.set_ylabel("Density", fontsize=labels_size)
         _plot_single_kde(
@@ -315,7 +313,9 @@ def plot_aggregated_series_by_region(
     return fig
 
 
-def plot_ppc_loopit(idata: xr.DataTree, target_name: str, title: str | None = None, **ppc_kwargs) -> list[plt.Axes]:
+def plot_ppc_loopit(
+    idata: xr.DataTree, target_name: str, title: str | None = None, **ppc_kwargs: Any
+) -> list[plt.Axes]:
     """
     Plot a posterior predictive check above its LOO-PIT diagnostics, as one figure.
 
@@ -342,7 +342,7 @@ def plot_ppc_loopit(idata: xr.DataTree, target_name: str, title: str | None = No
     ax_ecdf = fig.add_subplot(gs[1, 1])
 
     az.plot_ppc(idata, ax=ax_ppc, var_names=[target_name], **ppc_kwargs)
-    for ax, ecdf in zip([ax_loo, ax_ecdf], [False, True], strict=False):
+    for ax, ecdf in zip([ax_loo, ax_ecdf], [False, True], strict=True):
         az.plot_loo_pit(idata, y=target_name, ecdf=ecdf, ax=ax)
 
     if title is None:
@@ -355,7 +355,7 @@ def plot_ppc_loopit(idata: xr.DataTree, target_name: str, title: str | None = No
 SAMPLE_DIMS = ("chain", "draw")
 
 
-def _aligned_prediction_mean(draws, df):
+def _aligned_prediction_mean(draws: xr.DataArray, df: pd.DataFrame) -> np.ndarray:
     """Return the posterior-predictive mean, checked against the frame it will be attached to."""
     predictions = draws.mean(dim=SAMPLE_DIMS)
     if predictions.size != len(df):
@@ -363,10 +363,10 @@ def _aligned_prediction_mean(draws, df):
             f"posterior_predictive holds {predictions.size} observations but df has {len(df)} rows; "
             f"they must be the observations the model saw, in the same order."
         )
-    return predictions.values
+    return np.asarray(predictions.values)
 
 
-def attach_count_predictions(idata, df):
+def attach_count_predictions(idata: xr.DataTree, df: pd.DataFrame) -> pd.DataFrame:
     """Attach posterior-predictive means and HDI bounds to the observed frame.
 
     Parameters
@@ -396,7 +396,7 @@ def attach_count_predictions(idata, df):
     )
 
 
-def plot_predicted_counts(idata, df, country: str) -> plt.Figure:
+def plot_predicted_counts(idata: xr.DataTree, df: pd.DataFrame, country: str) -> plt.Figure:
     """
     Plot one country's predicted disaster counts against what was observed.
 
@@ -451,7 +451,7 @@ def plot_predicted_counts(idata, df, country: str) -> plt.Figure:
     return fig
 
 
-def attach_damage_predictions(idata, df):
+def attach_damage_predictions(idata: xr.DataTree, df: pd.DataFrame) -> pd.DataFrame:
     """Attach posterior-predictive damage means and HDI bounds to the observed frame.
 
     Parameters
@@ -481,7 +481,7 @@ def attach_damage_predictions(idata, df):
     )
 
 
-def plot_predicted_damages(idata, df: pd.DataFrame, country: str, target_variable: str) -> plt.Figure:
+def plot_predicted_damages(idata: xr.DataTree, df: pd.DataFrame, country: str, target_variable: str) -> plt.Figure:
     """
     Plot one country's predicted damages against what was observed.
 

--- a/climate_risk/plotting.py
+++ b/climate_risk/plotting.py
@@ -347,7 +347,7 @@ def _aligned_prediction_mean(draws, df):
     return predictions.values
 
 
-def generate_plot_inputs(idata, df):
+def attach_count_predictions(idata, df):
     """Attach posterior-predictive means and HDI bounds to the observed frame.
 
     Parameters
@@ -377,8 +377,8 @@ def generate_plot_inputs(idata, df):
     )
 
 
-def plotting_function(idata, df, country: str) -> plt.Figure:
-    df_predictions = generate_plot_inputs(idata=idata, df=df)
+def plot_predicted_counts(idata, df, country: str) -> plt.Figure:
+    df_predictions = attach_count_predictions(idata=idata, df=df)
 
     # Filter country
     data = df_predictions.query("ISO == @country")
@@ -417,7 +417,7 @@ def plotting_function(idata, df, country: str) -> plt.Figure:
 
 
 ############################################ Functions for the damage model  #############################################
-def generate_plot_inputs_damages(idata, df):
+def attach_damage_predictions(idata, df):
     """Attach posterior-predictive damage means and HDI bounds to the observed frame.
 
     Parameters
@@ -447,8 +447,8 @@ def generate_plot_inputs_damages(idata, df):
     )
 
 
-def plotting_function_damages(idata, df: pd.DataFrame, country: str, target_variable: str) -> plt.Figure:
-    df_predictions = generate_plot_inputs_damages(idata=idata, df=df)
+def plot_predicted_damages(idata, df: pd.DataFrame, country: str, target_variable: str) -> plt.Figure:
+    df_predictions = attach_damage_predictions(idata=idata, df=df)
 
     # Filter country
     data = df_predictions.query("ISO == @country")

--- a/climate_risk/plotting.py
+++ b/climate_risk/plotting.py
@@ -163,7 +163,8 @@ def plot_descriptive(
 
     if n_plots == 1:
         fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
-        return _plot_single_kde(df, axis=ax, bins=bins, color=color, add_sum_box=add_sum_box)
+        only = df if isinstance(df, pd.Series) else df.iloc[:, 0]
+        return _plot_single_kde(only, axis=ax, bins=bins, color=color, add_sum_box=add_sum_box)
 
     fig = plt.figure(figsize=figsize, dpi=dpi, **figure_kwargs)
 

--- a/climate_risk/plotting.py
+++ b/climate_risk/plotting.py
@@ -33,23 +33,24 @@ def configure_plot_style(add_grid=False):
 
 
 def prepare_gridspec_figure(n_cols: int, n_plots: int, figure: plt.Figure | None = None) -> tuple[GridSpec, list]:
-    """Prepare a figure with a grid of subplots. Centers the last row of plots if the number of plots is not square.
+    """
+    Lay out a grid of subplots, insetting the last row when it is not full.
 
     Parameters
     ----------
-     n_cols : int
-         The number of columns in the grid.
-     n_plots : int
-         The number of subplots in the grid.
-    figure: plt.Figure, optional
-        Figure on which to plot, passed to GridSpec constructor.
+    n_cols : int
+        Columns in the grid.
+    n_plots : int
+        Subplots to make room for.
+    figure : Figure, optional
+        Figure to attach the layout to. Default None, which leaves it unattached.
 
     Returns
     -------
-     GridSpec
-         A matplotlib GridSpec object representing the layout of the grid.
-    list of tuple(slice, slice)
-         A list of tuples of slices representing the indices of the grid cells to be used for each subplot.
+    gridspec : GridSpec
+        The layout the subplots are cut from.
+    locations : list of tuple of slice
+        Row and column slice for each subplot, in order.
     """
     remainder = n_plots % n_cols
     has_remainder = remainder > 0
@@ -81,23 +82,30 @@ def _plot_single_kde(
     set_title: bool = True,
     add_sum_box: bool = True,
 ):
-    """Plot a single KDE plot on a given axis.
+    """
+    Plot one series as a histogram with a kernel density estimate over it.
 
     Parameters
     ----------
-    data : array_like
-         The data to plot.
-    axis : matplotlib.axes.Axes, optional
-         The axis to plot on. If None, a new figure and axis are created.
+    data : Series
+        Values to plot. Missing values are dropped.
+    axis : Axes, optional
+        Axis to draw on. Default None, which creates a figure and axis.
     bins : int, optional
-        Number of bins to use in the histogram.
+        Histogram bins. Default 30.
     color : str, optional
-        The color of the histogram bars
+        Fill colour of the histogram. Default ``"tab:blue"``.
+    leg_loc : str, optional
+        Where to anchor the summary box. Default ``"upper left"``.
+    set_title : bool, optional
+        Whether to title the axis with the series name. Default True.
+    add_sum_box : bool, optional
+        Whether to annotate with descriptive statistics and a Jarque-Bera statistic. Default True.
 
     Returns
     -------
-     matplotlib.axes.Axes
-         The axis the plot was created on.
+    Axes
+        The axis drawn on.
     """
     data = data.dropna()
     if axis is None:
@@ -136,25 +144,32 @@ def plot_descriptive(
     add_sum_box: bool = True,
     **figure_kwargs,
 ):
-    """Plot a grid of KDE plots for each column in a DataFrame.
+    """
+    Plot one histogram and kernel density estimate per column.
 
     Parameters
     ----------
-    df : pd.DataFrame or pd.Series
-        The data to plot.
+    df : DataFrame or Series
+        Values to plot, one panel per column.
     n_cols : int, optional
-        The number of columns in the grid of plots.
+        Columns in the grid, capped at the number of panels. Default 3.
     bins : int, optional
-        Number of bins to use in the histogram.
+        Histogram bins. Default 30.
     color : str, optional
-        The color of the histogram bars
-    figure_kwargs : dict
-        Additional keyword arguments to pass to plt.figure().
+        Fill colour of the histograms. Default ``"tab:blue"``.
+    leg_loc : str, optional
+        Where to anchor each summary box. Default ``"upper left"``.
+    labels_size : int, optional
+        Point size of the y-axis labels. Default 14.
+    add_sum_box : bool, optional
+        Whether to annotate each panel with descriptive statistics. Default True.
+    **figure_kwargs
+        Passed to :func:`matplotlib.pyplot.figure`.
 
     Returns
     -------
-    fig: matplotlib.figure.Figure
-        The figure the plots were created on.
+    Figure or Axes
+        The figure the panels were drawn on, or the single axis when there is only one column.
     """
     figsize = figure_kwargs.pop("figsize", (14, 4))
     dpi = figure_kwargs.pop("dpi", 144)
@@ -301,21 +316,24 @@ def plot_aggregated_series_by_region(
 
 
 def plot_ppc_loopit(idata: xr.DataTree, target_name: str, title: str | None = None, **ppc_kwargs) -> list[plt.Axes]:
-    """Plot the posterior predictive check (PPC) and the leave-one-out predictive interval (LOO-PIT) for a given target variable.
+    """
+    Plot a posterior predictive check above its LOO-PIT diagnostics, as one figure.
 
     Parameters
     ----------
-    idata : arviz.InferenceData
-        The inference data object containing the posterior samples.
-    title : str
-        The title for the plot.
-    target_name : str, optional
-        The name of the target variable. If None, the first variable in the posterior predictive data is used.
+    idata : DataTree
+        Inference data carrying the posterior predictive samples.
+    target_name : str
+        Variable to check.
+    title : str, optional
+        Heading for the posterior predictive panel. Default None, which uses ``target_name``.
+    **ppc_kwargs
+        Passed to :func:`arviz.plot_ppc`.
 
     Returns
     -------
-    list
-        A list of matplotlib axes objects representing the plot.
+    list of Axes
+        The posterior predictive panel and the two LOO-PIT panels.
     """
     fig = plt.figure(figsize=(12, 9))
     gs = plt.GridSpec(2, 2, figure=fig)
@@ -379,9 +397,25 @@ def attach_count_predictions(idata, df):
 
 
 def plot_predicted_counts(idata, df, country: str) -> plt.Figure:
+    """
+    Plot one country's predicted disaster counts against what was observed.
+
+    Parameters
+    ----------
+    idata : DataTree
+        Inference data carrying a ``posterior_predictive`` group with a ``y_hat`` variable.
+    df : DataFrame
+        The observed frame, in the order the model saw it.
+    country : str
+        ISO 3166-1 alpha-3 code of the country to draw.
+
+    Returns
+    -------
+    Figure
+        Predicted mean, observed counts, and the 50% and 95% HDI bands.
+    """
     df_predictions = attach_count_predictions(idata=idata, df=df)
 
-    # Filter country
     data = df_predictions.query("ISO == @country")
 
     fig, ax = plt.subplots()
@@ -417,7 +451,6 @@ def plot_predicted_counts(idata, df, country: str) -> plt.Figure:
     return fig
 
 
-############################################ Functions for the damage model  #############################################
 def attach_damage_predictions(idata, df):
     """Attach posterior-predictive damage means and HDI bounds to the observed frame.
 
@@ -449,9 +482,27 @@ def attach_damage_predictions(idata, df):
 
 
 def plot_predicted_damages(idata, df: pd.DataFrame, country: str, target_variable: str) -> plt.Figure:
+    """
+    Plot one country's predicted damages against what was observed.
+
+    Parameters
+    ----------
+    idata : DataTree
+        Inference data carrying a ``posterior_predictive`` group with a ``damage_millions`` variable.
+    df : DataFrame
+        The observed frame, in the order the model saw it.
+    country : str
+        ISO 3166-1 alpha-3 code of the country to draw.
+    target_variable : str
+        Column holding the observed damages to plot against.
+
+    Returns
+    -------
+    Figure
+        Predicted mean, observed damages, and the 50% and 75% HDI bands.
+    """
     df_predictions = attach_damage_predictions(idata=idata, df=df)
 
-    # Filter country
     data = df_predictions.query("ISO == @country")
 
     fig, ax = plt.subplots()

--- a/climate_risk/plotting.py
+++ b/climate_risk/plotting.py
@@ -1,4 +1,4 @@
-import math
+from typing import Literal
 
 import arviz as az
 import matplotlib.pyplot as plt
@@ -185,61 +185,118 @@ def plot_descriptive(
     return fig
 
 
-# Aggregated plotting function
-def subplots_function(
-    df,
-    var_list,
-    index,
-    aggregation_funct,
-    title,
-    graph_rows=2,
-    figure_size=(20, 18),
-    subplot_title_fontsize=14,
-):
-    fig, axs = plt.subplots(graph_rows, 2, figsize=figure_size)
+AGGREGATE_COLUMNS = 2
 
-    for x in var_list:
-        a = math.floor(var_list.index(x) / 2)
-        b = var_list.index(x) % 2
-        axs[a, b].plot(df.pivot_table(values=x, index=index, aggfunc=aggregation_funct)[x])
-        axs[a, b].set_title(x, fontsize=subplot_title_fontsize)
+Aggregation = Literal["count", "first", "last", "max", "mean", "median", "min", "nunique", "std", "sum", "var"]
 
-    if (len(var_list) % 2) != 0:
-        axs[graph_rows - 1, 1].set_axis_off()
+
+def plot_aggregated_series(
+    df: pd.DataFrame,
+    variables: list[str],
+    index: str,
+    aggregation: Aggregation,
+    title: str,
+    graph_rows: int = 2,
+    figure_size: tuple[float, float] = (20, 18),
+    subplot_title_fontsize: int = 14,
+) -> plt.Figure:
+    """
+    Plot one variable per panel, each aggregated over ``index``.
+
+    Parameters
+    ----------
+    df : DataFrame
+        The observations to aggregate.
+    variables : list of str
+        Columns to plot, one panel each, filling the grid left to right.
+    index : str
+        Column to aggregate over, which becomes the x axis.
+    aggregation : str
+        How to combine rows sharing an index value, as named in ``Aggregation``.
+    title : str
+        Heading for the figure.
+    graph_rows : int, optional
+        Rows in the grid, which is two columns wide. Default 2.
+    figure_size : tuple of float, optional
+        Figure width and height in inches. Default (20, 18).
+    subplot_title_fontsize : int, optional
+        Point size for each panel's title; the figure heading is ten points larger. Default 14.
+
+    Returns
+    -------
+    Figure
+        The figure the panels were drawn on.
+    """
+    fig, axes = plt.subplots(graph_rows, AGGREGATE_COLUMNS, figsize=figure_size)
+
+    for position, variable in enumerate(variables):
+        axis = axes[position // AGGREGATE_COLUMNS, position % AGGREGATE_COLUMNS]
+        axis.plot(df.pivot_table(values=variable, index=index, aggfunc=aggregation)[variable])
+        axis.set_title(variable, fontsize=subplot_title_fontsize)
+
+    if len(variables) % AGGREGATE_COLUMNS:
+        axes[graph_rows - 1, 1].set_axis_off()
 
     plt.suptitle(title, fontsize=subplot_title_fontsize + 10)
     fig.tight_layout()
 
+    return fig
 
-# Aggregated plotting function for regions
-def subplots_function_regions(
-    df,
-    var_list,
-    index,
-    aggregation_funct,
-    title,
-    graph_rows=2,
-    figure_size=(20, 18),
-    subplot_title_fontsize=14,
-):
-    fig, axs = plt.subplots(graph_rows, 2, figsize=figure_size)
 
-    for x in var_list:
-        a = math.floor(var_list.index(x) / 2)
-        b = var_list.index(x) % 2
-        for y in REGIONS:
-            axs[a, b].plot(
-                df.query(f'Region == "{y}"').pivot_table(values=x, index=index, aggfunc=aggregation_funct),
-                label=y,
-            )
-            axs[a, b].set_title(x, fontsize=subplot_title_fontsize)
-        # axs[a,b].legend()
+def plot_aggregated_series_by_region(
+    df: pd.DataFrame,
+    variables: list[str],
+    index: str,
+    aggregation: Aggregation,
+    title: str,
+    graph_rows: int = 2,
+    figure_size: tuple[float, float] = (20, 18),
+    subplot_title_fontsize: int = 14,
+) -> plt.Figure:
+    """
+    Plot one variable per panel, aggregated over ``index`` and drawn once per region.
 
-    if (len(var_list) % 2) != 0:
-        axs[graph_rows - 1, 1].set_axis_off()
-    fig.legend(REGIONS, loc="lower right", ncol=5, fontsize=16)
+    Parameters
+    ----------
+    df : DataFrame
+        The observations to aggregate, carrying a ``Region`` column.
+    variables : list of str
+        Columns to plot, one panel each, filling the grid left to right.
+    index : str
+        Column to aggregate over, which becomes the x axis.
+    aggregation : str
+        How to combine rows sharing an index value, as named in ``Aggregation``.
+    title : str
+        Heading for the figure.
+    graph_rows : int, optional
+        Rows in the grid, which is two columns wide. Default 2.
+    figure_size : tuple of float, optional
+        Figure width and height in inches. Default (20, 18).
+    subplot_title_fontsize : int, optional
+        Point size for each panel's title; the figure heading is ten points larger. Default 14.
+
+    Returns
+    -------
+    Figure
+        The figure the panels were drawn on.
+    """
+    fig, axes = plt.subplots(graph_rows, AGGREGATE_COLUMNS, figsize=figure_size)
+
+    for position, variable in enumerate(variables):
+        axis = axes[position // AGGREGATE_COLUMNS, position % AGGREGATE_COLUMNS]
+        for region in REGIONS:
+            in_region = df[df["Region"] == region]
+            axis.plot(in_region.pivot_table(values=variable, index=index, aggfunc=aggregation), label=region)
+        axis.set_title(variable, fontsize=subplot_title_fontsize)
+
+    if len(variables) % AGGREGATE_COLUMNS:
+        axes[graph_rows - 1, 1].set_axis_off()
+
+    fig.legend(list(REGIONS), loc="lower right", ncol=len(REGIONS), fontsize=16)
     plt.suptitle(title, fontsize=subplot_title_fontsize + 10)
-    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+
+    return fig
 
 
 def plot_ppc_loopit(idata: xr.DataTree, target_name: str, title: str | None = None, **ppc_kwargs) -> list[plt.Axes]:

--- a/climate_risk/stats/timeseries.py
+++ b/climate_risk/stats/timeseries.py
@@ -1,6 +1,28 @@
 import pandas as pd
 
+from statsmodels.tsa.seasonal import STL
 from statsmodels.tsa.stattools import adfuller
+
+
+def stl_deviation(series: pd.Series, period: int = 3) -> pd.Series:
+    """
+    Return what is left of a series once its STL trend is removed.
+
+    Parameters
+    ----------
+    series : Series
+        The series to detrend, indexed by time.
+    period : int, optional
+        Periodicity of the seasonal component, in observations. Default 3.
+
+    Returns
+    -------
+    Series
+        The series minus its trend, on the same index.
+    """
+    trend = pd.Series(STL(series, period=period).fit().trend, index=series.index)
+
+    return series - trend
 
 
 def make_var_names(var: str, n_lags: int, reg: str) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ files = [
     "climate_risk/exceptions.py",
     "climate_risk/geo",
     "climate_risk/models",
+    "climate_risk/plotting.py",
     "climate_risk/replication_data.py",
     "climate_risk/sample.py",
     "climate_risk/stats",
@@ -187,9 +188,10 @@ warn_unreachable = true
 warn_unused_ignores = true
 strict_equality = true
 
-# None of these four ships stubs, and none exists on the index.
+# These ship no stubs in the package itself. scipy-stubs and types-seaborn exist on the index and
+# would replace two of these entries.
 [[tool.mypy.overrides]]
-module = ["pymc.*", "pytensor.*", "sklearn.*", "statsmodels.*"]
+module = ["arviz.*", "pymc.*", "pytensor.*", "scipy.*", "seaborn.*", "sklearn.*", "statsmodels.*"]
 ignore_missing_imports = true
 
 # Test functions carry no annotations, so their bodies need checking on their own terms.

--- a/tests/stats/test_timeseries.py
+++ b/tests/stats/test_timeseries.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from climate_risk.stats.timeseries import adf_test_summary, make_var_names
+from climate_risk.stats.timeseries import adf_test_summary, make_var_names, stl_deviation
 
 
 @pytest.mark.parametrize(
@@ -23,3 +23,30 @@ def test_missing_data_is_refused_by_default():
     """statsmodels would otherwise return a silent nan for the whole test."""
     with pytest.raises(ValueError, match="missing data"):
         adf_test_summary(pd.DataFrame({"x": [1.0, np.nan, 3.0]}))
+
+
+def test_removing_the_trend_leaves_a_series_with_no_drift():
+    """A rising series detrends to something centred on zero; keeping the trend is the failure."""
+    years = pd.date_range("1990", periods=40, freq="YS")
+    rising = pd.Series(np.arange(40, dtype=float) + np.tile([1.0, -1.0, 0.0, 0.5], 10), index=years)
+
+    residual = stl_deviation(rising)
+
+    assert abs(residual.mean()) < 0.5, "a trend survived the decomposition"
+    assert residual.max() - residual.min() < rising.max() - rising.min()
+
+
+def test_the_deviation_keeps_the_index_it_was_given():
+    """The result is subtracted from and plotted against the original, so a reindex breaks both."""
+    years = pd.date_range("1990", periods=30, freq="YS")
+    series = pd.Series(np.linspace(0.0, 10.0, 30), index=years)
+
+    assert stl_deviation(series).index.equals(series.index)
+
+
+def test_the_period_changes_what_counts_as_trend():
+    """Period is the one modelling choice here, and a default that ignored it would go unnoticed."""
+    years = pd.date_range("1990", periods=48, freq="YS")
+    seasonal = pd.Series(np.tile([2.0, -2.0, 0.0, 1.0], 12) + np.arange(48) * 0.1, index=years)
+
+    assert not stl_deviation(seasonal, period=4).equals(stl_deviation(seasonal, period=3))

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -5,12 +5,12 @@ import xarray as xr
 
 from climate_risk.plotting import (
     REGIONS,
-    generate_plot_inputs,
-    generate_plot_inputs_damages,
+    attach_count_predictions,
+    attach_damage_predictions,
     plot_aggregated_series,
     plot_aggregated_series_by_region,
-    plotting_function,
-    plotting_function_damages,
+    plot_predicted_counts,
+    plot_predicted_damages,
 )
 
 OBSERVATIONS = 4
@@ -47,7 +47,7 @@ def damages_idata():
 
 
 def test_predictions_are_attached_in_row_order(idata, counts):
-    inputs = generate_plot_inputs(idata, counts)
+    inputs = attach_count_predictions(idata, counts)
 
     assert set(counts.columns) <= set(inputs.columns)
     assert inputs["predictions"].is_monotonic_increasing
@@ -55,7 +55,7 @@ def test_predictions_are_attached_in_row_order(idata, counts):
 
 def test_hdi_bounds_bracket_the_prediction(idata, counts):
     """The bands are drawn as fill_between, so an inverted bound silently plots nothing."""
-    inputs = generate_plot_inputs(idata, counts)
+    inputs = attach_count_predictions(idata, counts)
 
     assert (inputs["lower_y_hat_95"] < inputs["predictions"]).all()
     assert (inputs["higher_y_hat_95"] > inputs["predictions"]).all()
@@ -66,18 +66,18 @@ def test_hdi_bounds_bracket_the_prediction(idata, counts):
 def test_a_frame_of_the_wrong_length_is_rejected(idata, counts):
     """Aligning by position means a mismatched frame would otherwise plot the wrong country."""
     with pytest.raises(ValueError, match="observations but df has"):
-        generate_plot_inputs(idata, counts.iloc[:2])
+        attach_count_predictions(idata, counts.iloc[:2])
 
 
 def test_plotting_one_country_draws_only_its_observations(idata, counts):
-    fig = plotting_function(idata, counts, "AAA")
+    fig = plot_predicted_counts(idata, counts, "AAA")
 
     predicted_line = fig.axes[0].lines[0]
     assert len(np.asarray(predicted_line.get_xdata())) == 2
 
 
 def test_damage_bounds_bracket_the_prediction(damages_idata, damages):
-    inputs = generate_plot_inputs_damages(damages_idata, damages)
+    inputs = attach_damage_predictions(damages_idata, damages)
 
     assert (inputs["lower_damage_75"] < inputs["predictions"]).all()
     assert (inputs["higher_damage_75"] > inputs["predictions"]).all()
@@ -86,7 +86,7 @@ def test_damage_bounds_bracket_the_prediction(damages_idata, damages):
 
 
 def test_plotting_damages_draws_only_one_country(damages_idata, damages):
-    fig = plotting_function_damages(damages_idata, damages, "AAA", "damage_millions")
+    fig = plot_predicted_damages(damages_idata, damages, "AAA", "damage_millions")
 
     observed_points = fig.axes[0].collections[0]
     assert len(np.asarray(observed_points.get_offsets())) == 2

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -8,11 +8,13 @@ from climate_risk.plotting import (
     REGIONS,
     attach_count_predictions,
     attach_damage_predictions,
+    configure_plot_style,
     plot_aggregated_series,
     plot_aggregated_series_by_region,
     plot_descriptive,
     plot_predicted_counts,
     plot_predicted_damages,
+    prepare_gridspec_figure,
 )
 
 OBSERVATIONS = 4
@@ -132,6 +134,31 @@ def test_every_region_is_drawn_on_each_panel():
     assert all(len(axis.get_lines()) == len(REGIONS) for axis in panels)
 
 
+def test_the_grid_centres_a_short_last_row():
+    """Five plots in three columns leaves two on the bottom row; left-aligning them looks broken."""
+    _, locations = prepare_gridspec_figure(n_cols=3, n_plots=5)
+
+    assert len(locations) == 5
+    last_row_columns = [columns.start for _, columns in locations[3:]]
+    assert last_row_columns == [1, 3], "the short row should be inset, not flush left"
+
+
+def test_the_grid_is_exact_when_the_plots_fill_it():
+    _, locations = prepare_gridspec_figure(n_cols=3, n_plots=6)
+
+    assert len(locations) == 6
+    assert [columns.start for _, columns in locations[:3]] == [0, 2, 4]
+
+
+def test_configuring_the_style_turns_the_grid_on_and_off():
+    """Every notebook opens with this call, and a silently ignored argument is invisible."""
+    configure_plot_style(add_grid=True)
+    assert plt.rcParams["axes.grid"] is True
+
+    configure_plot_style()
+    assert plt.rcParams["axes.grid"] is False
+
+
 def test_a_single_column_frame_plots_without_unwrapping_it_first():
     """A one-column DataFrame took the single-panel branch and reached `data.name`, which a frame
     does not have, so every caller with one variable raised AttributeError."""
@@ -141,3 +168,12 @@ def test_a_single_column_frame_plots_without_unwrapping_it_first():
 
     assert isinstance(axis, plt.Axes), "one column returns the axis, not the figure"
     assert axis.get_title() == "only"
+
+
+def test_one_panel_is_drawn_per_column():
+    df = pd.DataFrame({name: np.linspace(0.0, 1.0, 40) for name in ("a", "b", "c")})
+
+    fig = plot_descriptive(df, add_sum_box=False)
+
+    assert isinstance(fig, plt.Figure), "several columns return the figure, not an axis"
+    assert [axis.get_title() for axis in fig.axes] == ["a", "b", "c"]

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -9,6 +10,7 @@ from climate_risk.plotting import (
     attach_damage_predictions,
     plot_aggregated_series,
     plot_aggregated_series_by_region,
+    plot_descriptive,
     plot_predicted_counts,
     plot_predicted_damages,
 )
@@ -128,3 +130,14 @@ def test_every_region_is_drawn_on_each_panel():
     panels = [axis for axis in fig.axes if axis.get_title()]
     assert [axis.get_title() for axis in panels] == ["a", "b"]
     assert all(len(axis.get_lines()) == len(REGIONS) for axis in panels)
+
+
+def test_a_single_column_frame_plots_without_unwrapping_it_first():
+    """A one-column DataFrame took the single-panel branch and reached `data.name`, which a frame
+    does not have, so every caller with one variable raised AttributeError."""
+    df = pd.DataFrame({"only": np.linspace(0.0, 1.0, 40)})
+
+    axis = plot_descriptive(df, add_sum_box=False)
+
+    assert isinstance(axis, plt.Axes), "one column returns the axis, not the figure"
+    assert axis.get_title() == "only"

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -4,8 +4,11 @@ import pytest
 import xarray as xr
 
 from climate_risk.plotting import (
+    REGIONS,
     generate_plot_inputs,
     generate_plot_inputs_damages,
+    plot_aggregated_series,
+    plot_aggregated_series_by_region,
     plotting_function,
     plotting_function_damages,
 )
@@ -87,3 +90,41 @@ def test_plotting_damages_draws_only_one_country(damages_idata, damages):
 
     observed_points = fig.axes[0].collections[0]
     assert len(np.asarray(observed_points.get_offsets())) == 2
+
+
+def test_each_variable_lands_on_its_own_panel():
+    """Panels are filled by position; the previous index lookup sent duplicate names to one axis."""
+    df = pd.DataFrame({"year": [1990, 1991] * 3, "a": range(6), "b": range(6), "c": range(6)})
+
+    fig = plot_aggregated_series(df, ["a", "b", "c"], index="year", aggregation="mean", title="t")
+
+    drawn = [axis.get_title() for axis in fig.axes if axis.get_title()]
+    assert drawn == ["a", "b", "c"]
+
+
+def test_an_odd_number_of_variables_blanks_the_spare_panel():
+    """A grid is two wide, so an odd count leaves an empty axis that would otherwise show as blank
+    ticks and a frame."""
+    df = pd.DataFrame({"year": [1990, 1991] * 3, "a": range(6), "b": range(6), "c": range(6)})
+
+    fig = plot_aggregated_series(df, ["a", "b", "c"], index="year", aggregation="mean", title="t")
+
+    assert not fig.axes[3].axison
+
+
+def test_every_region_is_drawn_on_each_panel():
+    """One line per region per variable; a mis-scoped loop silently plots only the last region."""
+    df = pd.DataFrame(
+        {
+            "year": [1990, 1991] * len(REGIONS),
+            "Region": [region for region in REGIONS for _ in range(2)],
+            "a": range(2 * len(REGIONS)),
+            "b": range(2 * len(REGIONS)),
+        }
+    )
+
+    fig = plot_aggregated_series_by_region(df, ["a", "b"], index="year", aggregation="mean", title="t")
+
+    panels = [axis for axis in fig.axes if axis.get_title()]
+    assert [axis.get_title() for axis in panels] == ["a", "b"]
+    assert all(len(axis.get_lines()) == len(REGIONS) for axis in panels)


### PR DESCRIPTION
`plotting.py` was the only module outside mypy's include list, with four of its twelve functions tested. It's now typed, checked and covered — which turned up two bugs on the way: variables sharing a name collided on one panel because the position came from `list.index()`, and a single-column DataFrame raised `AttributeError` in `plot_descriptive`. Six functions got names that say what they draw.

Also lifts `stl_deviation` into `stats/timeseries.py`, the one notebook helper clean enough to move as it stood.
