### PR TITLE
Add the raster layer that grids a place into weighted cells

### DIFF
--- a/climate_risk/geo/raster.py
+++ b/climate_risk/geo/raster.py
@@ -218,6 +218,36 @@ class CellGrid:
             crs=GEOGRAPHIC_CRS,
         )
 
+    def column_of_cell(self, cell_ids: np.ndarray) -> np.ndarray:
+        """
+        Operator column of each lattice cell.
+
+        ``cell_id`` numbers the whole lattice while the operator's columns number the cells that
+        survived clipping, so the two spaces diverge from the first dropped cell onward. An
+        overlap table is keyed on the first and has to be translated to the second.
+
+        Parameters
+        ----------
+        cell_ids : ndarray
+            Lattice cell ids, as ``assign_cells_to_units`` reports them. Repeats are fine.
+
+        Returns
+        -------
+        ndarray
+            Column index of each, positions into ``cells``.
+        """
+        wanted = np.asarray(cell_ids)
+        column_of = pd.Series(np.arange(len(self.cells)), index=self.cells["cell_id"].to_numpy())
+
+        missing = np.setdiff1d(wanted, column_of.index.to_numpy())
+        if missing.size:
+            raise DataValidationError(
+                f"{missing.size} cells are not in the grid, starting {sorted(missing.tolist())[:5]}. They belong to "
+                f"a different lattice, or to this one before it was clipped."
+            )
+
+        return np.asarray(column_of.loc[wanted].to_numpy())
+
     @property
     def bounds(self) -> tuple[float, float, float, float]:
         """Outer edges of the lattice, half a cell beyond the outermost centres."""
@@ -355,3 +385,40 @@ def build_cell_grid(boundary: gpd.GeoDataFrame, *, resolution_km: float) -> Cell
             crs=GEOGRAPHIC_CRS,
         ),
     )
+
+
+def assign_cells_to_units(grid: CellGrid, units: gpd.GeoDataFrame, *, unit_column: str = "gid") -> pd.DataFrame:
+    """
+    Overlap between grid cells and administrative units, weighted by area.
+
+    A cell on a border appears once per unit it touches, carrying the ground it contributes to
+    each. Cells outside every unit produce no rows; a unit smaller than a cell still gets its share
+    of the cell it sits in.
+
+    Parameters
+    ----------
+    grid : CellGrid
+        The lattice and its cells.
+    units : GeoDataFrame
+        Administrative units, in any CRS, carrying ``unit_column``.
+    unit_column : str, optional
+        Column naming each unit. Default 'gid', which is what ``event_geography`` keys on.
+
+    Returns
+    -------
+    DataFrame
+        One row per overlapping cell and unit, with the unit key, ``cell_id``, the fraction of the
+        cell inside the unit, and the overlapping area in square kilometres.
+    """
+    if unit_column not in units.columns:
+        raise DataValidationError(f"The units carry no {unit_column!r} column to key the operator's rows on.")
+
+    if units.crs is None:
+        raise DataValidationError("The units carry no CRS, so they cannot be placed against the grid.")
+
+    overlaps = cell_coverage(grid.shape, grid.bounds, units, unit_column)
+
+    areas = grid.cells.set_index("cell_id")["cell_area_km2"]
+    within_place = overlaps[overlaps["cell_id"].isin(areas.index)].reset_index(drop=True)
+
+    return within_place.assign(overlap_km2=lambda frame: frame["coverage"] * areas.loc[frame["cell_id"]].to_numpy())

--- a/climate_risk/geo/raster.py
+++ b/climate_risk/geo/raster.py
@@ -1,0 +1,357 @@
+from dataclasses import dataclass
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import shapely
+
+from exactextract import exact_extract
+from exactextract.raster import NumPyRasterSource
+from pyproj import Geod
+from shapely.geometry import box
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.geo.crs import GEOGRAPHIC_CRS
+
+ISO_COLUMN = "ISO_A3"
+
+# Spherical, and only ever used to turn a target resolution into a cell count. Cell areas, which
+# are weights the model integrates with, are measured on the ellipsoid instead.
+KM_PER_DEGREE_LATITUDE = 111.32
+
+WGS84_ELLIPSOID = "WGS84"
+SQUARE_METRES_PER_SQUARE_KM = 1e6
+
+# One cell is a crude but well-defined quadrature over an extent smaller than the resolution. A
+# place that small is screened out by the place configuration rather than here.
+MIN_CELLS_PER_AXIS = 1
+
+
+def dissolve_place_boundary(boundary: gpd.GeoDataFrame, *, iso3: str | None = None) -> gpd.GeoDataFrame:
+    """
+    Reduce a place's boundary to one polygon per country.
+
+    A place either carries its own archive, which may hold many administrative features and no ISO
+    column, or resolves to a slice of the world shapefile, which carries ``ISO_A3`` and one feature
+    per country. Both grid to the same cells only once they have the same shape, so both are
+    reduced here rather than at each call site.
+
+    Parameters
+    ----------
+    boundary : GeoDataFrame
+        The place's geometry, in any CRS.
+    iso3 : str, optional
+        Code to label the geometry with when it carries no ``ISO_A3`` column. Default None, which
+        requires the geometry to label itself.
+
+    Returns
+    -------
+    GeoDataFrame
+        One row per country, carrying ``ISO_A3`` and ``geometry``, in ``GEOGRAPHIC_CRS``.
+    """
+    if boundary.empty:
+        raise DataValidationError("The boundary holds no geometry, so there would be nothing to grid.")
+
+    if boundary.crs is None:
+        raise DataValidationError("The boundary carries no CRS, so its coordinates cannot be placed on the globe.")
+
+    labelled = ISO_COLUMN in boundary.columns
+    if not labelled and iso3 is None:
+        raise DataValidationError(
+            f"The geometry carries no {ISO_COLUMN} column, so pass iso3 to say which country it covers."
+        )
+
+    located = boundary.to_crs(GEOGRAPHIC_CRS)
+    if not labelled:
+        located = located.assign(**{ISO_COLUMN: iso3})
+
+    dissolved = located.dissolve(by=ISO_COLUMN, as_index=False)
+
+    return gpd.GeoDataFrame(dissolved[[ISO_COLUMN, "geometry"]], geometry="geometry", crs=GEOGRAPHIC_CRS)
+
+
+def grid_axes(bounds: tuple[float, float, float, float], resolution_km: float) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Cell centre coordinates for a grid of approximately square cells tiling an extent.
+
+    Resolution is stated in kilometres rather than points per axis, because points per axis means a
+    different ground distance for every place and a different one along each axis of the same
+    place. Longitude is converted at the extent's mean latitude, so cells are square in the middle
+    of the place and drift from square towards its edges; the cell areas carry that drift rather
+    than the spacing.
+
+    Centres, not edges: the aggregation operator sums a field sampled once per cell, which is a
+    midpoint rule, and a midpoint rule wants the sample in the middle of the ground it stands for.
+
+    Parameters
+    ----------
+    bounds : tuple of float
+        ``(lon_min, lat_min, lon_max, lat_max)`` in degrees.
+    resolution_km : float
+        Target cell edge, in kilometres.
+
+    Returns
+    -------
+    longitudes : ndarray
+        Cell centre longitudes, one per cell along the axis.
+    latitudes : ndarray
+        Cell centre latitudes, one per cell along the axis.
+    """
+    if resolution_km <= 0.0:
+        raise DataValidationError(f"The grid resolution must be a positive distance, not {resolution_km}.")
+
+    lon_min, lat_min, lon_max, lat_max = bounds
+    if lon_max < lon_min or lat_max < lat_min:
+        raise DataValidationError(f"The bounds {bounds} are inverted, so they enclose nothing.")
+
+    mean_latitude = (lat_min + lat_max) / 2.0
+    km_per_degree_longitude = KM_PER_DEGREE_LATITUDE * np.cos(np.radians(mean_latitude))
+
+    spans_km = (
+        (lon_max - lon_min) * km_per_degree_longitude,
+        (lat_max - lat_min) * KM_PER_DEGREE_LATITUDE,
+    )
+    counts = [max(MIN_CELLS_PER_AXIS, round(span / resolution_km)) for span in spans_km]
+
+    longitude_edges = np.linspace(lon_min, lon_max, counts[0] + 1)
+    latitude_edges = np.linspace(lat_min, lat_max, counts[1] + 1)
+
+    return _midpoints(longitude_edges), _midpoints(latitude_edges)
+
+
+def _midpoints(edges: np.ndarray) -> np.ndarray:
+    centres: np.ndarray = (edges[:-1] + edges[1:]) / 2.0
+
+    return centres
+
+
+def cell_areas_km2(latitudes: np.ndarray, longitude_step: float, latitude_step: float) -> np.ndarray:
+    """
+    Ground area of each cell on a regular lon/lat grid, on the WGS84 ellipsoid.
+
+    Cells of equal angular size cover less ground the further they sit from the equator.
+
+    Parameters
+    ----------
+    latitudes : ndarray
+        Cell centre latitude, in degrees.
+    longitude_step : float
+        Angular cell width, in degrees.
+    latitude_step : float
+        Angular cell height, in degrees.
+
+    Returns
+    -------
+    ndarray
+        Cell area in square kilometres, one per entry of ``latitudes``.
+    """
+    # A spherical cos(latitude) form is biased by a few parts in a thousand, and the bias runs with
+    # latitude. Banding keeps the ellipsoidal figure cheap: one evaluation per row, not per cell.
+    geodesic = Geod(ellps=WGS84_ELLIPSOID)
+    bands, band_of_cell = np.unique(latitudes, return_inverse=True)
+
+    half_width, half_height = longitude_step / 2.0, latitude_step / 2.0
+    areas = np.array(
+        [
+            abs(geodesic.geometry_area_perimeter(box(-half_width, lat - half_height, half_width, lat + half_height))[0])
+            for lat in bands
+        ]
+    )
+
+    return areas[band_of_cell] / SQUARE_METRES_PER_SQUARE_KM
+
+
+@dataclass(frozen=True, slots=True)
+class CellGrid:
+    """
+    The quadrature lattice over a place, and the cells of it that fall inside.
+
+    Both halves are needed. The model integrates over ``cells``, but assigning cells to
+    administrative units treats the grid as a raster, and a raster is defined by the whole lattice
+    rather than by the part of it that survived clipping. ``cell_id`` on ``cells`` indexes the
+    lattice in raster order, north row first, so it is the join key between the two.
+
+    Parameters
+    ----------
+    longitudes : ndarray
+        Cell centre longitudes, ascending.
+    latitudes : ndarray
+        Cell centre latitudes, descending, so row zero is the northernmost.
+    longitude_step : float
+        Angular cell width, in degrees.
+    latitude_step : float
+        Angular cell height, in degrees.
+    cells : GeoDataFrame
+        Surviving cells, with ``cell_id``, ``lon``, ``lat``, ``ISO_A3``, ``cell_area_km2`` for the whole
+        cell and ``place_area_km2`` for the part of it inside the place.
+    """
+
+    longitudes: np.ndarray
+    latitudes: np.ndarray
+    longitude_step: float
+    latitude_step: float
+    cells: gpd.GeoDataFrame
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Rows and columns of the full lattice, before clipping."""
+        return len(self.latitudes), len(self.longitudes)
+
+    @property
+    def steps(self) -> tuple[float, float]:
+        """Angular cell width and height, in degrees."""
+        return self.longitude_step, self.latitude_step
+
+    @property
+    def footprints(self) -> gpd.GeoSeries:
+        """
+        The rectangle each cell stands for, rather than the centre it is sampled at.
+
+        ``cells.geometry`` is the centre, where the model evaluates the field.
+        """
+        half_width, half_height = (step / 2.0 for step in self.steps)
+        lon, lat = self.cells["lon"].to_numpy(), self.cells["lat"].to_numpy()
+
+        return gpd.GeoSeries(
+            shapely.box(lon - half_width, lat - half_height, lon + half_width, lat + half_height),
+            index=self.cells.index,
+            crs=GEOGRAPHIC_CRS,
+        )
+
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        """Outer edges of the lattice, half a cell beyond the outermost centres."""
+        half_width, half_height = (step / 2.0 for step in self.steps)
+
+        return (
+            float(self.longitudes[0]) - half_width,
+            float(self.latitudes[-1]) - half_height,
+            float(self.longitudes[-1]) + half_width,
+            float(self.latitudes[0]) + half_height,
+        )
+
+
+def cell_coverage(
+    shape: tuple[int, int],
+    bounds: tuple[float, float, float, float],
+    features: gpd.GeoDataFrame,
+    key_column: str,
+) -> pd.DataFrame:
+    """
+    Fraction of each grid cell covered by each feature.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Rows and columns of the lattice.
+    bounds : tuple of float
+        Outer edges of the lattice, ``(lon_min, lat_min, lon_max, lat_max)``.
+    features : GeoDataFrame
+        Polygons to measure against, in any CRS.
+    key_column : str
+        Column naming each feature.
+
+    Returns
+    -------
+    DataFrame
+        One row per feature and overlapping cell, with the key, ``cell_id`` and ``coverage``. Cells
+        a feature misses entirely produce no row.
+    """
+    rows, columns = shape
+    lon_min, lat_min, lon_max, lat_max = bounds
+    lattice = NumPyRasterSource(np.zeros((rows, columns)), xmin=lon_min, ymin=lat_min, xmax=lon_max, ymax=lat_max)
+
+    overlaps = exact_extract(
+        lattice,
+        features.to_crs(GEOGRAPHIC_CRS),
+        ["cell_id", "coverage"],
+        include_cols=[key_column],
+        output="pandas",
+    )
+    widths = overlaps["cell_id"].map(len).to_numpy()
+
+    return pd.DataFrame(
+        {
+            key_column: np.repeat(overlaps[key_column].to_numpy(), widths),
+            "cell_id": np.concatenate([np.asarray(ids) for ids in overlaps["cell_id"]]).astype(int),
+            "coverage": np.concatenate([np.asarray(share) for share in overlaps["coverage"]]),
+        }
+    )
+
+
+def build_cell_grid(boundary: gpd.GeoDataFrame, *, resolution_km: float) -> CellGrid:
+    """
+    Lay a grid of cells over a dissolved boundary and keep every cell it touches.
+
+    Membership is by coverage: a cell half inside the place is kept, credited with half its area.
+
+    Parameters
+    ----------
+    boundary : GeoDataFrame
+        One row per country, as :func:`dissolve_place_boundary` returns.
+    resolution_km : float
+        Target cell edge, in kilometres.
+
+    Returns
+    -------
+    CellGrid
+        The lattice and its surviving cells, in ``GEOGRAPHIC_CRS``.
+    """
+    # A country is mostly border at any resolution coarse enough to model, and a dropped border
+    # cell takes its overlaps with the border units with it.
+    if ISO_COLUMN not in boundary.columns:
+        raise DataValidationError(f"Grid the output of dissolve_place_boundary, which carries {ISO_COLUMN}.")
+
+    lon_min, lat_min, lon_max, lat_max = (float(edge) for edge in boundary.total_bounds)
+
+    longitudes, ascending_latitudes = grid_axes((lon_min, lat_min, lon_max, lat_max), resolution_km)
+    latitudes = ascending_latitudes[::-1]
+
+    # Raster order: rows run north to south, columns west to east, so cell_id matches what a zonal
+    # statistics pass over the same lattice reports.
+    latitude_mesh, longitude_mesh = (axis.ravel() for axis in np.meshgrid(latitudes, longitudes, indexing="ij"))
+
+    # A single-cell axis has no gap to measure, so the cell is as wide as the extent.
+    steps = (
+        longitudes[1] - longitudes[0] if len(longitudes) > 1 else lon_max - lon_min,
+        ascending_latitudes[1] - ascending_latitudes[0] if len(latitudes) > 1 else lat_max - lat_min,
+    )
+
+    lattice = pd.DataFrame(
+        {
+            "cell_id": np.arange(longitude_mesh.size),
+            "lon": longitude_mesh,
+            "lat": latitude_mesh,
+            "cell_area_km2": cell_areas_km2(latitude_mesh, *steps),
+        }
+    )
+
+    shape = (len(latitudes), len(longitudes))
+    edges = (
+        float(longitudes[0]) - steps[0] / 2.0,
+        float(ascending_latitudes[0]) - steps[1] / 2.0,
+        float(longitudes[-1]) + steps[0] / 2.0,
+        float(ascending_latitudes[-1]) + steps[1] / 2.0,
+    )
+    covered = cell_coverage(shape, edges, boundary, ISO_COLUMN)
+
+    # A cell on an internal frontier touches two countries. It is one piece of ground, labelled by
+    # whichever claims most of it and credited with everything the place covers.
+    inside = covered.groupby("cell_id")[["coverage"]].sum()
+    dominant = covered.sort_values("coverage", ascending=False).drop_duplicates("cell_id").set_index("cell_id")
+    inside[ISO_COLUMN] = dominant[ISO_COLUMN]
+
+    kept = lattice.join(inside, on="cell_id", how="inner").reset_index(drop=True)
+    kept["place_area_km2"] = kept["cell_area_km2"] * kept["coverage"].clip(upper=1.0)
+
+    return CellGrid(
+        longitudes=longitudes,
+        latitudes=latitudes,
+        longitude_step=float(steps[0]),
+        latitude_step=float(steps[1]),
+        cells=gpd.GeoDataFrame(
+            kept[["cell_id", "lon", "lat", ISO_COLUMN, "cell_area_km2", "place_area_km2"]],
+            geometry=gpd.points_from_xy(kept["lon"], kept["lat"]),
+            crs=GEOGRAPHIC_CRS,
+        ),
+    )

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -220,15 +220,16 @@ def _validated_weights(weights: np.ndarray) -> np.ndarray:
     validated = np.asarray(weights, dtype=float)
 
     if not np.all(np.isfinite(validated)):
-        raise DataValidationError("Cell weights carry a non-finite value, which would poison every total it enters.")
+        raise DataValidationError("A weight is non-finite, which would poison every total it enters.")
 
     if np.any(validated < 0.0):
-        raise DataValidationError("Cell weights are negative, so a polygon's total would not be a sum of parts.")
+        raise DataValidationError("A weight is negative, so a polygon's total would not be a sum of parts.")
 
     return validated
 
 
 def _rows_for_units(labels: list[str], units: Sequence[str] | None) -> tuple[tuple[str, ...], np.ndarray]:
+    """The row order, and the row each label occupies in it."""
     non_strings = sorted({type(label).__name__ for label in labels if not isinstance(label, str)})
     if non_strings:
         raise DataValidationError(

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -139,21 +139,38 @@ def build_aggregation(
     Aggregation
         The operator and its row labels.
     """
-    weights = np.asarray(weights, dtype=float)
+    weights = _validated_weights(weights)
     if len(unit_of_cell) != weights.shape[0]:
         raise DataValidationError(
             f"{len(unit_of_cell)} cell assignments against {weights.shape[0]} weights; they index the same cells."
         )
 
-    if not np.all(np.isfinite(weights)):
-        raise DataValidationError("Cell weights carry a non-finite value, which would poison every total it enters.")
-
-    if np.any(weights < 0.0):
-        raise DataValidationError("Cell weights are negative, so a polygon's total would not be a sum of parts.")
-
     assigned = np.array([label is not None for label in unit_of_cell], dtype=bool)
     labels = [label for label in unit_of_cell if label is not None]
+    row_order, rows = _rows_for_units(labels, units)
 
+    return Aggregation(
+        units=row_order,
+        rows=rows,
+        columns=np.flatnonzero(assigned),
+        weights=weights[assigned],
+        n_cells=weights.shape[0],
+    )
+
+
+def _validated_weights(weights: np.ndarray) -> np.ndarray:
+    validated = np.asarray(weights, dtype=float)
+
+    if not np.all(np.isfinite(validated)):
+        raise DataValidationError("Cell weights carry a non-finite value, which would poison every total it enters.")
+
+    if np.any(validated < 0.0):
+        raise DataValidationError("Cell weights are negative, so a polygon's total would not be a sum of parts.")
+
+    return validated
+
+
+def _rows_for_units(labels: list[str], units: Sequence[str] | None) -> tuple[tuple[str, ...], np.ndarray]:
     non_strings = sorted({type(label).__name__ for label in labels if not isinstance(label, str)})
     if non_strings:
         raise DataValidationError(
@@ -164,8 +181,7 @@ def build_aggregation(
     if units is None:
         units = sorted(set(labels))
 
-    counts = Counter(units)
-    repeated = sorted(unit for unit, count in counts.items() if count > 1)
+    repeated = sorted(unit for unit, count in Counter(units).items() if count > 1)
     if repeated:
         raise DataValidationError(f"The row order repeats units, so their rows would not be reachable: {repeated}.")
 
@@ -174,10 +190,4 @@ def build_aggregation(
     if unknown:
         raise DataValidationError(f"Cells are assigned to units absent from the row order: {unknown}.")
 
-    return Aggregation(
-        units=tuple(units),
-        rows=np.array([row_of_unit[label] for label in labels], dtype=int),
-        columns=np.flatnonzero(assigned),
-        weights=weights[assigned],
-        n_cells=weights.shape[0],
-    )
+    return tuple(units), np.array([row_of_unit[label] for label in labels], dtype=int)

--- a/climate_risk/models/aggregation.py
+++ b/climate_risk/models/aggregation.py
@@ -158,6 +158,64 @@ def build_aggregation(
     )
 
 
+def build_aggregation_from_overlaps(
+    *,
+    unit_of_overlap: Sequence[str],
+    cell_of_overlap: np.ndarray,
+    weights: np.ndarray,
+    n_cells: int,
+    units: Sequence[str] | None = None,
+) -> Aggregation:
+    """
+    Build the operator from cell-unit overlaps, where a cell may belong to several units.
+
+    Parameters
+    ----------
+    unit_of_overlap : sequence of str
+        The unit each overlap belongs to, one entry per overlap.
+    cell_of_overlap : ndarray
+        The cell each overlap belongs to, indexing the grid, one entry per overlap.
+    weights : ndarray
+        The weight each overlap contributes, one entry per overlap. Overlapping area gives an
+        integral over the polygon; overlapping population gives an exposure-weighted one.
+    n_cells : int
+        Width of the operator. Cells named in no overlap contribute to no total.
+    units : sequence of str, optional
+        Row order of the operator. Every named unit must appear, and no unit twice. Default None,
+        which orders the units that appear in ``unit_of_overlap``, sorted.
+
+    Returns
+    -------
+    Aggregation
+        The operator and its row labels.
+    """
+    weights = _validated_weights(weights)
+    cells = np.asarray(cell_of_overlap, dtype=int)
+    lengths = {len(unit_of_overlap), cells.shape[0], weights.shape[0]}
+    if len(lengths) != 1:
+        raise DataValidationError(
+            f"{len(unit_of_overlap)} units, {cells.shape[0]} cells and {weights.shape[0]} weights; one of each "
+            f"describes one overlap."
+        )
+
+    out_of_range = cells[(cells < 0) | (cells >= n_cells)]
+    if out_of_range.size:
+        raise DataValidationError(
+            f"Overlaps name cells outside the grid of {n_cells}: {sorted(set(out_of_range.tolist()))[:5]}."
+        )
+
+    row_order, rows = _rows_for_units(list(unit_of_overlap), units)
+
+    # A repeated pair is summed silently by the sparse matrix, so the same overlap listed twice
+    # would double the ground it stands for.
+    pairs, counts = np.unique(np.column_stack([rows, cells]), axis=0, return_counts=True)
+    if np.any(counts > 1):
+        repeated = [(row_order[row], int(cell)) for row, cell in pairs[counts > 1][:5]]
+        raise DataValidationError(f"The same unit and cell appear in more than one overlap: {repeated}.")
+
+    return Aggregation(units=row_order, rows=rows, columns=cells, weights=weights, n_cells=n_cells)
+
+
 def _validated_weights(weights: np.ndarray) -> np.ndarray:
     validated = np.asarray(weights, dtype=float)
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -54,6 +54,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/exactextract-0.3.0-py312ha2fa81c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fastexcel-0.20.2-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
@@ -556,6 +557,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py312h3093aea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.15.3-py312h04c11ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-hc919400_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/exactextract-0.3.0-py312hdf1b305_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastexcel-0.20.2-py312h232e7c1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.2-h2b252f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.63.0-py312h04c11ed_0.conda
@@ -791,6 +793,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/exactextract-0.3.0-py312ha2fa81c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fastexcel-0.20.2-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
@@ -1468,6 +1471,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.15.3-py312h04c11ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.21-py312h6510ced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-hc919400_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/exactextract-0.3.0-py312hdf1b305_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastexcel-0.20.2-py312h232e7c1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.2-h2b252f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.63.0-py312h04c11ed_0.conda
@@ -2451,6 +2455,25 @@ packages:
     - epoxy >=1.5.10,<1.6.0a0
   size: 411735
   timestamp: 1758743520805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/exactextract-0.3.0-py312ha2fa81c_5.conda
+  sha256: 9e594828b4a944080b4d526b81e30c295b0b578bf910cd5fb9921a69d1ba1ab4
+  md5: 1f1fb51932530781133ea23a837b5c24
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libgcc >=14
+  - libgdal-core >=3.13.1,<3.14.0a0
+  - libstdcxx >=14
+  - numpy
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/exactextract?source=hash-mapping
+  run_exports: {}
+  size: 454107
+  timestamp: 1783485581851
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fastexcel-0.20.2-py312h0ccc70a_0.conda
   sha256: d2c59dd2f7486a4edc2cccfa1b68e28da65ca3bf022f8caab3926c4cc97fd9c3
   md5: 7aea6d37a8edb19174f2a00272753e83
@@ -10043,6 +10066,25 @@ packages:
     - epoxy >=1.5.10,<1.6.0a0
   size: 296347
   timestamp: 1758743805063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/exactextract-0.3.0-py312hdf1b305_5.conda
+  sha256: 5fc23ce3881ad26e3599d8394fa59fed4b56f74cd257f04a1b660a938d05bacd
+  md5: f4d26d057f6cacbfb9120336aa5bba95
+  depends:
+  - __osx >=11.0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libcxx >=19
+  - libgdal-core >=3.13.1,<3.14.0a0
+  - numpy
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/exactextract?source=hash-mapping
+  run_exports: {}
+  size: 328236
+  timestamp: 1783486211540
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastexcel-0.20.2-py312h232e7c1_0.conda
   sha256: e0856ad50525172fb9a8d76764c897c1c10fdac87177dbebc7ae587be6b03e08
   md5: ea5361c46d1c4166303ddc19bac8d8c4
@@ -13101,6 +13143,7 @@ packages:
   name: climate-risk
   requires_dist:
   - arviz>=1.2,<2
+  - exactextract>=0.3,<1
   - fastexcel>=0.20,<1
   - geopandas>=1.1,<2
   - h5netcdf>=1.6,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "fastexcel>=0.20,<1",
     "kuznets[polars]>=1.0.1,<2",
     "geopandas>=1.1,<2",
+    "exactextract>=0.3,<1",
     "pymc>=6.3,<7",
     "pytensor>=3.3,<4",
     "arviz>=1.2,<2",
@@ -89,6 +90,7 @@ h5netcdf = ">=1.6,<2"
 openpyxl = ">=3.1,<4"
 xlrd = ">=2.0,<3"
 geopandas = ">=1.1,<2"
+exactextract = ">=0.3,<1"
 pymc = ">=6.3,<7"
 pytensor = ">=3.3,<4"
 arviz = ">=1.2,<2"
@@ -212,7 +214,7 @@ strict_equality = true
 
 # No stubs exist for these, on the index or in the packages themselves.
 [[tool.mypy.overrides]]
-module = ["arviz.*", "pymc.*", "pytensor.*", "ptgp.*", "sklearn.*", "statsmodels.*"]
+module = ["arviz.*", "pymc.*", "pytensor.*", "ptgp.*", "exactextract.*", "sklearn.*", "statsmodels.*"]
 ignore_missing_imports = true
 
 # Test functions carry no annotations, so their bodies need checking on their own terms.

--- a/tests/geo/test_raster.py
+++ b/tests/geo/test_raster.py
@@ -1,0 +1,361 @@
+import geopandas as gpd
+import numpy as np
+import pytest
+
+from pyproj import Geod
+from shapely.geometry import box
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.geo.crs import GEOGRAPHIC_CRS
+from climate_risk.geo.raster import (
+    KM_PER_DEGREE_LATITUDE,
+    MIN_CELLS_PER_AXIS,
+    build_cell_grid,
+    dissolve_place_boundary,
+    grid_axes,
+)
+
+
+def tiles(bounds, *, crs="EPSG:4326", **columns):
+    """A boundary split into several features, as a country's own administrative archive arrives."""
+    return gpd.GeoDataFrame({**columns, "geometry": [box(*corner) for corner in bounds]}, crs=crs)
+
+
+def test_both_boundary_sources_dissolve_to_the_same_geometry():
+    """The whole point of dissolving. A country's archive arrives as many districts with no ISO
+    column while the world slice arrives as one labelled feature, and the two paths must grid
+    identically or `lao` and `sea` silently disagree about where Laos is.
+    """
+    archive = tiles([(0, 0, 1, 1), (1, 0, 2, 1), (0, 1, 1, 2), (1, 1, 2, 2)], adm2_name=list("abcd"))
+    world_slice = tiles([(0, 0, 2, 2)], ISO_A3=["LAO"])
+
+    from_archive = dissolve_place_boundary(archive, iso3="LAO")
+    from_world = dissolve_place_boundary(world_slice)
+
+    assert list(from_archive.columns) == list(from_world.columns) == ["ISO_A3", "geometry"]
+    assert from_archive["ISO_A3"].tolist() == from_world["ISO_A3"].tolist() == ["LAO"]
+    assert from_archive.geometry.iloc[0].equals(from_world.geometry.iloc[0])
+
+
+def test_a_region_keeps_one_row_per_country():
+    """A region spans several countries and each keeps its own row, because the grid labels cells
+    by country. Dissolving the lot into one polygon would erase that.
+    """
+    region = tiles([(0, 0, 1, 1), (1, 0, 2, 1), (5, 5, 6, 6)], ISO_A3=["LAO", "LAO", "THA"])
+
+    dissolved = dissolve_place_boundary(region)
+
+    assert dissolved["ISO_A3"].tolist() == ["LAO", "THA"]
+    assert dissolved.loc[dissolved["ISO_A3"] == "LAO"].geometry.iloc[0].equals(box(0, 0, 2, 1))
+
+
+def test_a_labelled_boundary_ignores_the_fallback_code():
+    """A geometry that labels itself wins, matching `create_grid_from_shape`. Stamping the caller's
+    code over a multi-country slice would relabel every country as one.
+    """
+    dissolved = dissolve_place_boundary(tiles([(0, 0, 1, 1)], ISO_A3=["THA"]), iso3="LAO")
+
+    assert dissolved["ISO_A3"].tolist() == ["THA"]
+
+
+def test_the_boundary_comes_back_in_the_geographic_crs():
+    """Archives arrive in whatever CRS they were published in, and the grid is laid in degrees.
+    Gridding a projected boundary would put the cells in metres and space them wrongly.
+    """
+    projected = tiles([(0, 0, 1, 1)], crs="EPSG:3395", ISO_A3=["LAO"])
+
+    dissolved = dissolve_place_boundary(projected)
+
+    # A one-metre square on the equator spans about 9e-6 degrees, so untouched coordinates would
+    # come back a hundred thousand times wider than this.
+    assert dissolved.crs == GEOGRAPHIC_CRS
+    assert dissolved.total_bounds[2] < 1e-4
+
+
+def test_a_boundary_with_no_crs_is_rejected():
+    """Assuming lat/lon for an unlabelled CRS would place a projected archive off the coast of
+    Africa without complaint.
+    """
+    unlocated = gpd.GeoDataFrame({"ISO_A3": ["LAO"], "geometry": [box(0, 0, 1, 1)]})
+
+    with pytest.raises(DataValidationError, match="no CRS"):
+        dissolve_place_boundary(unlocated)
+
+
+def test_an_unlabelled_boundary_with_no_code_is_rejected():
+    with pytest.raises(DataValidationError, match="pass iso3"):
+        dissolve_place_boundary(tiles([(0, 0, 1, 1)]))
+
+
+def test_a_square_degree_on_the_equator_grids_squarely():
+    """On the equator a degree of longitude and a degree of latitude are the same distance, so the
+    two axes must come back with the same count. Any factor missing from the conversion shows up
+    as a difference here.
+    """
+    longitudes, latitudes = grid_axes((0.0, -0.5, 1.0, 0.5), resolution_km=KM_PER_DEGREE_LATITUDE / 4.0)
+
+    assert len(longitudes) == len(latitudes) == 4
+    np.testing.assert_allclose(longitudes, [0.125, 0.375, 0.625, 0.875])
+
+
+def test_the_axes_are_cell_centres_that_tile_the_extent():
+    """The operator sums one sample per cell, which is a midpoint rule. Returning the extent's
+    edges instead would put half of the first and last cells outside the place, and the weights
+    would claim ground the grid does not cover.
+    """
+    longitudes, _ = grid_axes((0.0, 0.0, 1.0, 1.0), resolution_km=KM_PER_DEGREE_LATITUDE / 4.0)
+    step = longitudes[1] - longitudes[0]
+
+    assert longitudes[0] == pytest.approx(step / 2.0)
+    assert longitudes[-1] == pytest.approx(1.0 - step / 2.0)
+
+
+def test_longitude_needs_fewer_cells_away_from_the_equator():
+    """A degree of longitude at 60N is half a degree at the equator, so the same degree span needs
+    about half the cells. Spacing both axes by degrees would make every high-latitude cell twice
+    as wide as it is tall, and the weights would inherit that.
+    """
+    longitudes, latitudes = grid_axes((0.0, 59.5, 1.0, 60.5), resolution_km=10.0)
+
+    assert len(longitudes) == pytest.approx(len(latitudes) / 2, abs=1)
+    assert len(longitudes) < len(latitudes)
+
+
+def test_cells_are_square_in_the_middle_of_a_tall_extent():
+    """Longitude is converted at the extent's mean latitude, so a place spanning many degrees gets
+    square cells at its centre. Converting at an edge instead skews every cell across the whole
+    grid, and the error grows with how tall the place is.
+    """
+    resolution = 50.0
+    longitudes, latitudes = grid_axes((0.0, 50.0, 10.0, 70.0), resolution_km=resolution)
+
+    middle = np.cos(np.radians(60.0))
+    longitude_step_km = (longitudes[1] - longitudes[0]) * KM_PER_DEGREE_LATITUDE * middle
+    latitude_step_km = (latitudes[1] - latitudes[0]) * KM_PER_DEGREE_LATITUDE
+
+    assert longitude_step_km == pytest.approx(resolution, rel=0.1)
+    assert latitude_step_km == pytest.approx(resolution, rel=0.1)
+
+
+def test_the_cell_count_scales_with_the_resolution_asked_for():
+    """Five times finer is five times as many cells along an axis. A conversion that ignored the
+    argument, or applied it as a count rather than a distance, would break this ratio.
+    """
+    coarse, _ = grid_axes((0.0, 0.0, 10.0, 10.0), resolution_km=50.0)
+    fine, _ = grid_axes((0.0, 0.0, 10.0, 10.0), resolution_km=10.0)
+
+    assert len(fine) == pytest.approx(5 * len(coarse), rel=0.02)
+
+
+def test_an_extent_smaller_than_a_cell_becomes_one_cell():
+    """A place smaller than the requested resolution is one cell sampled at its middle, not zero
+    cells and not a degenerate axis.
+    """
+    longitudes, latitudes = grid_axes((0.0, 0.0, 0.01, 0.01), resolution_km=100.0)
+
+    assert len(longitudes) == len(latitudes) == MIN_CELLS_PER_AXIS
+    assert longitudes[0] == pytest.approx(0.005)
+
+
+@pytest.mark.parametrize("resolution", [0.0, -5.0])
+def test_a_non_positive_resolution_is_rejected(resolution):
+    with pytest.raises(DataValidationError, match="positive distance"):
+        grid_axes((0.0, 0.0, 1.0, 1.0), resolution_km=resolution)
+
+
+def test_inverted_bounds_are_rejected():
+    """A transposed bounds tuple would otherwise give a negative span, one point per axis, and a
+    grid silently covering nothing.
+    """
+    with pytest.raises(DataValidationError, match="inverted"):
+        grid_axes((1.0, 0.0, 0.0, 1.0), resolution_km=10.0)
+
+
+def test_a_cell_the_place_misses_entirely_is_dropped():
+    """The grid is laid over a rectangular extent, so an L-shaped place has cells in the notch that
+    belong to nobody. Keeping them would put ground in the model that the place does not cover.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 1), (0, 1, 1, 2)], ISO_A3=["LAO", "LAO"]))
+
+    cells = build_cell_grid(boundary, resolution_km=20.0).cells
+    deep_in_the_notch = (cells["lon"] > 1.2) & (cells["lat"] > 1.2)
+
+    assert len(cells) > 0
+    assert not deep_in_the_notch.any()
+
+
+def test_a_cell_on_the_frontier_is_kept_with_the_part_inside():
+    """Dropping a straddling cell takes its overlaps with the border units too, and a country is
+    mostly border at any resolution coarse enough to model. It is kept, credited with the ground
+    the place actually covers.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 1), (0, 1, 1, 2)], ISO_A3=["LAO", "LAO"]))
+
+    cells = build_cell_grid(boundary, resolution_km=20.0).cells
+    partial = cells["place_area_km2"] < cells["cell_area_km2"] - 1e-9
+
+    assert partial.any(), "the notch and the outline should both cut cells"
+    assert (cells["place_area_km2"] > 0.0).all()
+    assert (cells["place_area_km2"] <= cells["cell_area_km2"] + 1e-9).all()
+
+
+def test_the_covered_area_adds_up_to_the_place():
+    """The reason for coverage over centre-in-polygon. Summed over cells, the covered area is the
+    place's own area; clipping by centre loses whatever the border cells were carrying, which for
+    a ragged outline is percent-scale rather than rounding.
+    """
+    outline = box(0, 0, 2, 1).union(box(0, 1, 1, 2))
+    boundary = dissolve_place_boundary(gpd.GeoDataFrame({"ISO_A3": ["LAO"], "geometry": [outline]}, crs=GEOGRAPHIC_CRS))
+    exact = abs(Geod(ellps="WGS84").geometry_area_perimeter(outline)[0]) / 1e6
+
+    cells = build_cell_grid(boundary, resolution_km=20.0).cells
+
+    assert cells["place_area_km2"].sum() == pytest.approx(exact, rel=1e-3)
+    assert cells["cell_area_km2"].sum() > exact, "the lattice covers the bounding box, not the place"
+
+
+def test_each_cell_takes_the_country_it_lands_in():
+    """Cells are labelled by the polygon they fall in, not by the place as a whole, because a
+    region spans several countries and the model reports by country.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 1, 1), (3, 0, 4, 1)], ISO_A3=["LAO", "THA"]))
+
+    cells = build_cell_grid(boundary, resolution_km=20.0).cells
+
+    assert set(cells["ISO_A3"]) == {"LAO", "THA"}
+    assert cells.loc[cells["lon"] < 2.0, "ISO_A3"].eq("LAO").all()
+    assert cells.loc[cells["lon"] > 2.0, "ISO_A3"].eq("THA").all()
+
+
+def test_the_cell_areas_sum_to_the_area_of_the_extent():
+    """The weights are what the operator integrates with, so they have to add up to real ground.
+    A lon/lat box has a closed-form area, and the band runs to 60N so that treating cells as
+    equal-area would overshoot it by a fifth rather than by a rounding error.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 1, 60)], ISO_A3=["LAO"]))
+    extent = box(0.0, 0.0, 1.0, 60.0)
+    exact = abs(Geod(ellps="WGS84").geometry_area_perimeter(extent)[0]) / 1e6
+    flat = KM_PER_DEGREE_LATITUDE**2 * 60.0
+
+    cells = build_cell_grid(boundary, resolution_km=25.0).cells
+
+    assert cells["cell_area_km2"].sum() == pytest.approx(exact, rel=1e-3)
+    assert exact < flat / 1.2
+
+
+def test_cells_shrink_towards_the_pole():
+    """Equal angular cells cover less ground at high latitude. Treating them as equal-area would
+    overweight the top of a tall place in every total that spans it.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 1, 60)], ISO_A3=["LAO"]))
+
+    cells = build_cell_grid(boundary, resolution_km=100.0).cells
+    southern = cells.loc[cells["lat"] < 5.0, "cell_area_km2"].mean()
+    northern = cells.loc[cells["lat"] > 55.0, "cell_area_km2"].mean()
+
+    assert northern < southern / 1.5
+
+
+def test_a_boundary_that_was_not_dissolved_is_rejected():
+    """Gridding a raw archive would work and label nothing, so the grid would carry no country."""
+    with pytest.raises(DataValidationError, match="dissolve_place_boundary"):
+        build_cell_grid(tiles([(0, 0, 1, 1)], adm2_name=["a"]), resolution_km=20.0)
+
+
+def test_an_empty_boundary_is_rejected():
+    """An ISO code matching nothing in the world file reaches here as an empty frame, and an empty
+    grid is a confusing way to find out.
+    """
+    with pytest.raises(DataValidationError, match="nothing to grid"):
+        dissolve_place_boundary(gpd.GeoDataFrame({"ISO_A3": [], "geometry": []}, crs="EPSG:4326"))
+
+
+def test_the_lattice_index_survives_clipping():
+    """`cell_id` indexes the full lattice, not the surviving rows, because the zonal pass runs over
+    the whole raster. Renumbering after the clip would silently shift every assignment.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 1), (0, 1, 1, 2)], ISO_A3=["LAO", "LAO"]))
+
+    grid = build_cell_grid(boundary, resolution_km=40.0)
+    rows, columns = grid.shape
+
+    # Rebuild the index from each cell's position in the lattice, independently of how it was set.
+    row_of_cell = np.searchsorted(-grid.latitudes, -grid.cells["lat"].to_numpy())
+    column_of_cell = np.searchsorted(grid.longitudes, grid.cells["lon"].to_numpy())
+
+    assert len(grid.cells) < rows * columns, "the notch should have cost some cells"
+    np.testing.assert_array_equal(grid.cells["cell_id"].to_numpy(), row_of_cell * columns + column_of_cell)
+
+
+def test_the_lattice_rows_run_north_to_south():
+    """Raster order, so `cell_id` lines up with what a zonal pass reports. Ascending latitudes
+    would flip the grid vertically and put every unit's cells in the wrong hemisphere of the place.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 1, 1)], ISO_A3=["LAO"]))
+
+    grid = build_cell_grid(boundary, resolution_km=20.0)
+
+    assert grid.latitudes[0] > grid.latitudes[-1]
+    northernmost = grid.cells.loc[grid.cells["cell_id"].idxmin(), "lat"]
+    assert northernmost == pytest.approx(grid.latitudes[0])
+
+
+def test_a_footprint_covers_the_ground_its_area_claims():
+    """The footprint and `cell_area_km2` describe the same rectangle, so measuring one must give
+    the other. A half-step error in the corners would show up as a factor of four here and is
+    otherwise invisible, since the centres would still look right.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 40)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=50.0)
+    geodesic = Geod(ellps="WGS84")
+
+    measured = np.array([abs(geodesic.geometry_area_perimeter(shape)[0]) / 1e6 for shape in grid.footprints])
+
+    np.testing.assert_allclose(measured, grid.cells["cell_area_km2"].to_numpy(), rtol=1e-9)
+
+
+def test_footprints_are_centred_on_the_cells_they_belong_to():
+    """Off-by-one in the index would pair each footprint with a neighbour's centre, which tiles
+    just as neatly and puts every covariate one cell out.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 2)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=40.0)
+
+    assert grid.footprints.contains(grid.cells.geometry).all()
+
+
+def test_a_one_cell_place_still_reports_its_geometry():
+    """A place smaller than the resolution grids to a single cell, and the derived geometry has to
+    survive that. Inferring the step from the gap between the first two centres has no gap to read
+    and takes every downstream caller down with it, including the unit assignment.
+    """
+    tiny = gpd.GeoDataFrame({"ISO_A3": ["SGP"], "geometry": [box(103.6, 1.2, 104.0, 1.5)]}, crs=GEOGRAPHIC_CRS)
+
+    grid = build_cell_grid(dissolve_place_boundary(tiny), resolution_km=200.0)
+
+    assert grid.shape == (1, 1)
+    assert grid.steps == pytest.approx((0.4, 0.3))
+    assert grid.bounds == pytest.approx((103.6, 1.2, 104.0, 1.5))
+    assert grid.footprints.iloc[0].bounds == pytest.approx((103.6, 1.2, 104.0, 1.5))
+
+
+def test_a_cell_on_an_internal_frontier_takes_the_larger_country():
+    """A region's cells straddle its members' shared borders. The cell is one piece of ground:
+    labelled by whichever country holds most of it, and credited with everything the place covers
+    rather than only the dominant country's share.
+    """
+    # The majority country sorts last, so labelling by the largest share and labelling by the first
+    # row the zonal pass returns give different answers.
+    boundary = dissolve_place_boundary(tiles([(0, 0, 0.95, 2), (0.95, 0, 2, 2)], ISO_A3=["AAA", "ZZZ"]))
+
+    grid = build_cell_grid(boundary, resolution_km=20.0)
+    half_width = grid.longitude_step / 2.0
+    straddling = grid.cells[(grid.cells["lon"] - half_width < 0.95) & (grid.cells["lon"] + half_width > 0.95)]
+
+    assert not straddling.empty, "a column of cells should span the frontier"
+    assert straddling["ISO_A3"].eq("ZZZ").all(), "the frontier sits left of centre, so ZZZ holds more"
+    # Coverage comes back from exactextract as float32, so two shares of one cell sum to 1 within
+    # single precision rather than exactly.
+    np.testing.assert_allclose(
+        straddling["place_area_km2"].to_numpy(), straddling["cell_area_km2"].to_numpy(), rtol=1e-6
+    )

--- a/tests/geo/test_raster.py
+++ b/tests/geo/test_raster.py
@@ -10,6 +10,7 @@ from climate_risk.geo.crs import GEOGRAPHIC_CRS
 from climate_risk.geo.raster import (
     KM_PER_DEGREE_LATITUDE,
     MIN_CELLS_PER_AXIS,
+    assign_cells_to_units,
     build_cell_grid,
     dissolve_place_boundary,
     grid_axes,
@@ -300,6 +301,82 @@ def test_the_lattice_rows_run_north_to_south():
     assert northernmost == pytest.approx(grid.latitudes[0])
 
 
+def test_a_cell_on_a_border_is_shared_between_units():
+    """The reason for area weighting. A column of cells straddling the border belongs half to each
+    unit, and the operator carries both rows. Assigning by centre would give one unit the lot.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 4, 4)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=KM_PER_DEGREE_LATITUDE)
+    units = gpd.GeoDataFrame(
+        {"gid": ["west", "east"], "geometry": [box(0, 0, 1.5, 4), box(1.5, 0, 4, 4)]}, crs=GEOGRAPHIC_CRS
+    )
+
+    overlaps = assign_cells_to_units(grid, units)
+    shared = overlaps["cell_id"].value_counts()
+
+    assert set(overlaps["gid"]) == {"west", "east"}
+    assert (shared == 2).sum() == 4, "one straddling cell per row of the grid"
+    np.testing.assert_allclose(overlaps.loc[overlaps["cell_id"] == 1, "coverage"].to_numpy(), [0.5, 0.5])
+
+
+def test_each_cell_is_fully_accounted_for_by_the_units_covering_it():
+    """Units that tile the place must claim every cell exactly once between them. Coverage summing
+    to less would lose ground from the totals and more would double-count it.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 4, 4)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=KM_PER_DEGREE_LATITUDE)
+    units = gpd.GeoDataFrame(
+        {"gid": ["west", "east"], "geometry": [box(0, 0, 1.5, 4), box(1.5, 0, 4, 4)]}, crs=GEOGRAPHIC_CRS
+    )
+
+    overlaps = assign_cells_to_units(grid, units)
+    per_cell = overlaps.groupby("cell_id")["coverage"].sum()
+
+    np.testing.assert_allclose(per_cell.to_numpy(), 1.0, atol=1e-6)
+    assert overlaps["overlap_km2"].sum() == pytest.approx(grid.cells["cell_area_km2"].sum(), rel=1e-6)
+
+
+def test_a_cell_outside_every_unit_gets_no_row():
+    """Units rarely tile a country exactly, and a cell in the gap contributes to no total. Keeping
+    it with zero coverage would put a column in the operator that nothing reads.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 4, 4)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=KM_PER_DEGREE_LATITUDE)
+    units = gpd.GeoDataFrame({"gid": ["corner"], "geometry": [box(0, 0, 1, 1)]}, crs=GEOGRAPHIC_CRS)
+
+    overlaps = assign_cells_to_units(grid, units)
+
+    assert len(overlaps) < len(grid.cells)
+    assert overlaps["gid"].eq("corner").all()
+
+
+def test_units_are_reprojected_before_they_meet_the_grid():
+    """Units arrive from GADM in whatever CRS it publishes. Overlaying a projected unit on a
+    lat/lon grid would find no overlap at all and return an empty operator.
+    """
+    # Away from the origin, so a polygon left in metres lands nowhere near the lattice rather than
+    # swallowing it. At the origin the projected coordinates still cover the degree-scale grid and
+    # the test would pass whether or not anything was reprojected.
+    boundary = dissolve_place_boundary(tiles([(100, 13, 104, 17)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=KM_PER_DEGREE_LATITUDE)
+    units = gpd.GeoDataFrame({"gid": ["all"], "geometry": [box(100, 13, 104, 17)]}, crs=GEOGRAPHIC_CRS).to_crs(
+        "EPSG:3395"
+    )
+
+    overlaps = assign_cells_to_units(grid, units)
+
+    assert len(overlaps) == len(grid.cells) > 0
+
+
+def test_units_without_the_key_column_are_rejected():
+    boundary = dissolve_place_boundary(tiles([(0, 0, 4, 4)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=KM_PER_DEGREE_LATITUDE)
+    units = gpd.GeoDataFrame({"name": ["all"], "geometry": [box(0, 0, 4, 4)]}, crs=GEOGRAPHIC_CRS)
+
+    with pytest.raises(DataValidationError, match="'gid'"):
+        assign_cells_to_units(grid, units)
+
+
 def test_a_footprint_covers_the_ground_its_area_claims():
     """The footprint and `cell_area_km2` describe the same rectangle, so measuring one must give
     the other. A half-step error in the corners would show up as a factor of four here and is
@@ -337,6 +414,7 @@ def test_a_one_cell_place_still_reports_its_geometry():
     assert grid.steps == pytest.approx((0.4, 0.3))
     assert grid.bounds == pytest.approx((103.6, 1.2, 104.0, 1.5))
     assert grid.footprints.iloc[0].bounds == pytest.approx((103.6, 1.2, 104.0, 1.5))
+    assert len(assign_cells_to_units(grid, tiny.rename(columns={"ISO_A3": "gid"}))) == 1
 
 
 def test_a_cell_on_an_internal_frontier_takes_the_larger_country():
@@ -359,3 +437,60 @@ def test_a_cell_on_an_internal_frontier_takes_the_larger_country():
     np.testing.assert_allclose(
         straddling["place_area_km2"].to_numpy(), straddling["cell_area_km2"].to_numpy(), rtol=1e-6
     )
+
+
+def test_a_unit_smaller_than_a_cell_still_gets_its_share():
+    """Small units are the ones with the fewest events, so losing them to the grid resolution drops
+    exactly the observations that most need the field. The unit's own area comes back out of the
+    cell it sits inside.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 2)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=50.0)
+    speck = box(0.5, 0.5, 0.55, 0.55)
+    units = gpd.GeoDataFrame({"gid": ["speck"], "geometry": [speck]}, crs=GEOGRAPHIC_CRS)
+    exact = abs(Geod(ellps="WGS84").geometry_area_perimeter(speck)[0]) / 1e6
+
+    overlaps = assign_cells_to_units(grid, units)
+
+    assert overlaps["gid"].eq("speck").all()
+    assert 0.0 < overlaps["coverage"].sum() < 1.0, "the speck is a fraction of one cell"
+    assert overlaps["overlap_km2"].sum() == pytest.approx(exact, rel=1e-3)
+
+
+def test_the_operator_column_is_the_position_among_surviving_cells():
+    """`cell_id` numbers the lattice and the operator numbers what survived clipping, so the two
+    diverge from the first dropped cell. Feeding lattice ids straight to the operator would index
+    the wrong cells and still produce plausible totals.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 1), (0, 1, 1, 2)], ISO_A3=["LAO", "LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=40.0)
+
+    columns = grid.column_of_cell(grid.cells["cell_id"].to_numpy())
+
+    assert (grid.cells["cell_id"].to_numpy() != columns).any(), "clipping should have shifted the spaces apart"
+    np.testing.assert_array_equal(columns, np.arange(len(grid.cells)))
+
+
+def test_a_repeated_cell_maps_to_the_same_column():
+    """An overlap table names a shared cell once per unit, so the translation has to be a lookup
+    rather than a renumbering of whatever it was handed.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 2, 2)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=40.0)
+    shared = grid.cells["cell_id"].to_numpy()[[3, 1, 3, 1]]
+
+    columns = grid.column_of_cell(shared)
+
+    assert columns[0] == columns[2] == 3
+    assert columns[1] == columns[3] == 1
+
+
+def test_a_cell_outside_the_grid_is_named_rather_than_translated():
+    """A cell id from a different lattice, or from this one before clipping, would otherwise become
+    a silently wrong column.
+    """
+    boundary = dissolve_place_boundary(tiles([(0, 0, 1, 1)], ISO_A3=["LAO"]))
+    grid = build_cell_grid(boundary, resolution_km=40.0)
+
+    with pytest.raises(DataValidationError, match="not in the grid"):
+        grid.column_of_cell(np.array([0, 10_000]))

--- a/tests/models/test_aggregation.py
+++ b/tests/models/test_aggregation.py
@@ -4,7 +4,7 @@ import pytensor.tensor as pt
 import pytest
 
 from climate_risk.exceptions import DataValidationError
-from climate_risk.models.aggregation import build_aggregation
+from climate_risk.models.aggregation import build_aggregation, build_aggregation_from_overlaps
 
 # A unit square split into a left and a right half, so both units have a known analytic integral.
 SPLIT = 0.5
@@ -275,3 +275,83 @@ def test_a_field_of_the_wrong_length_is_rejected():
 
     with pytest.raises(DataValidationError, match="built for 2"):
         aggregation.aggregate(np.ones(3))
+
+
+def test_a_cell_split_between_units_contributes_to_both():
+    """The reason this constructor exists. A cell on a border is one piece of ground shared between
+    two units, and each must receive the part that falls inside it. The per-cell constructor cannot
+    express that at all, since it takes one label per cell.
+    """
+    aggregation = build_aggregation_from_overlaps(
+        unit_of_overlap=["a", "a", "b", "b"],
+        cell_of_overlap=np.array([0, 1, 1, 2]),
+        weights=np.array([1.0, 0.25, 0.75, 1.0]),
+        n_cells=3,
+    )
+
+    totals = aggregation.aggregate(np.array([10.0, 100.0, 1000.0]))
+
+    assert aggregation.units == ("a", "b")
+    assert totals == pytest.approx([10.0 + 25.0, 75.0 + 1000.0])
+
+
+def test_the_two_constructors_agree_when_no_cell_is_shared():
+    """One overlap per cell is the case the per-cell constructor already covers, so the operators
+    must be identical there. A divergence means the shared validation has drifted.
+    """
+    per_cell = build_aggregation(unit_of_cell=["b", None, "a", "b"], weights=np.array([1.0, 9.0, 2.0, 3.0]))
+    from_overlaps = build_aggregation_from_overlaps(
+        unit_of_overlap=["b", "a", "b"],
+        cell_of_overlap=np.array([0, 2, 3]),
+        weights=np.array([1.0, 2.0, 3.0]),
+        n_cells=4,
+    )
+
+    field = np.array([1.0, 2.0, 4.0, 8.0])
+
+    assert from_overlaps.units == per_cell.units
+    assert from_overlaps.n_cells == per_cell.n_cells
+    np.testing.assert_allclose(from_overlaps.aggregate(field), per_cell.aggregate(field))
+
+
+def test_a_cell_named_in_no_overlap_keeps_its_column():
+    """Cells outside every unit still sit in the grid, so the operator has to stay as wide as the
+    field the model evaluates. A narrower operator would silently misalign against it.
+    """
+    aggregation = build_aggregation_from_overlaps(
+        unit_of_overlap=["a"], cell_of_overlap=np.array([0]), weights=np.array([1.0]), n_cells=4
+    )
+
+    assert aggregation.n_cells == 4
+    assert aggregation.aggregate(np.arange(4.0)) == pytest.approx([0.0])
+
+
+def test_the_same_unit_and_cell_twice_is_rejected():
+    """A duplicated pair is summed silently by the sparse matrix, so a double-counted overlap would
+    inflate one unit's total with nothing to show for it.
+    """
+    with pytest.raises(DataValidationError, match="more than one overlap"):
+        build_aggregation_from_overlaps(
+            unit_of_overlap=["a", "a"],
+            cell_of_overlap=np.array([1, 1]),
+            weights=np.array([0.5, 0.5]),
+            n_cells=2,
+        )
+
+
+@pytest.mark.parametrize("cell", [-1, 5])
+def test_an_overlap_naming_a_cell_outside_the_grid_is_rejected(cell):
+    """The cell index comes from a raster pass that knows the whole lattice, while the operator is
+    built for the clipped field. An index past the end would raise far away from the mismatch.
+    """
+    with pytest.raises(DataValidationError, match="outside the grid"):
+        build_aggregation_from_overlaps(
+            unit_of_overlap=["a"], cell_of_overlap=np.array([cell]), weights=np.array([1.0]), n_cells=3
+        )
+
+
+def test_mismatched_overlap_columns_are_rejected():
+    with pytest.raises(DataValidationError, match="one of each"):
+        build_aggregation_from_overlaps(
+            unit_of_overlap=["a", "b"], cell_of_overlap=np.array([0]), weights=np.array([1.0]), n_cells=2
+        )

--- a/tests/models/test_aggregation.py
+++ b/tests/models/test_aggregation.py
@@ -355,3 +355,17 @@ def test_mismatched_overlap_columns_are_rejected():
         build_aggregation_from_overlaps(
             unit_of_overlap=["a", "b"], cell_of_overlap=np.array([0]), weights=np.array([1.0]), n_cells=2
         )
+
+
+def test_units_that_miss_the_grid_entirely_give_an_empty_operator():
+    """The raster layer hands over whatever overlaps it found, and a place whose units all miss the
+    grid finds none. That has to come back as an operator with no rows rather than raise, and it
+    still has to be as wide as the field the model evaluates.
+    """
+    aggregation = build_aggregation_from_overlaps(
+        unit_of_overlap=[], cell_of_overlap=np.array([], dtype=int), weights=np.array([]), n_cells=4
+    )
+
+    assert aggregation.units == ()
+    assert aggregation.n_cells == 4
+    assert aggregation.aggregate(np.arange(4.0)).shape == (0,)


### PR DESCRIPTION
Turns a `Place` into the quadrature the areal model integrates over: a weighted cell grid, and a table of which administrative units each cell overlaps. Resolution is in kilometers rather than points per axis, and cell areas are measured on the ellipsoid, since a spherical cos(latitude) form is biased by a few parts in a thousand in a way that runs with latitude — a systematic tilt across a place, not noise.

Membership and assignment are both by area coverage rather than by whether a cell's center falls inside, which is why exactextract is now a dependency. At 20 km over Laos a third of cells sit on a province border, and center-clipping drops them whole: province areas came out 4.2% low on median and 11.3% off at worst, concentrated in the small units whose event counts are already thinnest. By coverage they reconcile exactly. `build_aggregation_from_overlaps` is the matching constructor, since a shared cell belongs to several units and the per-cell one takes a single label.
