### PR TITLE
Compare the two gazetteers by GADM id rather than by unit name

### DIFF
--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -153,10 +153,14 @@ def _best_unit_per_footprint(footprints: gpd.GeoDataFrame, units: gpd.GeoDataFra
     """Pair each footprint with the single unit covering most of it, dropping any that meet none."""
     located = footprints[["DisNo.", "ISO", "geocoding_q", "geometry"]].reset_index(names="footprint")
     pieces = gpd.overlay(located, units, how="intersection", keep_geom_type=False)
+
+    # Two polygons meeting along an edge intersect in a line, which `keep_geom_type=False` keeps and
+    # which covers none of the footprint. Taking the largest would place it in a unit it only borders.
+    pieces = pieces.assign(covered=pieces.geometry.area)
+    pieces = pieces[pieces["covered"] > 0.0]
     if pieces.empty:
         return pd.DataFrame(columns=RESOLVED_COLUMNS)
 
-    pieces = pieces.assign(covered=pieces.geometry.area)
     best = pieces.sort_values("covered").groupby("footprint").tail(1).set_index("footprint")
     shares = best["covered"] / footprints.geometry.area.reindex(best.index)
 

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -306,25 +306,6 @@ def normalise_unit_name(name: str) -> str:
     return "".join(character for character in decomposed if character.isalnum()).casefold()
 
 
-def event_unit_names(locations: pd.DataFrame) -> dict[str, set[str]]:
-    """
-    Collect the unit names Geo-Disasters records, keyed on the EM-DAT event id.
-
-    Parameters
-    ----------
-    locations : DataFrame
-        Rows as :func:`load_event_locations` returns them.
-
-    Returns
-    -------
-    dict mapping str to set of str
-        One entry per event, holding every unit it was geocoded to, named as published.
-    """
-    named = locations.assign(unit=unit_names(locations))
-
-    return {str(disno): set(group) for disno, group in named.groupby("DisNo.")["unit"]}
-
-
 def event_unit_ids(units: pd.DataFrame) -> dict[str, set[str]]:
     """
     Collect the GADM units an event was placed in, keyed on the EM-DAT event id.

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -146,7 +146,18 @@ def load_event_footprints(cache_dir: Path, *, iso: str, layer: str = GEO_DISASTE
 
 EQUAL_AREA_CRS = "ESRI:54009"
 
-RESOLVED_COLUMNS = ["DisNo.", "ISO", "geometry_source", "gid", "name", "admin_level", "geocoding_q", "overlap"]
+RESOLVED_DTYPES = {
+    "DisNo.": "string",
+    "ISO": "string",
+    "geometry_source": "string",
+    "gid": "string",
+    "name": "string",
+    "admin_level": "Int64",
+    "geocoding_q": "Int64",
+    "overlap": "float64",
+}
+
+RESOLVED_COLUMNS = list(RESOLVED_DTYPES)
 
 
 def _best_unit_per_footprint(footprints: gpd.GeoDataFrame, units: gpd.GeoDataFrame) -> pd.DataFrame:
@@ -193,7 +204,7 @@ def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFra
         ``geocoding_q``, and ``overlap``, the share of the footprint the unit covers.
     """
     if footprints.empty:
-        return pd.DataFrame(columns=RESOLVED_COLUMNS)
+        return pd.DataFrame(columns=RESOLVED_COLUMNS).astype(RESOLVED_DTYPES)
 
     countries = set(footprints["ISO"])
     if len(countries) > 1:
@@ -224,6 +235,7 @@ def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFra
         .assign(geometry_source="geo_disasters")[RESOLVED_COLUMNS]
         .sort_values(["DisNo.", "gid"])
         .reset_index(drop=True)
+        .astype(RESOLVED_DTYPES)
     )
 
 

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -325,6 +325,26 @@ def event_unit_names(locations: pd.DataFrame) -> dict[str, set[str]]:
     return {str(disno): set(group) for disno, group in named.groupby("DisNo.")["unit"]}
 
 
+def event_unit_ids(units: pd.DataFrame) -> dict[str, set[str]]:
+    """
+    Collect the GADM units an event was placed in, keyed on the EM-DAT event id.
+
+    Both sides of the comparison arrive in this shape: EM-DAT's own unit table, and the resolved
+    footprints :func:`resolve_to_gadm` returns.
+
+    Parameters
+    ----------
+    units : DataFrame
+        Any frame carrying ``DisNo.`` and ``gid``, one row per event-unit.
+
+    Returns
+    -------
+    dict mapping str to set of str
+        One entry per event, holding every GADM identifier it was placed in.
+    """
+    return {str(disno): set(group.dropna()) for disno, group in units.groupby("DisNo.")["gid"]}
+
+
 AGREEMENT_LEVELS = ("exact", "partial", "disjoint", "gained", "unmatched")
 
 AGREEMENT_COLUMNS = ["DisNo.", "agreement", "em_dat_units", "geo_disasters_units", "shared_units"]
@@ -345,9 +365,12 @@ def compare_event_units(em_dat: Mapping[str, set[str]], geo_disasters: Mapping[s
     """
     Report how EM-DAT's own geocoding and Geo-Disasters' agree, event by event.
 
-    The two are keyed on ``DisNo.`` and nothing else: EM-DAT names GADM units and Geo-Disasters names
-    GAUL ones, and the two gazetteers share no identifier, so units are matched on their names, put
-    through :func:`normalise_unit_name` here rather than by either caller.
+    Both sides are GADM identifiers, matched literally. The signature cannot tell an identifier from
+    a unit name and the two gazetteers' names do not compare, so Geo-Disasters' side comes through
+    :func:`resolve_to_gadm` first.
+
+    An identifier names a level as well as a place, so a province and a district inside it never
+    match, and an event the two sources describe at different resolutions reads as ``disjoint``.
 
     Each event is classified as ``exact`` when both name the same units, ``partial`` when they
     overlap, ``disjoint`` when both name units and none is shared, ``gained`` when only
@@ -356,9 +379,9 @@ def compare_event_units(em_dat: Mapping[str, set[str]], geo_disasters: Mapping[s
     Parameters
     ----------
     em_dat : mapping of str to set of str
-        Unit names EM-DAT records, keyed on event id.
+        GADM identifiers EM-DAT records, keyed on event id.
     geo_disasters : mapping of str to set of str
-        The same from Geo-Disasters, as :func:`event_unit_names` returns it.
+        The same from Geo-Disasters, as :func:`event_unit_ids` returns it.
 
     Returns
     -------
@@ -369,8 +392,8 @@ def compare_event_units(em_dat: Mapping[str, set[str]], geo_disasters: Mapping[s
     rows = []
 
     for disno in sorted(em_dat.keys() | geo_disasters.keys()):
-        recorded = {normalise_unit_name(name) for name in em_dat.get(disno, ()) if name}
-        published = {normalise_unit_name(name) for name in geo_disasters.get(disno, ()) if name}
+        recorded = {gid for gid in em_dat.get(disno, ()) if gid}
+        published = {gid for gid in geo_disasters.get(disno, ()) if gid}
         if not recorded and not published:
             continue
 

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -1,12 +1,14 @@
 import logging
 import unicodedata
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from functools import partial
 from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
 
+from climate_risk.data.cache import cached, pandas_parquet
 from climate_risk.data.gadm import load_units_in_country
 from climate_risk.data.source import ManualSource
 from climate_risk.exceptions import DataValidationError
@@ -237,6 +239,50 @@ def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFra
         .reset_index(drop=True)
         .astype(RESOLVED_DTYPES)
     )
+
+
+def _resolve_country(iso: str, cache_dir: Path) -> pd.DataFrame:
+    return resolve_to_gadm(load_event_footprints(cache_dir, iso=iso), cache_dir)
+
+
+def load_resolved_units(isos: Sequence[str], cache_dir: Path, *, force_reload: bool = False) -> pd.DataFrame:
+    """
+    Read the GADM units Geo-Disasters places, for several countries at once.
+
+    Resolving is a polygon overlay against every GADM unit in the country, so it is cached, one
+    entry per country.
+
+    Parameters
+    ----------
+    isos : sequence of str
+        ISO 3166-1 alpha-3 codes to read. Duplicates and ordering do not matter; the result is
+        ordered by code.
+    cache_dir : Path
+        Directory the caches live under.
+    force_reload : bool, optional
+        Resolve again and overwrite the cached entries. Default False.
+
+    Returns
+    -------
+    DataFrame
+        The columns of :func:`resolve_to_gadm`, one row per placed footprint, across every country
+        asked for.
+    """
+    frames = [
+        cached(
+            cache_dir,
+            "geo_disasters_units",
+            partial(_resolve_country, iso, cache_dir),
+            pandas_parquet(),
+            params={"iso": iso},
+            force=force_reload,
+        )
+        for iso in sorted(set(isos))
+    ]
+    if not frames:
+        return pd.DataFrame(columns=RESOLVED_COLUMNS).astype(RESOLVED_DTYPES)
+
+    return pd.concat(frames, ignore_index=True)
 
 
 def normalise_unit_name(name: str) -> str:

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -361,7 +361,7 @@ def _classify(em_dat: set[str], geo_disasters: set[str]) -> str:
     return "partial" if em_dat & geo_disasters else "disjoint"
 
 
-def compare_event_units(em_dat: Mapping[str, set[str]], geo_disasters: Mapping[str, set[str]]) -> pd.DataFrame:
+def compare_event_units(*, em_dat: Mapping[str, set[str]], geo_disasters: Mapping[str, set[str]]) -> pd.DataFrame:
     """
     Report how EM-DAT's own geocoding and Geo-Disasters' agree, event by event.
 

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -19,6 +19,7 @@ from climate_risk.data.geo_disasters import (
     geo_disasters_path,
     load_event_footprints,
     load_event_locations,
+    load_resolved_units,
     normalise_unit_name,
     resolve_to_gadm,
     unit_names,
@@ -270,6 +271,65 @@ def test_a_footprint_that_only_borders_a_unit_is_not_placed_in_it(write_gadm_cac
     resolved = resolve_to_gadm(beside_houayxay, cache_dir)
 
     assert resolved.empty, "a footprint sharing only an edge covers no unit"
+
+
+def test_resolved_units_span_every_country_asked_for(write_gadm_cache, write_geo_disasters_cache):
+    write_gadm_cache()
+    cache_dir = write_geo_disasters_cache()
+
+    resolved = load_resolved_units(["ZMB", "LAO"], cache_dir)
+
+    assert set(resolved["ISO"]) == {"LAO", "ZMB"}
+    assert (resolved["gid"].str[:3] == resolved["ISO"]).all(), "a unit belongs to the country it was read for"
+
+
+def test_a_country_is_resolved_once_and_read_back(write_gadm_cache, write_geo_disasters_cache):
+    """The overlay runs against every GADM unit in the country and takes a hundred seconds over a
+    region. A second read that touches the GeoPackages has not cached anything."""
+    write_gadm_cache()
+    cache_dir = write_geo_disasters_cache()
+    first = load_resolved_units(["LAO"], cache_dir)
+
+    (cache_dir / "geo_disasters" / "disaster_subnational_90_23.gpkg").unlink()
+    (cache_dir / "gadm" / "gadm_410.gpkg").unlink()
+
+    pd.testing.assert_frame_equal(load_resolved_units(["LAO"], cache_dir), first)
+
+
+def test_each_country_caches_under_its_own_key(write_gadm_cache, write_geo_disasters_cache):
+    """One entry per region would make `sea` and a global run rebuild each other's members, and a
+    shared key would serve Laos' units for a request about Zambia."""
+    write_gadm_cache()
+    cache_dir = write_geo_disasters_cache()
+
+    load_resolved_units(["LAO"], cache_dir)
+
+    assert set(load_resolved_units(["ZMB"], cache_dir)["gid"]) == {"ZMB.1_1"}
+
+
+def test_a_country_named_twice_is_read_once(write_gadm_cache, write_geo_disasters_cache):
+    """The argument is a set of countries, not a list of reads. A region listing a member twice —
+    or two overlapping regions concatenated — would otherwise duplicate every one of that country's
+    rows, and the event counts built on them come out twice as large."""
+    write_gadm_cache()
+    cache_dir = write_geo_disasters_cache()
+
+    once = load_resolved_units(["LAO", "ZMB"], cache_dir)
+    repeated_and_reordered = load_resolved_units(["ZMB", "LAO", "LAO"], cache_dir)
+
+    pd.testing.assert_frame_equal(once, repeated_and_reordered)
+    # Set iteration order over strings varies between processes, so row order would too.
+    assert once["ISO"].is_monotonic_increasing, "countries concatenate in a fixed order"
+
+
+def test_asking_for_no_countries_gives_the_empty_frame(tmp_path):
+    """A place whose members are all absent from Geo-Disasters reaches here as an empty list, and
+    the caller concatenates whatever comes back."""
+    resolved = load_resolved_units([], tmp_path)
+
+    assert resolved.empty
+    assert list(resolved.columns) == RESOLVED_COLUMNS
+    assert dict(resolved.dtypes.astype(str)) == RESOLVED_DTYPES
 
 
 REAL_GADM = REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg"

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -2,7 +2,10 @@ import re
 
 from pathlib import Path
 
+import geopandas as gpd
 import pytest
+
+from shapely.geometry import box
 
 from climate_risk.data.geo_disasters import (
     AGREEMENT_LEVELS,
@@ -19,7 +22,7 @@ from climate_risk.data.geo_disasters import (
     unit_names,
 )
 from climate_risk.exceptions import DataValidationError
-from tests.conftest import toy_geo_disasters
+from tests.conftest import toy_gadm, toy_geo_disasters
 
 
 def test_the_geopackage_is_looked_for_under_the_cache(tmp_path):
@@ -218,6 +221,35 @@ def test_every_classification_is_one_of_the_declared_levels():
     )
 
     assert set(report["agreement"]) == set(AGREEMENT_LEVELS)
+
+
+def test_a_footprint_that_only_borders_a_unit_is_not_placed_in_it(write_gadm_cache):
+    """Two polygons meeting along an edge intersect in a line of zero area. Taking the largest
+    overlap regardless would answer with a unit the footprint lies wholly outside, and answer it as
+    confidently as a real match."""
+    cache_dir = write_gadm_cache()
+    units = toy_gadm()
+    houayxay = units[units["GID_2"] == "LAO.2.1_1"].geometry.iloc[0]
+    beside_houayxay = gpd.GeoDataFrame(
+        {
+            "DisNo.": ["1999-0001-LAO"],
+            "ISO": ["LAO"],
+            "admin_level": [2],
+            "geocoding_q": [1],
+            "ADM1_NAME": ["Bokeo"],
+            "ADM2_NAME": ["Houayxay"],
+            "geometry": [box(2, 0, 3, 1)],
+        },
+        crs="EPSG:4326",
+    )
+    footprint = beside_houayxay.geometry.iloc[0]
+    assert footprint.touches(houayxay) and footprint.intersection(houayxay).area == 0.0, (
+        "the footprint must share an edge and no area, or this is the ordinary disjoint case"
+    )
+
+    resolved = resolve_to_gadm(beside_houayxay, cache_dir)
+
+    assert resolved.empty, "a footprint sharing only an edge covers no unit"
 
 
 REAL_GADM = REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg"

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -166,14 +166,14 @@ def test_geo_disasters_names_are_collected_per_event(write_geo_disasters_cache):
     ids=["exact", "partial", "disjoint", "gained", "unmatched"],
 )
 def test_an_event_is_classified_by_how_the_two_geocodings_overlap(em_dat, geo_disasters, expected):
-    report = compare_event_units({"E": em_dat}, {"E": geo_disasters})
+    report = compare_event_units(em_dat={"E": em_dat}, geo_disasters={"E": geo_disasters})
 
     assert report["agreement"].tolist() == [expected]
 
 
 def test_an_event_neither_source_geocoded_is_left_out():
     """Two thirds of EM-DAT carries no units at all; reporting them would bury the comparison."""
-    report = compare_event_units({"E": set()}, {"E": set()})
+    report = compare_event_units(em_dat={"E": set()}, geo_disasters={"E": set()})
 
     assert report.empty
     assert list(report.columns) == ["DisNo.", "agreement", "em_dat_units", "geo_disasters_units", "shared_units"]
@@ -183,7 +183,7 @@ def test_identifiers_are_compared_literally():
     """`normalise_unit_name` strips the punctuation that separates a GADM identifier's levels, so
     the district `LAO.1.1_1` and the province `LAO.11_1` both reduce to `lao111`. Putting the
     identifiers through it would merge two different units into an exact agreement."""
-    report = compare_event_units({"E": {"LAO.11_1"}}, {"E": {"LAO.1.1_1"}})
+    report = compare_event_units(em_dat={"E": {"LAO.11_1"}}, geo_disasters={"E": {"LAO.1.1_1"}})
 
     assert normalise_unit_name("LAO.11_1") == normalise_unit_name("LAO.1.1_1"), "the collision is real"
     assert report["agreement"].tolist() == ["disjoint"]
@@ -193,14 +193,14 @@ def test_a_province_and_a_district_inside_it_do_not_match():
     """An identifier names a level as well as a place. Every event the two sources describe at
     different resolutions lands here, and it reads as `disjoint` — the same verdict as two genuinely
     different provinces, which is a limit of the report rather than a claim about the event."""
-    report = compare_event_units({"E": {"PHL.19_1"}}, {"E": {"PHL.19.5_1"}})
+    report = compare_event_units(em_dat={"E": {"PHL.19_1"}}, geo_disasters={"E": {"PHL.19.5_1"}})
 
     assert report["agreement"].tolist() == ["disjoint"]
     assert report["shared_units"].tolist() == [0]
 
 
 def test_the_counts_describe_each_side_and_the_overlap():
-    report = compare_event_units({"E": {"LAO.15_1", "LAO.17_1"}}, {"E": {"LAO.15_1", "LAO.1_1"}})
+    report = compare_event_units(em_dat={"E": {"LAO.15_1", "LAO.17_1"}}, geo_disasters={"E": {"LAO.15_1", "LAO.1_1"}})
 
     assert report.loc[0, "em_dat_units"] == 2
     assert report.loc[0, "geo_disasters_units"] == 2
@@ -210,8 +210,8 @@ def test_the_counts_describe_each_side_and_the_overlap():
 def test_every_event_either_source_geocoded_appears_once():
     """A join done the wrong way round silently drops whichever side is absent."""
     report = compare_event_units(
-        {"A": {"LAO.1_1"}, "B": {"LAO.2_1"}},
-        {"B": {"LAO.2_1"}, "C": {"LAO.9_1"}},
+        em_dat={"A": {"LAO.1_1"}, "B": {"LAO.2_1"}},
+        geo_disasters={"B": {"LAO.2_1"}, "C": {"LAO.9_1"}},
     )
 
     assert report["DisNo."].tolist() == ["A", "B", "C"]
@@ -256,13 +256,13 @@ def test_every_classification_is_one_of_the_declared_levels():
     """`AGREEMENT_LEVELS` is the published vocabulary; a verdict outside it is one no caller can
     branch on."""
     report = compare_event_units(
-        {
+        em_dat={
             "exact": {"LAO.1_1"},
             "partial": {"LAO.1_1", "LAO.2_1"},
             "disjoint": {"LAO.1_1"},
             "unmatched": {"LAO.1_1"},
         },
-        {"exact": {"LAO.1_1"}, "partial": {"LAO.1_1"}, "disjoint": {"LAO.9_1"}, "gained": {"LAO.1_1"}},
+        geo_disasters={"exact": {"LAO.1_1"}, "partial": {"LAO.1_1"}, "disjoint": {"LAO.9_1"}, "gained": {"LAO.1_1"}},
     )
 
     assert set(report["agreement"]) == set(AGREEMENT_LEVELS)

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 
 import geopandas as gpd
+import pandas as pd
 import pytest
 
 from shapely.geometry import box
@@ -11,6 +12,7 @@ from climate_risk.data.geo_disasters import (
     AGREEMENT_LEVELS,
     GEO_DISASTERS,
     RESOLVED_COLUMNS,
+    RESOLVED_DTYPES,
     compare_event_units,
     event_unit_names,
     geo_disasters_dir,
@@ -193,13 +195,16 @@ def test_footprints_spanning_two_countries_are_refused(tmp_path):
 
 
 def test_no_footprints_resolve_to_an_empty_frame_of_the_right_shape(tmp_path):
-    """A country Geo-Disasters never geocoded is ordinary, and the caller concatenates the result."""
+    """A country Geo-Disasters never geocoded is ordinary, and the caller concatenates the result —
+    so the empty frame needs the dtypes a populated one has, or it drags every column it is
+    concatenated with back to object."""
     empty = toy_geo_disasters().iloc[:0]
 
     resolved = resolve_to_gadm(empty, tmp_path)
 
     assert resolved.empty
     assert list(resolved.columns) == RESOLVED_COLUMNS
+    assert dict(resolved.dtypes.astype(str)) == RESOLVED_DTYPES
 
 
 def test_footprints_come_back_with_their_geometry(write_geo_disasters_cache):
@@ -221,6 +226,21 @@ def test_every_classification_is_one_of_the_declared_levels():
     )
 
     assert set(report["agreement"]) == set(AGREEMENT_LEVELS)
+
+
+def test_the_resolved_dtypes_do_not_depend_on_which_levels_matched(write_gadm_cache):
+    """An admin level that places nothing contributes an all-object empty frame to the concatenation,
+    which would leave `admin_level` an object column for one country and an integer for the next —
+    a schema that varies with the data, and only where a level happened to come back empty."""
+    cache_dir = write_gadm_cache()
+    lao = toy_geo_disasters().query("ISO == 'LAO'")
+
+    both_levels = resolve_to_gadm(lao, cache_dir)
+    provinces_only = resolve_to_gadm(lao[lao["admin_level"] == 1], cache_dir)
+
+    assert not both_levels.empty and not provinces_only.empty, "both cases must place something"
+    pd.testing.assert_series_equal(both_levels.dtypes, provinces_only.dtypes)
+    assert both_levels["admin_level"].dtype == "Int64", "an admin level is a number the model compares"
 
 
 def test_a_footprint_that_only_borders_a_unit_is_not_placed_in_it(write_gadm_cache):

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -14,6 +14,7 @@ from climate_risk.data.geo_disasters import (
     RESOLVED_COLUMNS,
     RESOLVED_DTYPES,
     compare_event_units,
+    event_unit_ids,
     event_unit_names,
     geo_disasters_dir,
     geo_disasters_path,
@@ -122,9 +123,27 @@ def test_units_that_are_genuinely_different_stay_different():
 
 def test_a_different_romanisation_is_not_reconciled():
     """Normalisation handles typography, not spelling. `Xiangkhouang` and `Xiangkhoang` are one
-    province under two romanisations, and they compare as different units — so a `partial` in the
-    report is an upper bound on real disagreement, not a measurement of it."""
+    province under two romanisations, and normalising leaves them different — which is why the
+    agreement report matches identifiers and this function is not in its path."""
     assert normalise_unit_name("Xiangkhouang") != normalise_unit_name("Xiangkhoang")
+
+
+def test_unit_ids_are_collected_per_event():
+    """Both sides of the comparison come through here, and an event spans several units. The point
+    and country tiers of `event_geography` carry no unit at all, and those events contribute an
+    empty set rather than a set holding a null that would match nothing."""
+    units = pd.DataFrame(
+        {
+            "DisNo.": ["1991-0761-LAO", "1991-0761-LAO", "2018-0339-LAO", "2020-0001-LAO"],
+            "gid": ["LAO.15_1", "LAO.6_1", "LAO.1.1_1", None],
+        }
+    )
+
+    assert event_unit_ids(units) == {
+        "1991-0761-LAO": {"LAO.15_1", "LAO.6_1"},
+        "2018-0339-LAO": {"LAO.1.1_1"},
+        "2020-0001-LAO": set(),
+    }
 
 
 def test_geo_disasters_names_are_collected_per_event(write_geo_disasters_cache):
@@ -138,11 +157,11 @@ def test_geo_disasters_names_are_collected_per_event(write_geo_disasters_cache):
 @pytest.mark.parametrize(
     ("em_dat", "geo_disasters", "expected"),
     [
-        ({"Savannakhet", "Khammouan"}, {"Savannakhet", "Khammouan"}, "exact"),
-        ({"Vientiane", "Xaisomboun"}, {"Vientiane"}, "partial"),
-        ({"Vientiane"}, {"Attapu"}, "disjoint"),
-        (set(), {"Xekong", "Attapu"}, "gained"),
-        ({"Bokeo"}, set(), "unmatched"),
+        ({"LAO.6_1", "LAO.7_1"}, {"LAO.6_1", "LAO.7_1"}, "exact"),
+        ({"LAO.15_1", "LAO.17_1"}, {"LAO.15_1"}, "partial"),
+        ({"LAO.15_1"}, {"LAO.1_1"}, "disjoint"),
+        (set(), {"LAO.16_1", "LAO.1_1"}, "gained"),
+        ({"LAO.2_1"}, set(), "unmatched"),
     ],
     ids=["exact", "partial", "disjoint", "gained", "unmatched"],
 )
@@ -160,16 +179,28 @@ def test_an_event_neither_source_geocoded_is_left_out():
     assert list(report.columns) == ["DisNo.", "agreement", "em_dat_units", "geo_disasters_units", "shared_units"]
 
 
-def test_agreement_is_judged_after_normalisation():
-    """The whole point of normalising: Xekong and Xékong are one province, not a disjoint pair."""
-    report = compare_event_units({"E": {"Xékong"}}, {"E": {"Xekong"}})
+def test_identifiers_are_compared_literally():
+    """`normalise_unit_name` strips the punctuation that separates a GADM identifier's levels, so
+    the district `LAO.1.1_1` and the province `LAO.11_1` both reduce to `lao111`. Putting the
+    identifiers through it would merge two different units into an exact agreement."""
+    report = compare_event_units({"E": {"LAO.11_1"}}, {"E": {"LAO.1.1_1"}})
 
-    assert report["agreement"].tolist() == ["exact"]
-    assert report["shared_units"].tolist() == [1]
+    assert normalise_unit_name("LAO.11_1") == normalise_unit_name("LAO.1.1_1"), "the collision is real"
+    assert report["agreement"].tolist() == ["disjoint"]
+
+
+def test_a_province_and_a_district_inside_it_do_not_match():
+    """An identifier names a level as well as a place. Every event the two sources describe at
+    different resolutions lands here, and it reads as `disjoint` — the same verdict as two genuinely
+    different provinces, which is a limit of the report rather than a claim about the event."""
+    report = compare_event_units({"E": {"PHL.19_1"}}, {"E": {"PHL.19.5_1"}})
+
+    assert report["agreement"].tolist() == ["disjoint"]
+    assert report["shared_units"].tolist() == [0]
 
 
 def test_the_counts_describe_each_side_and_the_overlap():
-    report = compare_event_units({"E": {"Vientiane", "Xaisomboun"}}, {"E": {"Vientiane", "Attapu"}})
+    report = compare_event_units({"E": {"LAO.15_1", "LAO.17_1"}}, {"E": {"LAO.15_1", "LAO.1_1"}})
 
     assert report.loc[0, "em_dat_units"] == 2
     assert report.loc[0, "geo_disasters_units"] == 2
@@ -178,7 +209,10 @@ def test_the_counts_describe_each_side_and_the_overlap():
 
 def test_every_event_either_source_geocoded_appears_once():
     """A join done the wrong way round silently drops whichever side is absent."""
-    report = compare_event_units({"A": {"x"}, "B": {"y"}}, {"B": {"y"}, "C": {"z"}})
+    report = compare_event_units(
+        {"A": {"LAO.1_1"}, "B": {"LAO.2_1"}},
+        {"B": {"LAO.2_1"}, "C": {"LAO.9_1"}},
+    )
 
     assert report["DisNo."].tolist() == ["A", "B", "C"]
 
@@ -222,8 +256,13 @@ def test_every_classification_is_one_of_the_declared_levels():
     """`AGREEMENT_LEVELS` is the published vocabulary; a verdict outside it is one no caller can
     branch on."""
     report = compare_event_units(
-        {"exact": {"a"}, "partial": {"a", "b"}, "disjoint": {"a"}, "unmatched": {"a"}},
-        {"exact": {"a"}, "partial": {"a"}, "disjoint": {"z"}, "gained": {"a"}},
+        {
+            "exact": {"LAO.1_1"},
+            "partial": {"LAO.1_1", "LAO.2_1"},
+            "disjoint": {"LAO.1_1"},
+            "unmatched": {"LAO.1_1"},
+        },
+        {"exact": {"LAO.1_1"}, "partial": {"LAO.1_1"}, "disjoint": {"LAO.9_1"}, "gained": {"LAO.1_1"}},
     )
 
     assert set(report["agreement"]) == set(AGREEMENT_LEVELS)

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -15,7 +15,6 @@ from climate_risk.data.geo_disasters import (
     RESOLVED_DTYPES,
     compare_event_units,
     event_unit_ids,
-    event_unit_names,
     geo_disasters_dir,
     geo_disasters_path,
     load_event_footprints,
@@ -144,14 +143,6 @@ def test_unit_ids_are_collected_per_event():
         "2018-0339-LAO": {"LAO.1.1_1"},
         "2020-0001-LAO": set(),
     }
-
-
-def test_geo_disasters_names_are_collected_per_event(write_geo_disasters_cache):
-    cache_dir = write_geo_disasters_cache()
-
-    names = event_unit_names(load_event_locations(cache_dir, iso="LAO"))
-
-    assert names == {"1991-0761-LAO": {"Savannakhet", "Khammouan"}, "2018-0339-LAO": {"Sanamxay"}}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The agreement report between EM-DAT's own geocoding and Geo-Disasters matched on normalized unit names, and GADM and GAUL romanize the same place differently — `Saravan` against `Salavan`. Across Southeast Asia that reported 174 of 753 shared events as disagreeing about location. Comparing the resolved GADM identifiers instead brings it to 11, and none of those 11 is a disagreement about where: they're all a province against a district inside it.

Resolving footprints onto GADM is a polygon overlay that takes about a minute and a half for the region, so it's now cached per country. Two bugs surfaced while testing that: a footprint sharing only an edge with a unit was placed inside it, and the resolved table's dtypes changed depending on which admin levels happened to match.
