### PR TITLE
Add the cell-to-unit aggregation operator for the geo model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,7 @@ notebooks/final_paper/data/
 *.ncdf
 *.nc
 *idata
-models/
+/models/
 
 # Ignore archive
 notebooks/geo_damage_model/archive

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import numpy as np
 import pytensor.tensor as pt
 
+from pytensor.tensor import TensorVariable
 from scipy import sparse
 
 from climate_risk.exceptions import DataValidationError
@@ -11,18 +12,15 @@ from climate_risk.exceptions import DataValidationError
 
 @dataclass(frozen=True, slots=True)
 class Aggregation:
-    """
+    r"""
     The linear operator taking a cell-level field to the polygon totals it is observed through.
 
-    A polygon's total is :math:`\\sum_{i \\in A} w_i \\lambda_i`, so aggregation is a sparse matrix
-    product. It is stored as its coordinate triplet rather than as a matrix because the symbolic
-    path is a scatter-add over those indices: a scipy matrix cannot multiply a pytensor variable,
-    and expressing the sum with :func:`pytensor.tensor.inc_subtensor` avoids depending on how well
-    any given compilation backend covers sparse ops.
+    .. math::
 
-    Holding the operator and its row labels together is the point of the class: the model reads
-    totals by position, and a row order that silently disagrees with the observation order
-    attributes every polygon's events to the wrong place.
+        y_A = \sum_{i \in A} w_i \lambda_i
+
+    ``units`` fixes the row order, which the model reads by position: it must agree with the order
+    the observations arrive in.
 
     Parameters
     ----------
@@ -38,6 +36,7 @@ class Aggregation:
         Width of the operator, counting cells that contribute to no unit.
     """
 
+    # The triplet is primary because a scipy matrix cannot multiply a pytensor variable.
     units: tuple[str, ...]
     rows: np.ndarray
     columns: np.ndarray
@@ -78,12 +77,11 @@ class Aggregation:
 
         return np.asarray(self.matrix @ cell_values)
 
-    def aggregate_symbolic(self, cell_values: pt.TensorVariable) -> pt.TensorVariable:
+    def aggregate_symbolic(self, cell_values: TensorVariable) -> TensorVariable:
         """
         Sum a cell-level field to unit totals, as a graph.
 
-        The scatter-add accumulates over repeated row indices, so a unit collects every cell
-        assigned to it, and the gradient with respect to ``cell_values`` is the cell's weight.
+        Cells sharing a unit accumulate, and the reverse pass is the operator's transpose.
 
         Parameters
         ----------
@@ -97,7 +95,7 @@ class Aggregation:
         """
         contributions = pt.as_tensor_variable(self.weights) * cell_values[self.columns]
 
-        totals: pt.TensorVariable = pt.inc_subtensor(pt.zeros((self.n_units,))[self.rows], contributions)
+        totals: TensorVariable = pt.inc_subtensor(pt.zeros((self.n_units,))[self.rows], contributions)
 
         return totals
 

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -1,0 +1,164 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+import pytensor.tensor as pt
+
+from scipy import sparse
+
+from climate_risk.exceptions import DataValidationError
+
+
+@dataclass(frozen=True, slots=True)
+class Aggregation:
+    """
+    The linear operator taking a cell-level field to the polygon totals it is observed through.
+
+    A polygon's total is :math:`\\sum_{i \\in A} w_i \\lambda_i`, so aggregation is a sparse matrix
+    product. It is stored as its coordinate triplet rather than as a matrix because the symbolic
+    path is a scatter-add over those indices: a scipy matrix cannot multiply a pytensor variable,
+    and expressing the sum with :func:`pytensor.tensor.inc_subtensor` avoids depending on how well
+    any given compilation backend covers sparse ops.
+
+    Holding the operator and its row labels together is the point of the class: the model reads
+    totals by position, and a row order that silently disagrees with the observation order
+    attributes every polygon's events to the wrong place.
+
+    Parameters
+    ----------
+    units : tuple of str
+        Unit labels, in row order.
+    rows : ndarray
+        Unit index of each contributing cell, one entry per nonzero.
+    columns : ndarray
+        Cell index of each contributing cell, one entry per nonzero.
+    weights : ndarray
+        Weight of each contributing cell, one entry per nonzero.
+    n_cells : int
+        Width of the operator, counting cells that contribute to no unit.
+    """
+
+    units: tuple[str, ...]
+    rows: np.ndarray
+    columns: np.ndarray
+    weights: np.ndarray
+    n_cells: int
+
+    @property
+    def n_units(self) -> int:
+        """Rows of the operator, and the length of an aggregated vector."""
+        return len(self.units)
+
+    @property
+    def matrix(self) -> sparse.csr_array:
+        """The operator as a sparse matrix, shape ``(n_units, n_cells)``."""
+        return sparse.csr_array(
+            (self.weights, (self.rows, self.columns)),
+            shape=(self.n_units, self.n_cells),
+        )
+
+    def aggregate(self, cell_values: np.ndarray) -> np.ndarray:
+        """
+        Sum a cell-level field to unit totals, outside a graph.
+
+        Use this on drawn or observed arrays. Inside a model, use :meth:`aggregate_symbolic`.
+
+        Parameters
+        ----------
+        cell_values : ndarray
+            Shape ``(n_cells,)`` for one field, or ``(n_cells, k)`` to aggregate ``k`` of them at
+            once, which is how posterior draws are carried through.
+
+        Returns
+        -------
+        ndarray
+            Shape ``(n_units,)`` or ``(n_units, k)``, in the row order of ``units``.
+        """
+        self._check_width(cell_values.shape[0])
+
+        return np.asarray(self.matrix @ cell_values)
+
+    def aggregate_symbolic(self, cell_values: pt.TensorVariable) -> pt.TensorVariable:
+        """
+        Sum a cell-level field to unit totals, as a graph.
+
+        The scatter-add accumulates over repeated row indices, so a unit collects every cell
+        assigned to it, and the gradient with respect to ``cell_values`` is the cell's weight.
+
+        Parameters
+        ----------
+        cell_values : TensorVariable
+            Shape ``(n_cells,)``.
+
+        Returns
+        -------
+        TensorVariable
+            Shape ``(n_units,)``, in the row order of ``units``.
+        """
+        contributions = pt.as_tensor_variable(self.weights) * cell_values[self.columns]
+
+        totals: pt.TensorVariable = pt.inc_subtensor(pt.zeros((self.n_units,))[self.rows], contributions)
+
+        return totals
+
+    def _check_width(self, width: int) -> None:
+        if width != self.n_cells:
+            raise DataValidationError(f"The field has {width} cells but the operator was built for {self.n_cells}.")
+
+
+def build_aggregation(
+    *,
+    unit_of_cell: Sequence[str | None],
+    weights: np.ndarray,
+    units: Sequence[str] | None = None,
+) -> Aggregation:
+    """
+    Build the cell-to-unit aggregation operator.
+
+    Parameters
+    ----------
+    unit_of_cell : sequence of str or None
+        The unit each cell belongs to. ``None`` marks a cell inside the gridded extent but outside
+        every unit, which is dropped: it contributes to no total.
+    weights : ndarray
+        Each cell's weight in its unit, one per entry of ``unit_of_cell``. Cell area gives an
+        integral over the polygon; population gives an exposure-weighted one.
+    units : sequence of str, optional
+        Row order of the operator. Every assigned label must appear. Default None, which orders the
+        labels that appear in ``unit_of_cell``, sorted.
+
+    Returns
+    -------
+    Aggregation
+        The operator and its row labels.
+    """
+    weights = np.asarray(weights, dtype=float)
+    if len(unit_of_cell) != weights.shape[0]:
+        raise DataValidationError(
+            f"{len(unit_of_cell)} cell assignments against {weights.shape[0]} weights; they index the same cells."
+        )
+
+    if not np.all(np.isfinite(weights)):
+        raise DataValidationError("Cell weights carry a non-finite value, which would poison every total it enters.")
+
+    if np.any(weights < 0.0):
+        raise DataValidationError("Cell weights are negative, so a polygon's total would not be a sum of parts.")
+
+    assigned = np.array([label is not None for label in unit_of_cell], dtype=bool)
+    labels = [label for label in unit_of_cell if label is not None]
+
+    if units is None:
+        units = sorted(set(labels))
+
+    row_of_unit = {unit: row for row, unit in enumerate(units)}
+    unknown = sorted(set(labels) - row_of_unit.keys())
+    if unknown:
+        raise DataValidationError(f"Cells are assigned to units absent from the row order: {unknown}.")
+
+    return Aggregation(
+        units=tuple(units),
+        rows=np.array([row_of_unit[label] for label in labels], dtype=int),
+        columns=np.flatnonzero(assigned),
+        weights=weights[assigned],
+        n_cells=weights.shape[0],
+    )

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -122,8 +123,8 @@ def build_aggregation(
         Each cell's weight in its unit, one per entry of ``unit_of_cell``. Cell area gives an
         integral over the polygon; population gives an exposure-weighted one.
     units : sequence of str, optional
-        Row order of the operator. Every assigned label must appear. Default None, which orders the
-        labels that appear in ``unit_of_cell``, sorted.
+        Row order of the operator. Every assigned label must appear, and no label twice. Default
+        None, which orders the labels that appear in ``unit_of_cell``, sorted.
 
     Returns
     -------
@@ -147,6 +148,11 @@ def build_aggregation(
 
     if units is None:
         units = sorted(set(labels))
+
+    counts = Counter(units)
+    repeated = sorted(unit for unit, count in counts.items() if count > 1)
+    if repeated:
+        raise DataValidationError(f"The row order repeats units, so their rows would not be reachable: {repeated}.")
 
     row_of_unit = {unit: row for row, unit in enumerate(units)}
     unknown = sorted(set(labels) - row_of_unit.keys())

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -146,6 +146,13 @@ def build_aggregation(
     assigned = np.array([label is not None for label in unit_of_cell], dtype=bool)
     labels = [label for label in unit_of_cell if label is not None]
 
+    non_strings = sorted({type(label).__name__ for label in labels if not isinstance(label, str)})
+    if non_strings:
+        raise DataValidationError(
+            f"Cell assignments carry non-string labels ({', '.join(non_strings)}). A spatial join marks a cell it "
+            f"matched to nothing with NaN; mark it with None instead, which is what drops it."
+        )
+
     if units is None:
         units = sorted(set(labels))
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -220,12 +220,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-25.0.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-25.0.0-py312h2054cf2_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.13.0-py312hdb6ebaa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py312hbc8341d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py312h50ac2ff_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.2.4-py312hec6e119_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.2.4-np2py312h0f77346_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.3.0-py312h8e2dda0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.3.0-np2py312h0f77346_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.13.0-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
@@ -280,13 +279,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.2.0-pyh8e99733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.2.0-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/better-optimize-0.4.2-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
@@ -350,11 +347,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/preliz-0.27.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.2.0-hfd44b2b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.2.0-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-extras-0.14.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.3.1-h13dcb8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.3.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytensor-distributions-0.2.0-pyhc364b38_0.conda
@@ -383,7 +378,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-shapely-2.1.0.20260402-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-tqdm-4.70.0.20260731-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
@@ -397,17 +391,21 @@ environments:
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.2.0-pyh8e99733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.2.0-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/better-optimize-0.4.2-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
@@ -471,11 +469,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/preliz-0.27.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.2.0-hfd44b2b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.2.0-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-extras-0.14.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.3.1-h13dcb8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.3.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytensor-distributions-0.2.0-pyhc364b38_0.conda
@@ -503,7 +499,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-shapely-2.1.0.20260402-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-tqdm-4.70.0.20260731-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
@@ -698,11 +693,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-25.0.0-py312h1f38498_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-25.0.0-py312h7d9569a_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py312hb9d4441_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.13.0-py312hd1c4548_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py312h2a764c1_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.2.4-py312he07d2cc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.2.4-np2py312h60fbb24_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.3.0-py312h3f311c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.3.0-np2py312h60fbb24_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.13.0-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
@@ -733,9 +727,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   notebooks:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -803,8 +803,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.3-h95f0039_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
@@ -930,8 +928,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2026.0.0-ha770c72_915.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2026.0.0-hf2ce2f3_915.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-service-2.7.2-py312h9241c41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py312h0a2e395_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-2.3.0-py312h574c966_0.conda
@@ -960,12 +956,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-25.0.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-25.0.0-py312h2054cf2_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.13.0-py312hdb6ebaa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py312hbc8341d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py312h50ac2ff_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.2.4-py312hec6e119_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.2.4-np2py312h0f77346_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.3.0-py312h8e2dda0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.3.0-np2py312h0f77346_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.13.0-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
@@ -1023,7 +1018,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1037,7 +1031,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/better-optimize-0.4.2-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
@@ -1069,7 +1062,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geconpy-2.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.4-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
@@ -1119,7 +1111,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -1154,11 +1145,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.2.0-hfd44b2b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.2.0-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-extras-0.14.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.3.1-h13dcb8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.3.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytensor-distributions-0.2.0-pyhc364b38_0.conda
@@ -1187,8 +1176,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sympytensor-2.0.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -1203,7 +1190,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-shapely-2.1.0.20260402-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-tqdm-4.70.0.20260731-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
@@ -1224,15 +1210,24 @@ environments:
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/a3/68451ecf694c78b076741ace807673fe4e8723656cc14618e9aa2700973c/geconpy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/62/ae/5b30e13eb0132f3a3e753eb49680a41862e0bcde3948d96ac199c4f7d832/sympytensor-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/31/a2cf4619eb6863cb7d7b28c1e7641a3f6c222cb7cee881decf32815bc17d/nbclassic_mcp_bridge-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
@@ -1247,7 +1242,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/better-optimize-0.4.2-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
@@ -1281,7 +1275,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geconpy-2.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.4-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
@@ -1329,7 +1322,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
@@ -1364,11 +1356,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.2.0-hfd44b2b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.2.0-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-extras-0.14.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.3.1-h13dcb8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.3.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytensor-distributions-0.2.0-pyhc364b38_0.conda
@@ -1397,8 +1387,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sympytensor-2.0.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
@@ -1412,7 +1400,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-shapely-2.1.0.20260402-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-tqdm-4.70.0.20260731-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
@@ -1490,8 +1477,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.3-h5f197ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-h6f9ecc1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.3.0-py312he1ee7cc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py312h090f823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-14.1.2-hec8c438_0.conda
@@ -1593,8 +1578,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.11.1-py312hf2eba6f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.1-py312h07c8dfe_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.2.2-hdb7fadc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py312h3093aea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/muparser-2.3.5-h11e0b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-2.3.0-py312h939899b_0.conda
@@ -1621,13 +1604,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-25.0.0-py312h1f38498_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-25.0.0-py312h7d9569a_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py312hb9d4441_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.2.1-py312h55b240b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.1-py312h22cf174_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.13.0-py312hd1c4548_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py312h2a764c1_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.2.4-py312he07d2cc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.2.4-np2py312h60fbb24_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.3.0-py312h3f311c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.3.0-np2py312h60fbb24_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.13.0-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
@@ -1662,12 +1644,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/34/a3/68451ecf694c78b076741ace807673fe4e8723656cc14618e9aa2700973c/geconpy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/ae/5b30e13eb0132f3a3e753eb49680a41862e0bcde3948d96ac199c4f7d832/sympytensor-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/31/a2cf4619eb6863cb7d7b28c1e7641a3f6c222cb7cee881decf32815bc17d/nbclassic_mcp_bridge-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
   build_number: 7
@@ -2676,37 +2668,6 @@ packages:
     - glog >=0.7.1,<0.8.0a0
   size: 149031
   timestamp: 1784094370091
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
-  md5: c94a5994ef49749880a8139cf9afcbe1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  purls: []
-  run_exports:
-    weak:
-    - gmp >=6.3.0,<7.0a0
-  size: 460055
-  timestamp: 1718980856608
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
-  sha256: 6fbdd686d04a0d8c48efe92795137d3bba55a4325acd7931978fd8ea5e24684d
-  md5: fedbe80d864debab03541e1b447fc12a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gmp >=6.3.0,<7.0a0
-  - libgcc >=14
-  - mpc >=1.3.1,<2.0a0
-  - mpfr >=4.2.1,<5.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls:
-  - pkg:pypi/gmpy2?source=hash-mapping
-  run_exports: {}
-  size: 253171
-  timestamp: 1773245116314
 - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
   sha256: 3f962b2cbdc2aac3089a5c708477657266c0a665f0eed09981a34d1ab6793065
   md5: 68f704ea294dcec9e09edd9c3d233846
@@ -4859,37 +4820,6 @@ packages:
   run_exports: {}
   size: 76674
   timestamp: 1778548057387
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
-  sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
-  md5: 770d00bf57b5599c4544d61b61d8c6c6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gmp >=6.3.0,<7.0a0
-  - libgcc >=14
-  - mpfr >=4.2.2,<5.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls: []
-  run_exports:
-    weak:
-    - mpc >=1.4.0,<2.0a0
-  size: 100245
-  timestamp: 1774472435333
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-  sha256: 8690f550a780f75d9c47f7ffc15f5ff1c149d36ac17208e50eda101ca16611b9
-  md5: 85ce2ffa51ab21da5efa4a9edc5946aa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gmp >=6.3.0,<7.0a0
-  - libgcc >=14
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  run_exports:
-    weak:
-    - mpfr >=4.2.2,<5.0a0
-  size: 730422
-  timestamp: 1773413915171
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py312h0a2e395_1.conda
   sha256: c9764c77dd7f9c581c1d8a24c3024edf777cacfb5a4180de5badc6638dc8590f
   md5: a142257c1b69e37cfefc66dc228a4d93
@@ -5445,24 +5375,6 @@ packages:
   run_exports: {}
   size: 5395858
   timestamp: 1784258391353
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py312h868fb18_0.conda
-  sha256: b8260660d064fb947f4b573ec4a782696bc8b19042452eaa4e9bb1152b540555
-  md5: dfb9a57535eb8c35c6744da7043063f0
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pydantic-core?source=hash-mapping
-  run_exports: {}
-  size: 1895409
-  timestamp: 1778084226169
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.13.0-py312hdb6ebaa_0.conda
   sha256: 99e8fdd42f008ef9e955690efd1790a1182ae5d2eb48e8d8da6f6a1e59bd2899
   md5: 0b2a0e17bd514b53e2d12b8ac16225ae
@@ -5527,24 +5439,25 @@ packages:
   run_exports: {}
   size: 13797566
   timestamp: 1778933891067
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.2.4-py312hec6e119_0.conda
-  sha256: 7093e4fce2f4dd35f20f735e0579c21c2d6c57b0e501f523457b9a3354ec625d
-  md5: 9b4da13b594fb4935fab74ddacd9744f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.3.0-py312h8e2dda0_0.conda
+  sha256: 98970a675c3382e4562eed07c481c639eee885294534b41b735b20ca7138a1cf
+  md5: 93b298b67b92ceb175b37d9892b80101
   depends:
   - python
-  - pytensor-base ==3.2.4 np2py312h0f77346_0
+  - pytensor-base ==3.3.0 np2py312h0f77346_0
   - gxx
   - blas * mkl
   - mkl-service
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
+  license_family: BSD
   purls: []
   run_exports: {}
-  size: 10852
-  timestamp: 1785675942368
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.2.4-np2py312h0f77346_0.conda
-  sha256: bf31c1c8d884249ad228e59d093db5231f8d46d17631ed9b98f2345838cd4188
-  md5: dd56bc5c9fe2fd817607533539d872d0
+  size: 10750
+  timestamp: 1786614346232
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.3.0-np2py312h0f77346_0.conda
+  sha256: 1cd0997e3a0c309ba4aff48baa167e734e3482773264316f3f327bf597b80a7a
+  md5: 56188925edf21f1dd0915b4b9761fb52
   depends:
   - python
   - setuptools >=59.0.0
@@ -5552,17 +5465,18 @@ packages:
   - numpy >=2.0
   - numba >=0.58,<=0.66.0
   - filelock >=3.15
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.25,<3
+  - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.25,<3
   license: BSD-3-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/pytensor?source=hash-mapping
   run_exports: {}
-  size: 3049463
-  timestamp: 1785675942368
+  size: 3083404
+  timestamp: 1786614346232
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
   sha256: a44655c1c3e1d43ed8704890a91e12afd68130414ea2c0872e154e5633a13d7e
   md5: 7eccb41177e15cc672e1babe9056018e
@@ -6537,19 +6451,6 @@ packages:
   run_exports: {}
   size: 631452
   timestamp: 1758743294412
-- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
-  sha256: b8fcb994134d3918d1c64a9d62f4168ff85d5bfb89e698102fe4ed679fe0df24
-  md5: 108c928d2a8551832dbc762b535e90bb
-  depends:
-  - python >=3.10
-  - typing-extensions >=4.0.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/annotated-types?source=hash-mapping
-  run_exports: {}
-  size: 19461
-  timestamp: 1784935220549
 - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
   sha256: e36998c5e860e26b22e5dbcd5726dd0c4eabad949c84d383cad8512757bbf6a1
   md5: fb568fbae6908ba86a090a85a089d11f
@@ -6762,24 +6663,6 @@ packages:
   run_exports: {}
   size: 92704
   timestamp: 1780853175566
-- conda: https://conda.anaconda.org/conda-forge/noarch/better-optimize-0.4.2-pyhc455866_0.conda
-  sha256: 333dec92c76a4452668b6e5cb1a72aad07f0786e73a0ce346087db6cc066b928
-  md5: 89c64895ca762300994bd0cdf669f426
-  depends:
-  - joblib
-  - numpy
-  - pandas
-  - python >=3.12
-  - rich
-  - scipy >=1.15
-  - threadpoolctl
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/better-optimize?source=hash-mapping
-  run_exports: {}
-  size: 38866
-  timestamp: 1779544225828
 - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
   sha256: 0c786f3e571bd58ac73d730d06314716663884d848ae320de0b438fae5e0bea9
   md5: 93009c29cdd6f2500468f2502fff9209
@@ -7177,35 +7060,6 @@ packages:
   run_exports: {}
   size: 16705
   timestamp: 1733327494780
-- conda: https://conda.anaconda.org/conda-forge/noarch/geconpy-2.2.0-pyhc364b38_0.conda
-  sha256: 42262cdad92f2aefa9a9e8047556f3e16282b7e6584552c7c64eec9b9515b6d8
-  md5: 1e53c195b376bb364418bd515bc2489f
-  depends:
-  - python >=3.12
-  - better-optimize >=0.2.1
-  - matplotlib-base
-  - networkx
-  - numba
-  - numpy
-  - pandas
-  - pymc >=6.0.0
-  - pymc-extras >=0.11.0
-  - preliz >=0.23.0
-  - pyparsing
-  - pytensor >=3.0.0
-  - scipy
-  - sympy >=1.14.0
-  - sympytensor >=2.0.0
-  - ipython
-  - xarray
-  - python
-  license: GPL-3.0-only
-  license_family: GPL
-  purls:
-  - pkg:pypi/geconpy?source=hash-mapping
-  run_exports: {}
-  size: 244793
-  timestamp: 1780546590807
 - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.4-pyhd8ed1ab_0.conda
   sha256: cd478c0835106afce2478d6dcc525854219c4e710c7b446e2dd5042bfc9da082
   md5: 99d77e0f92f7b0b977f77cfb49c7eaf6
@@ -8011,18 +7865,6 @@ packages:
   run_exports: {}
   size: 93811
   timestamp: 1784722859728
-- conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
-  sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
-  md5: 3585aa87c43ab15b167b574cd73b057b
-  depends:
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/mpmath?source=hash-mapping
-  run_exports: {}
-  size: 439705
-  timestamp: 1733302781386
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -8524,23 +8366,6 @@ packages:
   run_exports: {}
   size: 55886
   timestamp: 1779293633166
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-  sha256: 69700e31165df070e9716315e042196aa92525dae5deb5107785847ab9f4189f
-  md5: 729843edafc0899b3348bd3f19525b9d
-  depends:
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  - python >=3.10
-  - annotated-types >=0.6.0
-  - pydantic-core ==2.46.4
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pydantic?source=hash-mapping
-  run_exports: {}
-  size: 346511
-  timestamp: 1778103405862
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
   sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
   md5: 16c18772b340887160c79a6acc022db0
@@ -8553,22 +8378,21 @@ packages:
   run_exports: {}
   size: 893031
   timestamp: 1774796815820
-- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.2.0-hfd44b2b_0.conda
-  sha256: b9b52b1799aa1f59a29dc1355d1f5ca62f602223becec7cb316d21f2dc807e5a
-  md5: bcd8e84edd6e84598f7cb7858a1891af
+- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-6.3.1-h13dcb8a_0.conda
+  sha256: 8926342c041abe24d8584ca3fb6bd2059b5b07c16a15a4b0a009f391282b8e8b
+  md5: 308492dc43b0d4d142783f1d1d6a3a48
   depends:
-  - pymc-base ==6.2.0 pyhc364b38_0
+  - pymc-base ==6.3.1 pyhc364b38_0
   - pytensor
   - python-graphviz
   license: Apache-2.0
-  license_family: APACHE
   purls: []
   run_exports: {}
-  size: 10380
-  timestamp: 1784825040451
-- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.2.0-pyhc364b38_0.conda
-  sha256: ef8c872cfa4b6d055cbeea46c3808592a87bb5167d261304916c3e2af5bcdbd5
-  md5: 0474966b3d83c45e9401625c996621f7
+  size: 10381
+  timestamp: 1786881579022
+- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.3.1-pyhc364b38_0.conda
+  sha256: 1164bc1e9d5bc098d9a2850d34c30e7e90f3f340058fc8d019e4b6aeac6e0574
+  md5: efd3cb76ffcdb10c76a9acada47d2159
   depends:
   - python >=3.12
   - arviz >=1.1.0,<2.0
@@ -8576,38 +8400,18 @@ packages:
   - cloudpickle
   - numpy >=1.25.0
   - pandas >=0.24.0
-  - pytensor-base >=3.2.2,<3.3
+  - pytensor-base >=3.2.2,<3.4
   - rich >=13.7.1
   - scipy >=1.4.1
   - threadpoolctl >=3.1.0,<4.0.0
   - typing_extensions >=3.7.4
   - python
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/pymc?source=hash-mapping
   run_exports: {}
-  size: 424391
-  timestamp: 1784825040451
-- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-extras-0.14.0-pyhc364b38_0.conda
-  sha256: 18b531f5cd1cbcaae83c3849dbe8d07ddf7e40783c06f02b56c37c491cc33a1d
-  md5: 4625542109cce9437f64bfbf0839eb16
-  depends:
-  - python >=3.12
-  - pymc >=6.2.0,<6.3
-  - arviz >=1.2,<2.0
-  - better-optimize >=0.4.2,<1.0
-  - pydantic >=2.0.0,<3.0
-  - preliz >=0.27.0,<0.28.0
-  - pytensor >=3.2.3,<3.3
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/pymc-extras?source=hash-mapping
-  run_exports: {}
-  size: 244717
-  timestamp: 1785326233082
+  size: 430767
+  timestamp: 1786881579022
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
   sha256: 417fba4783e528ee732afa82999300859b065dc59927344b4859c64aae7182de
   md5: 3687cc0b82a8b4c17e1f0eb7e47163d5
@@ -9018,38 +8822,6 @@ packages:
   run_exports: {}
   size: 26988
   timestamp: 1733569565672
-- conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
-  sha256: 1c8057e6875eba958aa8b3c1a072dc9a75d013f209c26fd8125a5ebd3abbec0c
-  md5: 32d866e43b25275f61566b9391ccb7b5
-  depends:
-  - __unix
-  - cpython
-  - gmpy2 >=2.0.8
-  - mpmath >=1.1.0,<1.5
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/sympy?source=hash-mapping
-  run_exports: {}
-  size: 4661767
-  timestamp: 1771952371059
-- conda: https://conda.anaconda.org/conda-forge/noarch/sympytensor-2.0.1-pyhc455866_0.conda
-  sha256: 3f21836d3a08ab98f7db574cc6eb781d1f6ca75e8208fb9da9157b2d2562f724
-  md5: ad692d65fc6cf95d3f890dd145253a20
-  depends:
-  - mpmath >=1.1.0,<1.4.0
-  - pymc
-  - pytensor >=2.37.0
-  - python >=3.12
-  - sympy
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/sympytensor?source=hash-mapping
-  run_exports: {}
-  size: 21802
-  timestamp: 1778876127660
 - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
   sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
   md5: 13dc3adbc692664cd3beabd216434749
@@ -9240,20 +9012,6 @@ packages:
   run_exports: {}
   size: 94080
   timestamp: 1783002732887
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
-  sha256: 8b90d2f19f9458b8c58a55e1fcdc1d90c1603a847a47654d8a454549413ba60a
-  md5: 53f5409c5cfd6c5a66417d68e3f0a864
-  depends:
-  - python >=3.10
-  - typing_extensions >=4.12.0
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/typing-inspection?source=hash-mapping
-  run_exports: {}
-  size: 20935
-  timestamp: 1777105465795
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
   sha256: 2d888f90af0686044882c74193ec80a90ec1943145d94a7b1b048958acda1848
   md5: c70ad746c22219b9700931707482992c
@@ -10467,37 +10225,6 @@ packages:
     - glog >=0.7.1,<0.8.0a0
   size: 112670
   timestamp: 1784094909098
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
-  md5: eed7278dfbab727b56f2c0b64330814b
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  purls: []
-  run_exports:
-    weak:
-    - gmp >=6.3.0,<7.0a0
-  size: 365188
-  timestamp: 1718981343258
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.3.0-py312he1ee7cc_1.conda
-  sha256: 5f30afd0ef54b4744eb61f71a5ccc9965d9b07830cecc0db9dc6ce73f39b05c4
-  md5: bd0f515e01326c13cc81424233ac7b18
-  depends:
-  - __osx >=11.0
-  - gmp >=6.3.0,<7.0a0
-  - mpc >=1.3.1,<2.0a0
-  - mpfr >=4.2.1,<5.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls:
-  - pkg:pypi/gmpy2?source=hash-mapping
-  run_exports: {}
-  size: 194024
-  timestamp: 1773245811244
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py312h090f823_1.conda
   sha256: cf6c1345d2c4fb4cee1128256d3a1d3fe5150c8788bc6cad12a04cbfc44bb247
   md5: 0c8ad601cdbec3be85d1c62080b388d7
@@ -12245,35 +11972,6 @@ packages:
     - minizip >=4.2.2,<5.0a0
   size: 462323
   timestamp: 1782852375098
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
-  sha256: a9774664adea222e4165efddcd902641c03c7d08fda3a83a5b0885e675ead309
-  md5: 2845c3a1d0d8da1db92aba8323892475
-  depends:
-  - __osx >=11.0
-  - gmp >=6.3.0,<7.0a0
-  - mpfr >=4.2.2,<5.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls: []
-  run_exports:
-    weak:
-    - mpc >=1.4.0,<2.0a0
-  size: 86181
-  timestamp: 1774472395307
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-  sha256: af5eca85f7ffdd403275e916f1de40a7d4b48ae138f12479523d9500c6a073ba
-  md5: a47a14da2103c9c7a390f7c8bc8d7f9b
-  depends:
-  - __osx >=11.0
-  - gmp >=6.3.0,<7.0a0
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  run_exports:
-    weak:
-    - mpfr >=4.2.2,<5.0a0
-  size: 348767
-  timestamp: 1773414111071
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py312h3093aea_1.conda
   sha256: 1ace9b344734fda6d8c84d02c3efbf106fe68a90b6dfdb49cd46009f58e831ee
   md5: bcab4615e2f53affe6b34fc8887b3f12
@@ -12787,24 +12485,6 @@ packages:
   run_exports: {}
   size: 4371556
   timestamp: 1784258363255
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py312hb9d4441_0.conda
-  sha256: 480b10f3197270a98c2b564670ca6e201bc57b5005e9d58fd0d232338fd33ad7
-  md5: e38d54c5e4318faa79f71b713b059566
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - python 3.12.* *_cpython
-  - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pydantic-core?source=hash-mapping
-  run_exports: {}
-  size: 1720774
-  timestamp: 1778084314791
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.2.1-py312h55b240b_0.conda
   sha256: c69e1e2c7277d4704adf4c6e46e9c231db4a9f6de6c39a5f500b21be8705c97b
   md5: c0ce814629aa18f83303246068ec41d2
@@ -12874,23 +12554,24 @@ packages:
   run_exports: {}
   size: 515651
   timestamp: 1773003243277
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.2.4-py312he07d2cc_0.conda
-  sha256: cf583d38b71ac8d7a473082b9720ea31bc53545842d7123d359622539a28aa23
-  md5: fef07eecb9da355a92f6a39dce3d9ff7
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.3.0-py312h3f311c3_0.conda
+  sha256: 898b3a9b16d453b9c96b2e09bcdf24f7eb4f4b72ea1015a205e250c45a1fc2d9
+  md5: 77dfb441e47f180a2ce765aac1d606f9
   depends:
   - python
-  - pytensor-base ==3.2.4 np2py312h60fbb24_0
+  - pytensor-base ==3.3.0 np2py312h60fbb24_0
   - clangxx
   - blas * *accelerate
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
+  license_family: BSD
   purls: []
   run_exports: {}
-  size: 9406
-  timestamp: 1785676010705
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.2.4-np2py312h60fbb24_0.conda
-  sha256: f2dbb3947b8c5405099cbfae3eba7215d62d7d7ef37201ff56d25179bffd9961
-  md5: db052c4bfbc2cc311001680a85c9d853
+  size: 9399
+  timestamp: 1786614453497
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.3.0-np2py312h60fbb24_0.conda
+  sha256: 61cc87ffb16eb0c6b06020187de556c4b9b0a9a7fe47ed0a2907ac9a56cd9dcc
+  md5: 8916657c5a9914742fc1536b172b1666
   depends:
   - python
   - setuptools >=59.0.0
@@ -12898,17 +12579,18 @@ packages:
   - numpy >=2.0
   - numba >=0.58,<=0.66.0
   - filelock >=3.15
+  - python 3.12.* *_cpython
   - libcxx >=19
   - __osx >=11.0
-  - python 3.12.* *_cpython
-  - python_abi 3.12.* *_cp312
   - numpy >=1.25,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/pytensor?source=hash-mapping
   run_exports: {}
-  size: 3046572
-  timestamp: 1785676010705
+  size: 3080339
+  timestamp: 1786614453497
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
   sha256: e658e647a4a15981573d6018928dec2c448b10c77c557c29872043ff23c0eb6a
   md5: 8e7608172fa4d1b90de9a745c2fd2b81
@@ -13426,8 +13108,8 @@ packages:
   - pandas>=3.0,<4
   - preliz>=0.27.1,<1
   - pymc-extras>=0.14.0,<1
-  - pymc>=6.2,<7
-  - pytensor>=3.2,<4
+  - pymc>=6.3,<7
+  - pytensor>=3.3,<4
   - requests>=2.34,<3
   - scikit-learn>=1.9,<2
   - scipy>=1.18,<2
@@ -13471,6 +13153,57 @@ packages:
   version: 1.9.0
   sha256: 7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
+  name: pydantic-core
+  version: 2.46.4
+  sha256: 962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f
+  requires_dist:
+  - typing-extensions>=4.14.1
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/34/a3/68451ecf694c78b076741ace807673fe4e8723656cc14618e9aa2700973c/geconpy-2.2.0-py3-none-any.whl
+  name: geconpy
+  version: 2.2.0
+  sha256: 45e84708110630486e6cf473d41396a8775fb019bdb6aae178dcf4424c2dd846
+  requires_dist:
+  - better-optimize>=0.2.1
+  - ipython
+  - matplotlib
+  - networkx
+  - numba
+  - numpy
+  - pandas
+  - preliz>=0.23.0
+  - pymc-extras>=0.11.0
+  - pymc>=6.0.0
+  - pyparsing
+  - pytensor>=3.0.0
+  - scipy
+  - setuptools
+  - sympy>=1.14.0
+  - sympytensor>=2.0.0
+  - xarray
+  - asv ; extra == 'dev'
+  - numdifftools ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-benchmark ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - versioneer ; extra == 'dev'
+  - ipython ; extra == 'docs'
+  - jupyter-sphinx ; extra == 'docs'
+  - myst-nb ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - pre-commit ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx-codeautolink ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-design ; extra == 'docs'
+  - sphinx-notfound-page ; extra == 'docs'
+  - sphinx-sitemap ; extra == 'docs'
+  - sphinx>=5 ; extra == 'docs'
+  - sphinxcontrib-bibtex ; extra == 'docs'
+  - watermark ; extra == 'docs'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
   name: joblib-stubs
   version: 1.5.3.1.20260117
@@ -13481,6 +13214,70 @@ packages:
   - mypy==1.19.1 ; extra == 'mypy-strict'
   - mypy>=1.19.1 ; extra == 'mypy-strict'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+  name: mpmath
+  version: 1.3.0
+  sha256: a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
+  requires_dist:
+  - pytest>=4.6 ; extra == 'develop'
+  - pycodestyle ; extra == 'develop'
+  - pytest-cov ; extra == 'develop'
+  - codecov ; extra == 'develop'
+  - wheel ; extra == 'develop'
+  - sphinx ; extra == 'docs'
+  - gmpy2>=2.1.0a4 ; platform_python_implementation != 'PyPy' and extra == 'gmpy'
+  - pytest>=4.6 ; extra == 'tests'
+- pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
+  name: pymc-extras
+  version: 0.14.0
+  sha256: 86f68e4f6120c43f92cc713af48c6f73051786f2021f1d28b4902b2c9587da30
+  requires_dist:
+  - arviz>=1.2,<2.0
+  - better-optimize>=0.4.2,<1.0
+  - preliz>=0.27.0,<0.28.0
+  - pydantic>=2.0.0,<3.0
+  - pymc>=6.2.0,<6.3
+  - pytensor>=3.2.3,<3.3
+  - dask[complete]<2025.1.1 ; extra == 'complete'
+  - xhistogram ; extra == 'complete'
+  - dask[complete]<2025.1.1 ; extra == 'dask-histogram'
+  - xhistogram ; extra == 'dask-histogram'
+  - blackjax>=0.12,<2.0 ; extra == 'dev'
+  - dask[all]<2025.1.1 ; extra == 'dev'
+  - pytest>=6.0,<10.0 ; extra == 'dev'
+  - statsmodels ; extra == 'dev'
+  - nbsphinx>=0.4.2,<1.0 ; extra == 'docs'
+  - pymc-sphinx-theme>=0.16,<1.0 ; extra == 'docs'
+  - sphinx>=4.0,<10.0 ; extra == 'docs'
+  - xhistogram ; extra == 'histogram'
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: pydantic-core
+  version: 2.46.4
+  sha256: 926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce
+  requires_dist:
+  - typing-extensions>=4.14.1
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/62/ae/5b30e13eb0132f3a3e753eb49680a41862e0bcde3948d96ac199c4f7d832/sympytensor-2.1.0-py3-none-any.whl
+  name: sympytensor
+  version: 2.1.0
+  sha256: cb22f266dac19749b72bfeb181543e7f9d43bfaf9fe7c472f16ddd887bc51bf0
+  requires_dist:
+  - pymc>=6.2.0,<7.0.0
+  - pytensor>=3.2.4,<4.0.0
+  - sympy>=1.14.0
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - ruff==0.16.1 ; extra == 'dev'
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+  name: typing-inspection
+  version: 0.4.4
+  sha256: 65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147
+  requires_dist:
+  - typing-extensions>=4.15.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
   name: lxml
   version: 6.1.1
@@ -13522,11 +13319,40 @@ packages:
   version: 0.16.0
   sha256: 5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+  name: annotated-types
+  version: 0.8.0
+  sha256: f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+  name: sympy
+  version: 1.14.0
+  sha256: e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5
+  requires_dist:
+  - mpmath>=1.1.0,<1.4
+  - pytest>=7.1.0 ; extra == 'dev'
+  - hypothesis>=6.70.0 ; extra == 'dev'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: jiter
   version: 0.16.0
   sha256: 46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
+  name: better-optimize
+  version: 0.4.2
+  sha256: 6618ad973e32af160521581ce8978aba95c607458dd40931925ddeeddbb291e9
+  requires_dist:
+  - numpy
+  - scipy>=1.15
+  - rich
+  - threadpoolctl
+  - joblib
+  - pandas
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pre-commit ; extra == 'tests'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/e8/31/a2cf4619eb6863cb7d7b28c1e7641a3f6c222cb7cee881decf32815bc17d/nbclassic_mcp_bridge-1.1.0-py3-none-any.whl
   name: nbclassic-mcp-bridge
   version: 1.1.0
@@ -13576,3 +13402,15 @@ packages:
   - pyarrow ; extra == 'polars'
   - pyarrow ; extra == 'pyarrow'
   requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
+  name: pydantic
+  version: 2.13.4
+  sha256: 45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba
+  requires_dist:
+  - annotated-types>=0.6.0
+  - pydantic-core==2.46.4
+  - typing-extensions>=4.14.1
+  - typing-inspection>=0.4.2
+  - email-validator>=2.0.0 ; extra == 'email'
+  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
+  requires_python: '>=3.9'

--- a/pixi.lock
+++ b/pixi.lock
@@ -395,6 +395,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a6/2a4426d03f78bfb2f0d205dfa07a81728f9a03c2d7cc3ee1bfad5c238646/ptgp-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
@@ -733,6 +734,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a6/2a4426d03f78bfb2f0d205dfa07a81728f9a03c2d7cc3ee1bfad5c238646/ptgp-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
@@ -1221,6 +1223,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a6/2a4426d03f78bfb2f0d205dfa07a81728f9a03c2d7cc3ee1bfad5c238646/ptgp-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/31/a2cf4619eb6863cb7d7b28c1e7641a3f6c222cb7cee881decf32815bc17d/nbclassic_mcp_bridge-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
@@ -1656,6 +1659,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a6/2a4426d03f78bfb2f0d205dfa07a81728f9a03c2d7cc3ee1bfad5c238646/ptgp-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/31/a2cf4619eb6863cb7d7b28c1e7641a3f6c222cb7cee881decf32815bc17d/nbclassic_mcp_bridge-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/56/ff1348a6965a603e854059574b36d9f3466ce201b0cecf6b52d4f957d86e/kuznets-1.0.1-py3-none-any.whl
@@ -13107,6 +13111,7 @@ packages:
   - openpyxl>=3.1,<4
   - pandas>=3.0,<4
   - preliz>=0.27.1,<1
+  - ptgp>=0.1.2,<1
   - pymc-extras>=0.14.0,<1
   - pymc>=6.3,<7
   - pytensor>=3.3,<4
@@ -13338,6 +13343,19 @@ packages:
   version: 0.16.0
   sha256: 46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ce/a6/2a4426d03f78bfb2f0d205dfa07a81728f9a03c2d7cc3ee1bfad5c238646/ptgp-0.1.2-py3-none-any.whl
+  name: ptgp
+  version: 0.1.2
+  sha256: 35c3ce44bc8ec9393e7d633f093505a713d5d4dc7c29a9019b627a24ed2e3491
+  requires_dist:
+  - numpy
+  - pymc>=6.2.0,<6.3
+  - pytensor>=3.2.3,<3.3
+  - mypy ; extra == 'dev'
+  - polars ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/e1/be/cb8b5a47fa80cfc7ab98e32c46422d6f1269e2a3a2c1ca37e3f97ad4cb98/better_optimize-0.4.2-py3-none-any.whl
   name: better-optimize
   version: 0.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     "fastexcel>=0.20,<1",
     "kuznets[polars]>=1.0.1,<2",
     "geopandas>=1.1,<2",
-    "pymc>=6.2,<7",
-    "pytensor>=3.2,<4",
+    "pymc>=6.3,<7",
+    "pytensor>=3.3,<4",
     "arviz>=1.2,<2",
     "nutpie>=0.16,<1",
     "pymc-extras>=0.14.0,<1",
@@ -88,11 +88,10 @@ h5netcdf = ">=1.6,<2"
 openpyxl = ">=3.1,<4"
 xlrd = ">=2.0,<3"
 geopandas = ">=1.1,<2"
-pymc = ">=6.2,<7"
-pytensor = ">=3.2,<4"
+pymc = ">=6.3,<7"
+pytensor = ">=3.3,<4"
 arviz = ">=1.2,<2"
 nutpie = ">=0.16,<1"
-pymc-extras = ">=0.14.0,<1"
 preliz = ">=0.27.1,<1"
 scikit-learn = ">=1.9,<2"
 statsmodels = ">=0.14,<1"
@@ -126,14 +125,21 @@ joblib-stubs = ">=1.5.3.1,<2"
 notebook = ">=7.6,<8"
 ipywidgets = ">=8.1,<9"
 nbclassic = ">=1.3.3,<2"
-geconpy = ">=2.2,<3"
 
-# nbclassic-mcp-bridge is not on conda-forge.
+# nbclassic-mcp-bridge is not on conda-forge. gEconpy is, but its conda build depends on
+# pymc-extras, which would put that back in the conda solve and re-impose its caps.
 [tool.pixi.feature.notebooks.pypi-dependencies]
 nbclassic-mcp-bridge = ">=1.1.0,<2"
+geconpy = ">=2.2,<3"
+
+# pymc-extras caps pytensor and pymc at the minor it was built against. The caps are
+# defensive, so it is resolved from PyPI where the overrides below can relax them.
+[tool.pixi.pypi-options]
+dependency-overrides = { pytensor = ">=3.3,<4", pymc = ">=6.3,<7" }
 
 [tool.pixi.pypi-dependencies]
 climate-risk = { path = ".", editable = true }
+pymc-extras = ">=0.14.0,<1"
 
 [tool.pixi.environments]
 default = { features = ["dev"], solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "arviz>=1.2,<2",
     "nutpie>=0.16,<1",
     "pymc-extras>=0.14.0,<1",
+    "ptgp>=0.1.2,<1",
     "preliz>=0.27.1,<1",
     "scikit-learn>=1.9,<2",
     "statsmodels>=0.14,<1",
@@ -140,6 +141,7 @@ dependency-overrides = { pytensor = ">=3.3,<4", pymc = ">=6.3,<7" }
 [tool.pixi.pypi-dependencies]
 climate-risk = { path = ".", editable = true }
 pymc-extras = ">=0.14.0,<1"
+ptgp = ">=0.1.2,<1"
 
 [tool.pixi.environments]
 default = { features = ["dev"], solve-group = "default" }

--- a/tests/models/test_aggregation.py
+++ b/tests/models/test_aggregation.py
@@ -217,6 +217,14 @@ def test_a_unit_absent_from_the_row_order_is_named():
         build_aggregation(unit_of_cell=["a", "ghost"], weights=np.ones(2), units=["a"])
 
 
+def test_a_nan_assignment_is_rejected_by_name():
+    """A spatial join marks a cell it matched to nothing with NaN rather than None, and NaN is not
+    None, so it would otherwise be taken for a real unit label.
+    """
+    with pytest.raises(DataValidationError, match="None"):
+        build_aggregation(unit_of_cell=["a", np.nan, "b"], weights=np.ones(3))  # type: ignore[list-item]
+
+
 def test_a_repeated_unit_in_the_row_order_is_rejected():
     """A duplicated label makes the row lookup last-wins, which leaves the earlier row permanently
     zero and shifts that unit's total onto a row the caller thinks belongs to something else. A

--- a/tests/models/test_aggregation.py
+++ b/tests/models/test_aggregation.py
@@ -90,6 +90,23 @@ def test_a_cell_outside_every_unit_contributes_to_nothing():
     assert aggregation.matrix.sum() == pytest.approx(2.0)
 
 
+def test_a_grid_that_misses_every_unit_gives_an_empty_operator():
+    """A bounding box can miss the geometries altogether: an all-sea tile, or a place whose
+    polygons failed to load. Both paths have to return no rows rather than raise, so the caller
+    sees an empty result instead of a traceback from inside the operator. The field is still the
+    full width, so aggregating one of the right length must not trip the width check.
+    """
+    aggregation = build_aggregation(unit_of_cell=[None, None], weights=np.ones(2))
+    field = np.array([1.0, 2.0])
+
+    cells = pt.vector("cells")
+    symbolic = pytensor.function([cells], aggregation.aggregate_symbolic(cells))
+
+    assert aggregation.units == ()
+    assert aggregation.aggregate(field).shape == (0,)
+    assert symbolic(field).shape == (0,)
+
+
 def test_draws_aggregate_columnwise():
     """Posterior draws come through as (n_cells, n_draws), and each column is its own field."""
     aggregation = build_aggregation(unit_of_cell=["a", "a", "b"], weights=np.ones(3))

--- a/tests/models/test_aggregation.py
+++ b/tests/models/test_aggregation.py
@@ -217,6 +217,15 @@ def test_a_unit_absent_from_the_row_order_is_named():
         build_aggregation(unit_of_cell=["a", "ghost"], weights=np.ones(2), units=["a"])
 
 
+def test_a_repeated_unit_in_the_row_order_is_rejected():
+    """A duplicated label makes the row lookup last-wins, which leaves the earlier row permanently
+    zero and shifts that unit's total onto a row the caller thinks belongs to something else. A
+    repeated gid in an upstream geometry table is an ordinary way to arrive here.
+    """
+    with pytest.raises(DataValidationError, match="repeats units"):
+        build_aggregation(unit_of_cell=["a", "b"], weights=np.ones(2), units=["a", "a", "b"])
+
+
 def test_mismatched_assignments_and_weights_are_rejected():
     with pytest.raises(DataValidationError, match="same cells"):
         build_aggregation(unit_of_cell=["a", "b"], weights=np.ones(3))

--- a/tests/models/test_aggregation.py
+++ b/tests/models/test_aggregation.py
@@ -1,0 +1,228 @@
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.models.aggregation import build_aggregation
+
+# A unit square split into a left and a right half, so both units have a known analytic integral.
+SPLIT = 0.5
+
+
+def square_grid(cells_per_axis: int):
+    """Cell centroids and areas for a regular grid over the unit square, split into two units."""
+    edges = np.linspace(0.0, 1.0, cells_per_axis + 1)
+    centres = (edges[:-1] + edges[1:]) / 2.0
+    x, y = (axis.ravel() for axis in np.meshgrid(centres, centres, indexing="ij"))
+
+    area = (1.0 / cells_per_axis) ** 2
+    unit_of_cell = ["left" if position < SPLIT else "right" for position in x]
+
+    return x, y, np.full(x.shape, area), unit_of_cell
+
+
+def integrate_plane(a: float, b: float, c: float, x0: float, x1: float, y0: float, y1: float) -> float:
+    """The exact integral of ``a + b*x + c*y`` over a rectangle."""
+    return a * (x1 - x0) * (y1 - y0) + b * (x1**2 - x0**2) / 2.0 * (y1 - y0) + c * (y1**2 - y0**2) / 2.0 * (x1 - x0)
+
+
+def test_a_plane_integrates_exactly():
+    """The midpoint rule is exact for a linear field, so this pins the operator against a closed
+    form rather than against a tolerance. An error in the weights or the row order shows up here.
+    """
+    a, b, c = 2.0, 3.0, -1.5
+    x, y, areas, unit_of_cell = square_grid(cells_per_axis=8)
+
+    aggregation = build_aggregation(unit_of_cell=unit_of_cell, weights=areas)
+    totals = aggregation.aggregate(a + b * x + c * y)
+
+    assert aggregation.units == ("left", "right")
+    assert totals == pytest.approx(
+        [
+            integrate_plane(a, b, c, 0.0, SPLIT, 0.0, 1.0),
+            integrate_plane(a, b, c, SPLIT, 1.0, 0.0, 1.0),
+        ]
+    )
+
+
+def test_refining_the_grid_converges_on_a_curved_field():
+    """A sinusoid is not integrated exactly by the midpoint rule, so the claim is convergence.
+    A fixed tolerance would pass on an operator that is wrong by a constant factor.
+    """
+    # Integral of sin(pi x) sin(pi y) over the unit square, which separates into (2 / pi) squared.
+    exact = 4.0 / np.pi**2
+
+    errors = []
+    for cells_per_axis in (8, 32):
+        x, y, areas, unit_of_cell = square_grid(cells_per_axis)
+        aggregation = build_aggregation(unit_of_cell=unit_of_cell, weights=areas)
+        totals = aggregation.aggregate(np.sin(np.pi * x) * np.sin(np.pi * y))
+        errors.append(abs(totals.sum() - exact))
+
+    assert errors[1] < errors[0] / 10.0, errors
+
+
+def test_weights_place_each_cell_in_exactly_one_unit():
+    """Every cell's weight appears once in the operator, so the column sums are the weights back.
+    A cell double-counted into two units inflates one polygon's total and is invisible in a
+    row-wise check.
+    """
+    _, _, areas, unit_of_cell = square_grid(cells_per_axis=6)
+
+    aggregation = build_aggregation(unit_of_cell=unit_of_cell, weights=areas)
+
+    assert np.asarray(aggregation.matrix.sum(axis=0)) == pytest.approx(areas)
+
+
+def test_a_cell_outside_every_unit_contributes_to_nothing():
+    """The gridded extent is a bounding box, so cells over the sea or a neighbouring country are
+    normal. They must drop out rather than join whichever unit is nearest.
+    """
+    aggregation = build_aggregation(
+        unit_of_cell=["left", None, "right"],
+        weights=np.array([1.0, 99.0, 1.0]),
+    )
+
+    totals = aggregation.aggregate(np.array([1.0, 1.0, 1.0]))
+
+    assert totals == pytest.approx([1.0, 1.0])
+    assert aggregation.matrix.sum() == pytest.approx(2.0)
+
+
+def test_draws_aggregate_columnwise():
+    """Posterior draws come through as (n_cells, n_draws), and each column is its own field."""
+    aggregation = build_aggregation(unit_of_cell=["a", "a", "b"], weights=np.ones(3))
+
+    totals = aggregation.aggregate(np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]]))
+
+    np.testing.assert_allclose(totals, [[3.0, 30.0], [3.0, 30.0]])
+
+
+def test_the_symbolic_path_integrates_the_plane_exactly():
+    """The graph is a scatter-add over index arrays while the array path is a sparse matrix
+    product, so they are two implementations of one operator. Pinning the graph against the same
+    closed form as :func:`test_a_plane_integrates_exactly` checks it on its own terms rather than
+    checking that the two agree, which they would if a shared index array were wrong.
+    """
+    a, b, c = 2.0, 3.0, -1.5
+    x, y, areas, unit_of_cell = square_grid(cells_per_axis=8)
+
+    aggregation = build_aggregation(unit_of_cell=unit_of_cell, weights=areas)
+    cells = pt.vector("cells")
+    totals = pytensor.function([cells], aggregation.aggregate_symbolic(cells))(a + b * x + c * y)
+
+    assert totals == pytest.approx(
+        [
+            integrate_plane(a, b, c, 0.0, SPLIT, 0.0, 1.0),
+            integrate_plane(a, b, c, SPLIT, 1.0, 0.0, 1.0),
+        ]
+    )
+
+
+def test_the_symbolic_path_handles_repeats_gaps_and_empty_units():
+    """The scatter-add has to accumulate over cells sharing a unit, skip cells assigned to none,
+    and leave an empty unit's row at zero. A plain assignment rather than an increment would keep
+    only the last cell of each unit and pass a test where every unit holds one cell.
+    """
+    aggregation = build_aggregation(
+        unit_of_cell=["b", "a", None, "b", "a"],
+        weights=np.array([1.5, 2.0, 99.0, 0.5, 3.0]),
+        units=["a", "empty", "b"],
+    )
+    field = np.array([1.0, 2.0, 7.0, 3.0, 4.0])
+
+    cells = pt.vector("cells")
+    totals = pytensor.function([cells], aggregation.aggregate_symbolic(cells))(field)
+
+    assert totals == pytest.approx([16.0, 0.0, 3.0])
+
+
+def test_the_symbolic_gradient_is_the_operator_transpose():
+    """The model differentiates through this, and a gather paired with the wrong scatter can give
+    the right totals with the wrong sensitivities. The operator is linear, so its Jacobian is the
+    matrix itself and the reverse pass is exactly its transpose.
+    """
+    _, _, areas, unit_of_cell = square_grid(cells_per_axis=4)
+    aggregation = build_aggregation(unit_of_cell=unit_of_cell, weights=areas)
+
+    cotangent = np.array([2.0, -3.0])
+    cells = pt.vector("cells")
+    seeded = pt.sum(aggregation.aggregate_symbolic(cells) * pt.as_tensor_variable(cotangent))
+    pullback = pytensor.function([cells], pt.grad(seeded, cells))
+
+    np.testing.assert_allclose(pullback(np.zeros_like(areas)), aggregation.matrix.T @ cotangent)
+
+
+def test_the_default_row_order_is_sorted():
+    """Sorted, not first-appearance: a caller joining totals back to a sorted unit table would get
+    silently transposed rows if the default followed the order the cells happened to arrive in.
+    """
+    aggregation = build_aggregation(unit_of_cell=["b", "a"], weights=np.array([1.0, 2.0]))
+
+    assert aggregation.units == ("a", "b")
+    assert aggregation.aggregate(np.array([10.0, 20.0])) == pytest.approx([40.0, 10.0])
+
+
+def test_the_row_order_can_be_given():
+    """The model reads totals by position, so the caller has to be able to fix the order rather
+    than depend on the sort of whatever labels happened to appear.
+    """
+    aggregation = build_aggregation(
+        unit_of_cell=["b", "a"],
+        weights=np.ones(2),
+        units=["b", "a"],
+    )
+
+    assert aggregation.units == ("b", "a")
+    assert aggregation.aggregate(np.array([1.0, 2.0])) == pytest.approx([1.0, 2.0])
+
+
+def test_a_unit_with_no_cells_keeps_its_row():
+    """A polygon smaller than a cell is real, and its row is all zeros. Dropping the row instead
+    would shift every later unit up one and misalign the observations.
+    """
+    aggregation = build_aggregation(
+        unit_of_cell=["a", "a"],
+        weights=np.ones(2),
+        units=["a", "empty", "b"],
+    )
+
+    totals = aggregation.aggregate(np.array([1.0, 1.0]))
+
+    assert aggregation.units == ("a", "empty", "b")
+    assert totals == pytest.approx([2.0, 0.0, 0.0])
+
+
+def test_a_unit_absent_from_the_row_order_is_named():
+    """Silently dropping the cells of an unlisted unit would lose part of the field with no sign."""
+    with pytest.raises(DataValidationError, match="ghost"):
+        build_aggregation(unit_of_cell=["a", "ghost"], weights=np.ones(2), units=["a"])
+
+
+def test_mismatched_assignments_and_weights_are_rejected():
+    with pytest.raises(DataValidationError, match="same cells"):
+        build_aggregation(unit_of_cell=["a", "b"], weights=np.ones(3))
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf])
+def test_a_non_finite_weight_is_rejected(bad):
+    """One NaN weight silently turns a polygon's total into NaN and the fit into a wall of errors
+    a long way from the cause.
+    """
+    with pytest.raises(DataValidationError, match="non-finite"):
+        build_aggregation(unit_of_cell=["a", "b"], weights=np.array([1.0, bad]))
+
+
+def test_a_negative_weight_is_rejected():
+    with pytest.raises(DataValidationError, match="negative"):
+        build_aggregation(unit_of_cell=["a", "b"], weights=np.array([1.0, -1.0]))
+
+
+def test_a_field_of_the_wrong_length_is_rejected():
+    """The operator is built once and applied many times, so a mismatch here means the cell table
+    changed underneath it."""
+    aggregation = build_aggregation(unit_of_cell=["a", "b"], weights=np.ones(2))
+
+    with pytest.raises(DataValidationError, match="built for 2"):
+        aggregation.aggregate(np.ones(3))


### PR DESCRIPTION
First piece of the areal disaster model: the linear operator that sums a raster field to the polygon totals events are actually observed at.

pymc-extras and ptgp both cap pytensor below 3.3 and pymc below 6.3, so both resolve from PyPI now and `dependency-overrides` relaxes the caps. The caps are defensive rather than real — I ran an SVGP ELBO and its gradient on the new versions before overriding them, clean on both backends. gEconpy moved to PyPI for the same reason: its conda build pulls pymc-extras back into the conda solve, where the overrides can't reach.
