### PR TITLE
Measure distance to the nearest feature with a spatial join

### DIFF
--- a/climate_risk/data_functions/rivers_damage.py
+++ b/climate_risk/data_functions/rivers_damage.py
@@ -12,7 +12,7 @@ from climate_risk.data_functions.emdat_processing import event_filter, load_emda
 from climate_risk.data_functions.rivers_data_loader import load_rivers_data
 from climate_risk.data_functions.shapefiles_data_loader import load_shapefile
 from climate_risk.geo.crs import to_km
-from climate_risk.geo.distance import get_distance_to_rivers
+from climate_risk.geo.distance import get_distance_to
 
 DAMAGE_COLUMNS = ("ISO", "End Year", "Latitude", "Longitude", "River Basin", "Total_Damage", "Total_Affected", "Deaths")
 
@@ -81,7 +81,9 @@ def _create_rivers_damage(
             crs=world.crs,
         )
 
-        closest_river = get_distance_to_rivers(big_rivers, damage_df)
+        closest_river = get_distance_to(big_rivers, points=damage_df, return_columns=["ORD_FLOW", "HYRIV_ID"]).rename(
+            columns={"distance_to_closest": "closest_river"}
+        )
         closest_river["closest_river"] = to_km(closest_river["closest_river"])
 
         damage_df = damage_df.join(closest_river).rename(columns=totals)

--- a/climate_risk/geo/distance.py
+++ b/climate_risk/geo/distance.py
@@ -1,33 +1,11 @@
 import geopandas as gpd
 import pandas as pd
 
-from tqdm.auto import tqdm
-
 from climate_risk.exceptions import DataValidationError
 from climate_risk.geo.crs import PROJECTED_CRS
 
 # Distances come back in metres, and a point sitting on a feature measures zero, which has no log.
 MIN_DISTANCE_METRES = 1.0
-
-
-def get_distance_to_rivers(
-    rivers: gpd.GeoDataFrame, points: gpd.GeoDataFrame, crs: str = PROJECTED_CRS
-) -> pd.DataFrame:
-    ret = pd.DataFrame(index=points.index, columns=["closest_river", "ORD_FLOW", "HYRIV_ID"])
-    rivers_km = rivers.copy().to_crs(crs)
-    points_km = points.copy().to_crs(crs)
-    for idx, row in tqdm(points_km.iterrows(), total=points.shape[0]):
-        series = rivers_km.distance(row.geometry)
-        ret.loc[idx, "closest_river"] = series.min()
-
-        index = series[series == series.min()].index[0]
-        ret.loc[idx, "ORD_FLOW"] = rivers_km.loc[index]["ORD_FLOW"]
-        ret.loc[idx, "HYRIV_ID"] = rivers_km.loc[index]["HYRIV_ID"]
-
-    ret["ORD_FLOW"] = ret["ORD_FLOW"].astype("int")
-    ret["HYRIV_ID"] = ret["HYRIV_ID"].astype("int")
-    ret["closest_river"] = ret["closest_river"].astype("float")
-    return ret
 
 
 def get_distance_to(

--- a/climate_risk/geo/distance.py
+++ b/climate_risk/geo/distance.py
@@ -1,11 +1,9 @@
-from typing import Any
-
 import geopandas as gpd
 import pandas as pd
 
-from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
+from climate_risk.exceptions import DataValidationError
 from climate_risk.geo.crs import PROJECTED_CRS
 
 # Distances come back in metres, and a point sitting on a feature measures zero, which has no log.
@@ -37,8 +35,6 @@ def get_distance_to(
     points: gpd.GeoDataFrame,
     return_columns: list[str] | None = None,
     crs: str = PROJECTED_CRS,
-    n_cores: int = -1,
-    name: str | None = None,
 ) -> pd.DataFrame:
     """
     Measure the distance from every point to the nearest feature in ``gdf``.
@@ -56,11 +52,6 @@ def get_distance_to(
     crs : str, optional
         Projected CRS to measure in, which fixes the units of the result. Default
         ``PROJECTED_CRS``, giving metres.
-    n_cores : int, optional
-        Cores to measure on, passed to joblib. Default -1, meaning all of them.
-    name : str, optional
-        Name of the features, used only in the progress description. Default None, which shows no
-        description.
 
     Returns
     -------
@@ -68,29 +59,26 @@ def get_distance_to(
         ``distance_to_closest`` plus one column per entry in ``return_columns``, indexed like
         ``points``.
     """
-    if return_columns is None:
-        return_columns = []
+    carried = list(return_columns or [])
 
-    gdf_km = gdf.copy().to_crs(crs)
-    points_km = points.copy().to_crs(crs)
-
-    def get_closest(
-        idx: object, row: pd.Series, gdf_km: gpd.GeoDataFrame | gpd.GeoSeries, return_columns: list[str]
-    ) -> tuple[Any, ...]:
-        series = gdf_km.distance(row.geometry)
-        index = series[series == series.min()].index[0]
-
-        ret_vals: tuple[Any, ...] = (series.min(),)
-        for col in return_columns:
-            ret_vals += (gdf_km.loc[index][col],)
-
-        return ret_vals
-
-    desc = f"Calculating distances to {name}" if name is not None else None
-
-    with Parallel(n_cores, require="sharedmem") as pool:
-        results = pool(
-            delayed(get_closest)(idx, row, gdf_km, return_columns)
-            for idx, row in tqdm(points_km.iterrows(), total=points.shape[0], desc=desc)
+    if gdf.empty:
+        raise DataValidationError(
+            "There are no features to measure to, so every distance would come back as NaN and poison whatever "
+            "it is joined onto."
         )
-    return pd.DataFrame(results, columns=["distance_to_closest", *return_columns], index=points.index)
+
+    wanted = gdf if isinstance(gdf, gpd.GeoSeries) else gdf[[*carried, gdf.geometry.name]]
+    features = gpd.GeoDataFrame(geometry=wanted) if isinstance(wanted, gpd.GeoSeries) else wanted
+    features = features.to_crs(crs).reset_index(drop=True)
+
+    # Only the geometry crosses the join, so a column shared with the features cannot collide, and
+    # the index is positional so that a repeated label in `points` is not mistaken for a tie below.
+    origins = gpd.GeoDataFrame(geometry=points.geometry.to_numpy(), crs=points.crs).to_crs(crs)
+
+    matched = origins.sjoin_nearest(features, how="left", distance_col="distance_to_closest")
+    # A point equidistant from two features matches both; the first is as good as either.
+    nearest = matched[~matched.index.duplicated(keep="first")]
+
+    return pd.DataFrame(
+        {column: nearest[column].to_numpy() for column in ("distance_to_closest", *carried)}, index=points.index
+    )

--- a/pixi.lock
+++ b/pixi.lock
@@ -391,7 +391,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
@@ -731,7 +730,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl
@@ -1216,7 +1214,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/a3/68451ecf694c78b076741ace807673fe4e8723656cc14618e9aa2700973c/geconpy-2.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -1653,7 +1650,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/34/a3/68451ecf694c78b076741ace807673fe4e8723656cc14618e9aa2700973c/geconpy-2.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/aa/5eadc617e5c0ffcb93e716fa57204376be2f161f5cd3a4054ae63c9abecd/pymc_extras-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/ae/5b30e13eb0132f3a3e753eb49680a41862e0bcde3948d96ac199c4f7d832/sympytensor-2.1.0-py3-none-any.whl
@@ -13166,7 +13162,6 @@ packages:
   - tqdm>=4.70,<5
   - xarray>=2026.7,<2027
   - xlrd>=2.0,<3
-  - joblib-stubs>=1.5.3.1,<2 ; extra == 'dev'
   - mypy>=2.3,<3 ; extra == 'dev'
   - pandas-stubs>=3.0.5,<4 ; extra == 'dev'
   - pre-commit>=4.6,<5 ; extra == 'dev'
@@ -13251,16 +13246,6 @@ packages:
   - sphinx>=5 ; extra == 'docs'
   - sphinxcontrib-bibtex ; extra == 'docs'
   - watermark ; extra == 'docs'
-  requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/37/7c/67ada9621b3c93caa75aba1a0b651dae988b22cdea93b33e7e49261364f5/joblib_stubs-1.5.3.1.20260117-py3-none-any.whl
-  name: joblib-stubs
-  version: 1.5.3.1.20260117
-  sha256: ef9f570617b232263c8166f5b4351a5dcc90669d8b07e7e2cd7b25c3b0f26d5f
-  requires_dist:
-  - typing-extensions>=4.4.0
-  - mypy>=1.19.1 ; extra == 'mypy'
-  - mypy==1.19.1 ; extra == 'mypy-strict'
-  - mypy>=1.19.1 ; extra == 'mypy-strict'
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
   name: mpmath

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dev = [
     "types-geopandas>=1.1.4,<2",
     "types-shapely>=2.1,<3",
     "types-tqdm>=4.70,<5",
-    "joblib-stubs>=1.5.3.1,<2",
     "scipy-stubs>=1.18.0.1,<2",
     "types-seaborn>=0.13.2.20240417,<1",
     "types-requests>=2.33,<3",
@@ -119,10 +118,6 @@ types-shapely = ">=2.1,<3"
 types-requests = ">=2.33.0.20260712,<3"
 scipy-stubs = ">=1.18.0.1,<2"
 types-seaborn = ">=0.13.2.20240417,<1"
-
-# joblib-stubs is not on conda-forge.
-[tool.pixi.feature.dev.pypi-dependencies]
-joblib-stubs = ">=1.5.3.1,<2"
 
 [tool.pixi.feature.notebooks.dependencies]
 notebook = ">=7.6,<8"

--- a/tests/geo/test_distance.py
+++ b/tests/geo/test_distance.py
@@ -1,20 +1,27 @@
 import geopandas as gpd
+import numpy as np
+import pytest
 
-from shapely.geometry import LineString
+from shapely.geometry import LineString, box
 
+from climate_risk.exceptions import DataValidationError
 from climate_risk.geo.distance import get_distance_to
 
 
 def test_distance_is_measured_in_metres_of_the_projected_crs(grid_points):
-    """to_km only holds while the CRS is metric, and every caller runs the default parallel path."""
+    """`to_km` and the log transforms downstream only hold while the result is in metres. Measuring
+    in the points' own lat/lon would return half a degree here and read as half a metre.
+    """
     rivers = gpd.GeoDataFrame(
         {"ORD_FLOW": [4], "HYRIV_ID": [1], "geometry": [LineString([(0, -1), (0, 2)])]}, crs="EPSG:4326"
     )
 
     distances = get_distance_to(rivers, points=grid_points)["distance_to_closest"]
 
-    assert distances.iloc[0] > 10_000
-    assert distances.iloc[0] < distances.iloc[1]
+    # The fixture sits half a degree and two and a half degrees east of the river, on the equator,
+    # where a degree of longitude is about 111.3 km in the projected CRS.
+    assert distances.iloc[0] == pytest.approx(55_660, rel=0.01)
+    assert distances.iloc[1] == pytest.approx(278_299, rel=0.01)
 
 
 def test_requested_columns_come_from_the_nearest_feature(grid_points):
@@ -22,7 +29,102 @@ def test_requested_columns_come_from_the_nearest_feature(grid_points):
     near = LineString([(0, -1), (0, 2)])
     rivers = gpd.GeoDataFrame({"ORD_FLOW": [9, 4], "HYRIV_ID": [99, 1], "geometry": [far, near]}, crs="EPSG:4326")
 
-    nearest = get_distance_to(rivers, points=grid_points, return_columns=["ORD_FLOW", "HYRIV_ID"], n_cores=1)
+    nearest = get_distance_to(rivers, points=grid_points, return_columns=["ORD_FLOW", "HYRIV_ID"])
 
     assert nearest["HYRIV_ID"].tolist() == [1, 1]
     assert nearest["ORD_FLOW"].tolist() == [4, 4]
+
+
+def test_a_point_equidistant_from_two_features_gets_one_row():
+    """A nearest join reports every tied feature, so a point on the midline between two rivers
+    matches both. One row per point in, one row out, or the caller's frame silently grows and
+    stops aligning with the grid it was built from.
+    """
+    rivers = gpd.GeoDataFrame(
+        {
+            "ORD_FLOW": [4, 4],
+            "HYRIV_ID": [1, 2],
+            "geometry": [LineString([(-1, -1), (-1, 1)]), LineString([(1, -1), (1, 1)])],
+        },
+        crs="EPSG:4326",
+    )
+    midline = gpd.GeoDataFrame(geometry=gpd.points_from_xy([0.0, 0.0], [0.0, 0.5]), crs="EPSG:4326")
+
+    nearest = get_distance_to(rivers, points=midline, return_columns=["HYRIV_ID"])
+
+    assert len(nearest) == len(midline)
+    assert nearest["HYRIV_ID"].isin([1, 2]).all(), "one of the two tied rivers, not a missing match"
+    # Either tie is a degree away, so the distance is the same whichever was kept.
+    np.testing.assert_allclose(nearest["distance_to_closest"].to_numpy(), 111_319, rtol=0.01)
+
+
+def test_a_geoseries_of_boundaries_is_measured_to():
+    """`create_grid_from_shape` passes `coastline.boundary`, which is a GeoSeries rather than a
+    frame, so it carries no columns to join on. Measuring to the boundary rather than the polygon
+    is what makes a point inside the landmass a positive distance from the coast.
+    """
+    land = gpd.GeoDataFrame(geometry=[box(-2, -2, 2, 2)], crs="EPSG:4326")
+    inside = gpd.GeoDataFrame(geometry=gpd.points_from_xy([0.0], [0.0]), crs="EPSG:4326")
+
+    to_coast = get_distance_to(land.boundary, points=inside)["distance_to_closest"]
+
+    assert to_coast.iloc[0] > 100_000, "the centre of the box is far from its edge"
+    assert get_distance_to(land, points=inside)["distance_to_closest"].iloc[0] == 0.0
+
+
+def test_the_result_is_indexed_like_the_points():
+    """The caller merges this back onto the grid by index, so a reset index would misalign every
+    distance by however many rows the grid had already dropped.
+    """
+    rivers = gpd.GeoDataFrame(
+        {"ORD_FLOW": [4], "HYRIV_ID": [1], "geometry": [LineString([(0, -1), (0, 2)])]}, crs="EPSG:4326"
+    )
+    points = gpd.GeoDataFrame(geometry=gpd.points_from_xy([1.0, 2.0], [1.0, 1.0]), crs="EPSG:4326", index=[17, 42])
+
+    nearest = get_distance_to(rivers, points=points, return_columns=["HYRIV_ID"])
+
+    assert nearest.index.tolist() == [17, 42]
+    assert nearest["distance_to_closest"].idxmin() == 17, "the nearer point keeps its own label"
+
+
+def test_points_sharing_an_index_label_each_keep_their_own_distance():
+    """The nearest join reports ties as extra rows, and the index is how they are collapsed. If
+    that runs on the caller's labels rather than on position, two distinct points that happen to
+    share a label look like one point matched twice, and one of them is silently discarded.
+    """
+    rivers = gpd.GeoDataFrame({"HYRIV_ID": [1], "geometry": [LineString([(0, -1), (0, 2)])]}, crs="EPSG:4326")
+    shared_label = gpd.GeoDataFrame(
+        geometry=gpd.points_from_xy([1.0, 5.0, 9.0], [1.0, 1.0, 1.0]), crs="EPSG:4326", index=[7, 7, 8]
+    )
+
+    nearest = get_distance_to(rivers, points=shared_label, return_columns=["HYRIV_ID"])
+
+    assert len(nearest) == len(shared_label)
+    assert nearest["distance_to_closest"].is_monotonic_increasing, "each point keeps its own distance"
+
+
+def test_features_whose_geometry_column_is_named_something_else_are_measured_to():
+    """A GeoDataFrame's active geometry need not be called `geometry`, and upstream archives are
+    read as published. Selecting the column by name would drop the geometry and fail the join.
+    """
+    rivers = gpd.GeoDataFrame(
+        {"HYRIV_ID": [1], "geometry": [LineString([(0, -1), (0, 2)])]}, crs="EPSG:4326"
+    ).rename_geometry("geom")
+    points = gpd.GeoDataFrame(geometry=gpd.points_from_xy([1.0], [1.0]), crs="EPSG:4326")
+
+    nearest = get_distance_to(rivers, points=points, return_columns=["HYRIV_ID"])
+
+    assert nearest["HYRIV_ID"].tolist() == [1]
+    assert nearest["distance_to_closest"].iloc[0] > 10_000
+
+
+def test_measuring_to_nothing_is_refused():
+    """A place whose river or coastline query returns nothing reaches here as an empty frame. The
+    nearest join answers NaN for every point, which survives the clip, becomes NaN through the log,
+    and shows up as a column of missing covariates rather than as a failure.
+    """
+    nothing = gpd.GeoDataFrame({"HYRIV_ID": [], "geometry": []}, crs="EPSG:4326")
+    points = gpd.GeoDataFrame(geometry=gpd.points_from_xy([1.0], [1.0]), crs="EPSG:4326")
+
+    with pytest.raises(DataValidationError, match="no features to measure to"):
+        get_distance_to(nothing, points=points, return_columns=["HYRIV_ID"])


### PR DESCRIPTION
`get_distance_to` looped over points in Python, measuring each one against every feature. `sjoin_nearest` does the same thing through the GEOS spatial index — 54x faster on a million points, and most of what's left is inside GEOS. joblib goes away with the loop.

Empty features used to raise `IndexError` from the loop and now come back as NaN from the join, which survives the clip and the log and lands as a column of missing covariates. It raises instead.

`get_distance_to_rivers` was the same computation with the column names hardcoded, so its one caller moved over.
