### PR TITLE
Add the aggregated Poisson objective for polygon counts

### DIFF
--- a/climate_risk/models/aggregated_poisson.py
+++ b/climate_risk/models/aggregated_poisson.py
@@ -1,0 +1,202 @@
+import numpy as np
+import pytensor.tensor as pt
+
+from ptgp.gp import SVGP
+from pytensor import shared
+from pytensor.tensor import TensorVariable
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.models.aggregation import Aggregation
+
+
+def latent_moments(svgp: SVGP, cell_features: TensorVariable) -> tuple[TensorVariable, TensorVariable, TensorVariable]:
+    r"""
+    Posterior mean and covariance factors of the latent field at the raster cells.
+
+    The posterior covariance is :math:`\mathrm{diag}(d) + B B^T`, dropping the off-diagonal of the
+    Nyström residual as the marginal path does. ``predict_marginal`` assembles the diagonal and
+    discards the factors, so both are recomputed here.
+
+    Parameters
+    ----------
+    svgp : SVGP
+        A whitened ptgp SVGP. The unwhitened parameterization is not supported.
+    cell_features : TensorVariable
+        Shape ``(n_cells, n_features)``.
+
+    Returns
+    -------
+    mean : TensorVariable
+        Shape ``(n_cells,)``.
+    independent_variance : TensorVariable
+        Shape ``(n_cells,)``, the prior variance the inducing points do not explain.
+    factor : TensorVariable
+        Shape ``(n_cells, n_inducing)``, the variational covariance factor.
+    """
+    if not svgp.whiten:
+        raise DataValidationError("The aggregated objective is derived for a whitened SVGP.")
+
+    inducing, kernel = svgp.inducing_variable, svgp.kernel
+    cross = inducing.K_uf(kernel, cell_features)
+    whitened = inducing.Kuu_sqrt_solve(kernel, cross)
+
+    mean = whitened.T @ svgp.q_mu + svgp.mean(cell_features)
+    independent_variance = kernel.diag(cell_features) - pt.sum(whitened**2, axis=0)
+    factor = whitened.T @ svgp.q_sqrt
+
+    return mean, independent_variance, factor
+
+
+def expected_intensity(
+    aggregation: Aggregation,
+    mean: TensorVariable,
+    independent_variance: TensorVariable,
+    factor: TensorVariable,
+) -> TensorVariable:
+    r"""
+    :math:`\mathbb{E}_q[\Lambda_A]` for :math:`\Lambda_A = \sum_{i \in A} w_i e^{f_i}`.
+
+    Exact, and needs only the marginal variances: the expectation of a sum does not see the
+    correlation between cells.
+
+    Parameters
+    ----------
+    aggregation : Aggregation
+        The cell-to-unit operator.
+    mean : TensorVariable
+        Shape ``(n_cells,)``.
+    independent_variance : TensorVariable
+        Shape ``(n_cells,)``.
+    factor : TensorVariable
+        Shape ``(n_cells, n_inducing)``.
+
+    Returns
+    -------
+    TensorVariable
+        Shape ``(n_units,)``.
+    """
+    variance = independent_variance + pt.sum(factor**2, axis=1)
+    log_scaled = mean + variance / 2.0
+
+    shift = pt.max(log_scaled)
+
+    expected: TensorVariable = aggregation.aggregate_symbolic(pt.exp(log_scaled - shift)) * pt.exp(shift)
+
+    return expected
+
+
+def sample_log_intensity(
+    aggregation: Aggregation,
+    mean: TensorVariable,
+    independent_variance: TensorVariable,
+    factor: TensorVariable,
+    inducing_draws: np.ndarray | TensorVariable,
+    cell_draws: np.ndarray | TensorVariable,
+) -> TensorVariable:
+    r"""
+    :math:`\log \Lambda_A` at each of a fixed set of draws from the variational posterior.
+
+    :math:`\mathbb{E}_q[\log \Lambda_A]` has no closed form, and a sum over cells is not a function
+    of any one marginal, so it is estimated by sampling the field. The draws are reparameterized
+    through :math:`f = m + B \varepsilon + \sqrt{d}\,\eta`, which is exact for the factored
+    covariance and puts the sampling noise outside the gradient.
+
+    The draw matrices are fixed rather than resampled, so the objective is deterministic and a
+    quasi-Newton optimizer can be used on it. That trades the estimator's variance for a bias that
+    falls as the number of draws grows.
+
+    Parameters
+    ----------
+    aggregation : Aggregation
+        The cell-to-unit operator.
+    mean : TensorVariable
+        Shape ``(n_cells,)``.
+    independent_variance : TensorVariable
+        Shape ``(n_cells,)``.
+    factor : TensorVariable
+        Shape ``(n_cells, n_inducing)``.
+    inducing_draws : ndarray or TensorVariable
+        Shape ``(n_inducing, n_draws)``, standard normal.
+    cell_draws : ndarray or TensorVariable
+        Shape ``(n_cells, n_draws)``, standard normal.
+
+    Returns
+    -------
+    TensorVariable
+        Shape ``(n_units, n_draws)``.
+    """
+    spread = pt.sqrt(pt.clip(independent_variance, 0.0, np.inf))
+    field = (
+        mean[:, None]
+        + factor @ pt.as_tensor_variable(inducing_draws)
+        + spread[:, None] * pt.as_tensor_variable(cell_draws)
+    )
+
+    # Shifted before exponentiating: the optimizer visits fields far from the data early on, and a
+    # unit whose cells all underflow would otherwise take log of zero and poison the gradient.
+    shift = pt.max(field, axis=0)
+    totals = aggregation.aggregate_symbolic(pt.exp(field - shift))
+
+    log_totals: TensorVariable = pt.log(totals) + shift
+
+    return log_totals
+
+
+def aggregated_poisson_elbo(
+    svgp: SVGP,
+    cell_features: TensorVariable,
+    unit_counts: TensorVariable,
+    aggregation: Aggregation,
+    n_draws: int = 16,
+    seed: int = 0,
+) -> TensorVariable:
+    r"""
+    The variational objective for counts observed as polygon totals of a cell-level intensity.
+
+    ptgp's own ELBO pairs observation :math:`i` with latent point :math:`i` and scales by the
+    number of latent points, neither of which holds when an observation is a sum over cells, so
+    this replaces it rather than supplying a ``Likelihood``.
+
+    :math:`\mathbb{E}_q[\Lambda_A]` is taken in closed form and only :math:`\mathbb{E}_q[\log
+    \Lambda_A]` is sampled, which removes the estimator's variance from the term that dominates
+    the gradient.
+
+    Parameters
+    ----------
+    svgp : SVGP
+        A whitened ptgp SVGP over the cell features.
+    cell_features : TensorVariable
+        Shape ``(n_cells, n_features)``.
+    unit_counts : TensorVariable
+        Shape ``(n_units,)``, in the row order of ``aggregation.units``.
+    aggregation : Aggregation
+        The cell-to-unit operator.
+    n_draws : int, optional
+        Draws behind the log-intensity term. Default 16.
+    seed : int, optional
+        Seed for the fixed draw matrices. Default 0.
+
+    Returns
+    -------
+    TensorVariable
+        Scalar.
+    """
+    mean, independent_variance, factor = latent_moments(svgp, cell_features)
+
+    rng = np.random.default_rng(seed)
+    # Shared rather than constant: at raster scale the cell draws are far too large to fold into
+    # the graph, and numba refuses to cache a function carrying one.
+    inducing_draws = shared(rng.standard_normal((svgp.q_sqrt.type.shape[1] or 1, n_draws)), name="inducing_draws")
+    cell_draws = shared(rng.standard_normal((aggregation.n_cells, n_draws)), name="cell_draws")
+
+    expected = expected_intensity(aggregation, mean, independent_variance, factor)
+    log_intensity = pt.mean(
+        sample_log_intensity(aggregation, mean, independent_variance, factor, inducing_draws, cell_draws),
+        axis=1,
+    )
+
+    log_likelihood = unit_counts * log_intensity - expected - pt.gammaln(unit_counts + 1.0)
+
+    elbo: TensorVariable = pt.sum(log_likelihood) - svgp.prior_kl()
+
+    return elbo

--- a/climate_risk/models/aggregated_poisson.py
+++ b/climate_risk/models/aggregated_poisson.py
@@ -101,10 +101,6 @@ def sample_log_intensity(
     through :math:`f = m + B \varepsilon + \sqrt{d}\,\eta`, which is exact for the factored
     covariance and puts the sampling noise outside the gradient.
 
-    The draw matrices are fixed rather than resampled, so the objective is deterministic and a
-    quasi-Newton optimizer can be used on it. That trades the estimator's variance for a bias that
-    falls as the number of draws grows.
-
     Parameters
     ----------
     aggregation : Aggregation
@@ -147,19 +143,20 @@ def aggregated_poisson_elbo(
     cell_features: TensorVariable,
     unit_counts: TensorVariable,
     aggregation: Aggregation,
+    *,
     n_draws: int = 16,
     seed: int = 0,
 ) -> TensorVariable:
     r"""
     The variational objective for counts observed as polygon totals of a cell-level intensity.
 
-    ptgp's own ELBO pairs observation :math:`i` with latent point :math:`i` and scales by the
-    number of latent points, neither of which holds when an observation is a sum over cells, so
-    this replaces it rather than supplying a ``Likelihood``.
+    Replaces ptgp's own ELBO rather than supplying a ``Likelihood``: that interface pairs
+    observation :math:`i` with latent point :math:`i` and scales by the number of latent points,
+    and an aggregated observation satisfies neither.
 
-    :math:`\mathbb{E}_q[\Lambda_A]` is taken in closed form and only :math:`\mathbb{E}_q[\log
-    \Lambda_A]` is sampled, which removes the estimator's variance from the term that dominates
-    the gradient.
+    :math:`\mathbb{E}_q[\Lambda_A]` is closed form and only :math:`\mathbb{E}_q[\log \Lambda_A]` is
+    sampled, on draws fixed once so the objective stays deterministic and a quasi-Newton optimizer
+    can be used on it.
 
     Parameters
     ----------
@@ -186,7 +183,7 @@ def aggregated_poisson_elbo(
     rng = np.random.default_rng(seed)
     # Shared rather than constant: at raster scale the cell draws are far too large to fold into
     # the graph, and numba refuses to cache a function carrying one.
-    inducing_draws = shared(rng.standard_normal((svgp.q_sqrt.type.shape[1] or 1, n_draws)), name="inducing_draws")
+    inducing_draws = shared(rng.standard_normal((svgp.inducing_variable.num_inducing, n_draws)), name="inducing_draws")
     cell_draws = shared(rng.standard_normal((aggregation.n_cells, n_draws)), name="cell_draws")
 
     expected = expected_intensity(aggregation, mean, independent_variance, factor)

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -87,16 +87,24 @@ class Aggregation:
         Parameters
         ----------
         cell_values : TensorVariable
-            Shape ``(n_cells,)``.
+            Shape ``(n_cells,)`` for one field, or ``(n_cells, k)`` to aggregate ``k`` of them at
+            once, each column independently.
 
         Returns
         -------
         TensorVariable
-            Shape ``(n_units,)``, in the row order of ``units``.
+            Shape ``(n_units,)`` or ``(n_units, k)``, in the row order of ``units``.
         """
-        contributions = pt.as_tensor_variable(self.weights) * cell_values[self.columns]
+        weights = pt.as_tensor_variable(self.weights)
+        if cell_values.ndim == 2:
+            weights = weights[:, None]
+            base = pt.zeros((self.n_units, cell_values.shape[1]))
+        else:
+            base = pt.zeros((self.n_units,))
 
-        totals: TensorVariable = pt.inc_subtensor(pt.zeros((self.n_units,))[self.rows], contributions)
+        contributions = weights * cell_values[self.columns]
+
+        totals: TensorVariable = pt.inc_subtensor(base[self.rows], contributions)
 
         return totals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ strict_equality = true
 
 # No stubs exist for these, on the index or in the packages themselves.
 [[tool.mypy.overrides]]
-module = ["arviz.*", "pymc.*", "pytensor.*", "sklearn.*", "statsmodels.*"]
+module = ["arviz.*", "pymc.*", "pytensor.*", "ptgp.*", "sklearn.*", "statsmodels.*"]
 ignore_missing_imports = true
 
 # Test functions carry no annotations, so their bodies need checking on their own terms.

--- a/tests/models/test_aggregated_poisson.py
+++ b/tests/models/test_aggregated_poisson.py
@@ -1,0 +1,129 @@
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+
+from climate_risk.models.aggregated_poisson import (
+    expected_intensity,
+    sample_log_intensity,
+)
+from climate_risk.models.aggregation import build_aggregation
+
+N_CELLS, N_INDUCING = 12, 4
+
+
+def latent_pieces(seed: int):
+    """A mean, an independent variance, and a covariance factor, standing in for an SVGP fit."""
+    rng = np.random.default_rng(seed)
+    mean = rng.normal(0.0, 0.4, size=N_CELLS)
+    independent_variance = rng.uniform(0.05, 0.3, size=N_CELLS)
+    factor = rng.normal(0.0, 0.3, size=(N_CELLS, N_INDUCING))
+
+    return mean, independent_variance, factor
+
+
+def brute_force_intensities(mean, independent_variance, factor, weights, unit_of_cell, units, n_draws, seed):
+    """Draw the field from the covariance the factors describe and aggregate it with numpy."""
+    rng = np.random.default_rng(seed)
+    covariance = np.diag(independent_variance) + factor @ factor.T
+    chol = np.linalg.cholesky(covariance + 1e-10 * np.eye(len(mean)))
+    field = mean[:, None] + chol @ rng.standard_normal((len(mean), n_draws))
+
+    rows = np.array([units.index(unit) for unit in unit_of_cell])
+    contributions = weights[:, None] * np.exp(field)
+
+    return np.stack([contributions[rows == row].sum(axis=0) for row in range(len(units))])
+
+
+def test_the_expected_intensity_matches_sampling_the_field():
+    """E[Lambda] is exact and needs only the marginals, so it must agree with sampling the full
+    factored covariance. Aggregating before exponentiating, or dropping the variance correction,
+    both show up as a bias here.
+    """
+    mean, independent_variance, factor = latent_pieces(seed=0)
+    weights = np.linspace(0.5, 1.5, N_CELLS)
+    unit_of_cell = ["a"] * 5 + ["b"] * 7
+    aggregation = build_aggregation(unit_of_cell=unit_of_cell, weights=weights)
+
+    closed_form = pytensor.function(
+        [], expected_intensity(aggregation, pt.as_tensor_variable(mean), independent_variance, factor)
+    )()
+    drawn = brute_force_intensities(
+        mean, independent_variance, factor, weights, unit_of_cell, ["a", "b"], n_draws=400_000, seed=1
+    )
+
+    np.testing.assert_allclose(closed_form, drawn.mean(axis=1), rtol=0.02)
+
+
+def test_the_sampled_log_intensity_converges_on_the_truth():
+    """The log term is the one with no closed form. Its estimator has to be centred on the real
+    expectation, and the Jensen gap is the thing it exists to capture: log E[Lambda] is an upper
+    bound that a correct estimator must sit strictly below.
+    """
+    mean, independent_variance, factor = latent_pieces(seed=2)
+    weights = np.linspace(0.5, 1.5, N_CELLS)
+    unit_of_cell = ["a"] * 5 + ["b"] * 7
+    aggregation = build_aggregation(unit_of_cell=unit_of_cell, weights=weights)
+
+    rng = np.random.default_rng(3)
+    n_draws = 40_000
+    inducing_draws, cell_draws = pt.matrix("inducing_draws"), pt.matrix("cell_draws")
+    sampled = pytensor.function(
+        [inducing_draws, cell_draws],
+        sample_log_intensity(
+            aggregation, pt.as_tensor_variable(mean), independent_variance, factor, inducing_draws, cell_draws
+        ),
+    )(rng.standard_normal((N_INDUCING, n_draws)), rng.standard_normal((N_CELLS, n_draws))).mean(axis=1)
+
+    drawn = brute_force_intensities(
+        mean, independent_variance, factor, weights, unit_of_cell, ["a", "b"], n_draws=400_000, seed=4
+    )
+    truth = np.log(drawn).mean(axis=1)
+    jensen = np.log(drawn.mean(axis=1))
+
+    np.testing.assert_allclose(sampled, truth, rtol=0.01)
+    assert (sampled < jensen).all(), "the estimator must sit below the Jensen bound it corrects"
+
+
+def test_the_draws_reproduce_the_within_unit_correlation():
+    """A unit's cells are correlated through the shared inducing values, and that correlation is
+    what the log term is sensitive to. Sampling each cell independently would leave the mean
+    intact and the spread of Lambda far too small.
+    """
+    mean, independent_variance, factor = latent_pieces(seed=5)
+    aggregation = build_aggregation(unit_of_cell=["a"] * N_CELLS, weights=np.ones(N_CELLS))
+
+    rng = np.random.default_rng(6)
+    n_draws = 20_000
+    values = (rng.standard_normal((N_INDUCING, n_draws)), rng.standard_normal((N_CELLS, n_draws)))
+    inducing_draws, cell_draws = pt.matrix("inducing_draws"), pt.matrix("cell_draws")
+
+    def spread(factor_used):
+        log_intensity = pytensor.function(
+            [inducing_draws, cell_draws],
+            sample_log_intensity(
+                aggregation,
+                pt.as_tensor_variable(mean),
+                independent_variance,
+                factor_used,
+                inducing_draws,
+                cell_draws,
+            ),
+        )(*values)
+        return log_intensity.std()
+
+    assert spread(factor) > 1.5 * spread(np.zeros_like(factor))
+
+
+def test_an_unwhitened_svgp_is_refused():
+    """The moment expressions are derived from the whitened conditional. Running them against the
+    unwhitened parameterization would silently use the wrong covariance factor.
+    """
+    from climate_risk.exceptions import DataValidationError
+    from climate_risk.models.aggregated_poisson import latent_moments
+
+    class Unwhitened:
+        whiten = False
+
+    with pytest.raises(DataValidationError, match="whitened"):
+        latent_moments(Unwhitened(), pt.matrix("X"))

--- a/tests/models/test_aggregated_poisson.py
+++ b/tests/models/test_aggregated_poisson.py
@@ -3,8 +3,18 @@ import pytensor
 import pytensor.tensor as pt
 import pytest
 
+from ptgp.gp import SVGP, init_variational_params
+from ptgp.inducing import Points
+from ptgp.kernels import ExpQuad
+from ptgp.likelihoods import Poisson
+from pytensor.graph.traversal import explicit_graph_inputs
+from pytensor.tensor.special import gammaln
+
+from climate_risk.exceptions import DataValidationError
 from climate_risk.models.aggregated_poisson import (
+    aggregated_poisson_elbo,
     expected_intensity,
+    latent_moments,
     sample_log_intensity,
 )
 from climate_risk.models.aggregation import build_aggregation
@@ -119,11 +129,106 @@ def test_an_unwhitened_svgp_is_refused():
     """The moment expressions are derived from the whitened conditional. Running them against the
     unwhitened parameterization would silently use the wrong covariance factor.
     """
-    from climate_risk.exceptions import DataValidationError
-    from climate_risk.models.aggregated_poisson import latent_moments
 
     class Unwhitened:
         whiten = False
 
     with pytest.raises(DataValidationError, match="whitened"):
         latent_moments(Unwhitened(), pt.matrix("X"))
+
+
+def small_svgp(features):
+    """A whitened SVGP whose variational parameters are still symbolic, as ptgp leaves them."""
+    rng = np.random.default_rng(7)
+
+    return SVGP(
+        kernel=ExpQuad(input_dim=features.shape[1], ls=0.5),
+        likelihood=Poisson(),
+        inducing_variable=Points(Z=rng.uniform(0.0, 1.0, size=(N_INDUCING, features.shape[1]))),
+        variational_params=init_variational_params(N_INDUCING),
+        whiten=True,
+    )
+
+
+def evaluate_elbo(seed: int, counts=(3.0, 5.0)):
+    """The objective and its gradient at one point in the variational parameters."""
+    rng = np.random.default_rng(8)
+    features = rng.uniform(0.0, 1.0, size=(N_CELLS, 2))
+    aggregation = build_aggregation(unit_of_cell=["a"] * 5 + ["b"] * 7, weights=np.ones(N_CELLS))
+
+    elbo = aggregated_poisson_elbo(
+        small_svgp(features),
+        pt.as_tensor_variable(features),
+        pt.as_tensor_variable(np.asarray(counts)),
+        aggregation,
+        n_draws=8,
+        seed=seed,
+    )
+    parameters = list(explicit_graph_inputs([elbo]))
+    # The claim is about the graph, not the backend. Compiling it is the expensive part, and
+    # numba spends seconds on a graph this size for no extra coverage.
+    gradients = pt.grad(elbo, parameters)
+    assert isinstance(gradients, list), "a list of wrt variables gives a list of gradients"
+    compiled = pytensor.function(parameters, [elbo, *gradients], mode="FAST_COMPILE")
+
+    return compiled(*[rng.normal(0.0, 0.2, size=parameter.type.shape) for parameter in parameters])
+
+
+def test_the_objective_and_its_gradient_are_finite_and_informative():
+    """An optimizer is handed this, so a detached graph or a NaN is the failure that matters:
+    L-BFGS reads a zero gradient as a converged fit rather than as an error, and the run ends
+    looking successful.
+    """
+    value, *gradients = evaluate_elbo(seed=0)
+
+    assert np.isfinite(value)
+    assert all(np.all(np.isfinite(gradient)) for gradient in gradients)
+    assert all(np.any(gradient != 0.0) for gradient in gradients), "every variational parameter moves the objective"
+
+
+def test_the_same_seed_gives_the_same_objective():
+    """The draws are fixed so the objective is a deterministic function of the parameters. Drawing
+    afresh per evaluation would make it jitter and a quasi-Newton line search would fail on it.
+    """
+    first, *_ = evaluate_elbo(seed=0)
+    again, *_ = evaluate_elbo(seed=0)
+    other, *_ = evaluate_elbo(seed=1)
+
+    assert first == again
+    assert first != other, "a different seed draws a different estimate"
+
+
+def test_the_objective_is_the_poisson_likelihood_less_the_divergence():
+    """The three pieces are checked separately above; this pins how they are combined. Dropping
+    the counts, or the divergence, still leaves a finite differentiable scalar that an optimizer
+    would minimize happily into the wrong answer.
+    """
+    rng = np.random.default_rng(8)
+    features = rng.uniform(0.0, 1.0, size=(N_CELLS, 2))
+    aggregation = build_aggregation(unit_of_cell=["a"] * 5 + ["b"] * 7, weights=np.ones(N_CELLS))
+    counts = np.array([3.0, 5.0])
+    n_draws, seed = 8, 0
+
+    svgp = small_svgp(features)
+    cell_features = pt.as_tensor_variable(features)
+    elbo = aggregated_poisson_elbo(
+        svgp, cell_features, pt.as_tensor_variable(counts), aggregation, n_draws=n_draws, seed=seed
+    )
+
+    # The objective seeds its own draws; the same seed and the same order reproduces them.
+    draws = np.random.default_rng(seed)
+    inducing_draws = draws.standard_normal((N_INDUCING, n_draws))
+    cell_draws = draws.standard_normal((aggregation.n_cells, n_draws))
+
+    mean, independent_variance, factor = latent_moments(svgp, cell_features)
+    expected = expected_intensity(aggregation, mean, independent_variance, factor)
+    log_intensity = pt.mean(
+        sample_log_intensity(aggregation, mean, independent_variance, factor, inducing_draws, cell_draws), axis=1
+    )
+    assembled = pt.sum(counts * log_intensity - expected - gammaln(counts + 1.0)) - svgp.prior_kl()
+
+    parameters = list(explicit_graph_inputs([elbo, assembled]))
+    compiled = pytensor.function(parameters, [elbo, assembled], mode="FAST_COMPILE")
+    from_objective, from_pieces = compiled(*[rng.normal(0.0, 0.2, size=p.type.shape) for p in parameters])
+
+    assert from_objective == pytest.approx(from_pieces)

--- a/tests/models/test_aggregation.py
+++ b/tests/models/test_aggregation.py
@@ -155,6 +155,21 @@ def test_the_symbolic_path_handles_repeats_gaps_and_empty_units():
     assert totals == pytest.approx([16.0, 0.0, 3.0])
 
 
+@pytest.mark.parametrize("n_columns", [1, 3])
+def test_the_symbolic_path_aggregates_a_stack_of_fields_columnwise(n_columns):
+    """Draws and covariance factors arrive as (n_cells, k) blocks. Each column is its own field,
+    so a base array of the wrong rank would sum them together and return one column.
+    """
+    weights = np.array([2.0, 3.0, 4.0])
+    aggregation = build_aggregation(unit_of_cell=["a", "a", "b"], weights=weights)
+    block = np.arange(3 * n_columns, dtype=float).reshape(3, n_columns)
+
+    cells = pt.matrix("cells")
+    totals = pytensor.function([cells], aggregation.aggregate_symbolic(cells))(block)
+
+    np.testing.assert_allclose(totals, np.stack([weights[:2] @ block[:2], weights[2] * block[2]]))
+
+
 def test_the_symbolic_gradient_is_the_operator_transpose():
     """The model differentiates through this, and a gather paired with the wrong scatter can give
     the right totals with the wrong sensitivities. The operator is linear, so its Jacobian is the


### PR DESCRIPTION
Counts observed as polygon totals need an objective that sums over cells, which ptgp's ELBO can't express: it scales by `X.shape[0]`, the cell count, so an aggregated observation is wrong by `n_units / n_cells` and a `Likelihood` subclass can't reach that. This replaces the objective instead. `E[Λ_A]` is closed form; `E[log Λ_A]` isn't, and is sampled on draws fixed once so the objective stays deterministic for a quasi-Newton optimizer.

Synthetic data only. The spatial lengthscale is not learnable from coarse polygon totals — the objective prefers short ones by around 2400 nats while cell-level recovery is best at long ones — so it has to be pinned, and step 3 needs to report the held-out check both ways.
