### PR TITLE
Place every GADM unit majority-inside an event's footprint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   rev: 0.4.1
   hooks:
     - id: no-print-statements
-      exclude: 'climate_risk/stats/timeseries.py'
+      exclude: '^(climate_risk/stats/timeseries\.py|tools/)'
     - id: check-execution-order
 - repo: local
   hooks:

--- a/climate_risk/data/cache.py
+++ b/climate_risk/data/cache.py
@@ -15,8 +15,9 @@ PARAMETER_SEPARATOR = "__"
 VALUE_SEPARATOR = "="
 
 # A key becomes a filename, so a value carrying a path separator would write outside the cache, and
-# one carrying a key separator would make two different parameter sets collide on a single entry.
-FORBIDDEN_IN_KEY = ("/", "\\", PARAMETER_SEPARATOR, VALUE_SEPARATOR)
+# one carrying a key separator would make two different parameter sets collide on a single entry. A
+# dot collides the same way: the suffix is taken from the last one, so `4.1` and `4.2` name one file.
+FORBIDDEN_IN_KEY = ("/", "\\", ".", PARAMETER_SEPARATOR, VALUE_SEPARATOR)
 
 
 @dataclass(frozen=True, slots=True)

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -259,6 +259,15 @@ def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFra
     )
 
 
+def _placement_rule() -> str:
+    """Name the procedure that placed a cached entry, so the entry cannot outlive it.
+
+    Rename this whenever the procedure changes; the threshold follows :data:`MIN_CONTAINMENT`.
+    """
+    # A cache key may not carry a dot, so the threshold is written without one.
+    return f"dissolved-containment{MIN_CONTAINMENT}".replace(".", "-")
+
+
 def _resolve_country(iso: str, cache_dir: Path) -> pd.DataFrame:
     return resolve_to_gadm(load_event_footprints(cache_dir, iso=iso), cache_dir)
 
@@ -292,7 +301,7 @@ def load_resolved_units(isos: Sequence[str], cache_dir: Path, *, force_reload: b
             "geo_disasters_units",
             partial(_resolve_country, iso, cache_dir),
             pandas_parquet(),
-            params={"iso": iso},
+            params={"iso": iso, "placement": _placement_rule()},
             force=force_reload,
         )
         for iso in sorted(set(isos))

--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -162,22 +162,34 @@ RESOLVED_DTYPES = {
 RESOLVED_COLUMNS = list(RESOLVED_DTYPES)
 
 
-def _best_unit_per_footprint(footprints: gpd.GeoDataFrame, units: gpd.GeoDataFrame) -> pd.DataFrame:
-    """Pair each footprint with the single unit covering most of it, dropping any that meet none."""
-    located = footprints[["DisNo.", "ISO", "geocoding_q", "geometry"]].reset_index(names="footprint")
-    pieces = gpd.overlay(located, units, how="intersection", keep_geom_type=False)
+# A unit belongs to an event when most of the unit lies inside the event's footprint.
+MIN_CONTAINMENT = 0.5
 
-    # Two polygons meeting along an edge intersect in a line, which `keep_geom_type=False` keeps and
-    # which covers none of the footprint. Taking the largest would place it in a unit it only borders.
+
+def _units_within_events(footprints: gpd.GeoDataFrame, units: gpd.GeoDataFrame) -> pd.DataFrame:
+    """Pair each event with every unit lying mostly inside its footprint, dropping those with none."""
+    # Repaired before the union: a footprint crossing the antimeridian is valid in lat/lon and
+    # self-intersecting once projected, and unioning one raises rather than returning a bad answer.
+    repaired = footprints.assign(geometry=footprints.geometry.make_valid())
+
+    # One geometry per event, so a unit straddling two of its footprints is measured against the
+    # whole and cannot arrive twice. The quality flag takes the worse of the footprints it came
+    # from, which is how Geo-Disasters propagates it.
+    merged = repaired.dissolve(by="DisNo.", aggfunc={"ISO": "first", "geocoding_q": "max"}).reset_index()
+    measured = units.assign(unit_area=units.geometry.area)
+    pieces = gpd.overlay(merged, measured, how="intersection", keep_geom_type=False)
     pieces = pieces.assign(covered=pieces.geometry.area)
-    pieces = pieces[pieces["covered"] > 0.0]
-    if pieces.empty:
+
+    # Membership is the share of the unit inside the footprint, which means the same thing whatever
+    # the unit's size; the share of the footprint the unit covers does not, and is the weight below.
+    inside = pieces[pieces["covered"] / pieces["unit_area"] > MIN_CONTAINMENT]
+    if inside.empty:
         return pd.DataFrame(columns=RESOLVED_COLUMNS)
 
-    best = pieces.sort_values("covered").groupby("footprint").tail(1).set_index("footprint")
-    shares = best["covered"] / footprints.geometry.area.reindex(best.index)
+    footprint_area = merged.set_index("DisNo.").geometry.area
+    shares = inside["covered"].to_numpy() / footprint_area.reindex(inside["DisNo."]).to_numpy()
 
-    return best.assign(overlap=shares).drop(columns=["geometry", "covered"])
+    return inside.assign(overlap=shares).drop(columns=["geometry", "covered", "unit_area"])
 
 
 def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFrame:
@@ -185,12 +197,15 @@ def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFra
     Name each Geo-Disasters footprint as the GADM unit it covers, so it can join EM-DAT's own units.
 
     The two gazetteers share no identifier and spell the same unit differently, so a footprint is
-    placed by where it is rather than what it is called, and the largest overlap wins outright. No
-    minimum share applies: the published polygons are simplified to 0.005°, roughly 550 m, which
-    costs a small municipality a third of its area and a province almost none, so the same share
-    means different things at different sizes.
+    placed by where it is rather than what it is called. Every GADM unit more than
+    ``MIN_CONTAINMENT`` of the way inside the footprint is named, because one GAUL unit routinely
+    covers several GADM ones — where GAUL's admin-1 is a region and GADM's is a province, one
+    footprint holds five or six.
 
-    A footprint covering no unit at all is dropped and logged.
+    An event's footprints are dissolved per administrative level before the overlay, so a unit
+    straddling two of them is measured against the whole and named once.
+
+    An event holding no unit at all is dropped and logged.
 
     Parameters
     ----------
@@ -202,8 +217,9 @@ def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFra
     Returns
     -------
     DataFrame
-        ``DisNo.``, ``ISO``, ``geometry_source``, the GADM unit that was matched, the location's
-        ``geocoding_q``, and ``overlap``, the share of the footprint the unit covers.
+        ``DisNo.``, ``ISO``, ``geometry_source``, a GADM unit, the location's ``geocoding_q``, and
+        ``overlap``, the share of the event's footprint that unit covers. One row per event and
+        unit, so an event spanning several units contributes several.
     """
     if footprints.empty:
         return pd.DataFrame(columns=RESOLVED_COLUMNS).astype(RESOLVED_DTYPES)
@@ -225,12 +241,14 @@ def resolve_to_gadm(footprints: gpd.GeoDataFrame, cache_dir: Path) -> pd.DataFra
             _log.warning("GADM holds no level-%d unit for %s, so %d footprints go unplaced", level, iso, len(at_level))
             continue
 
-        matched.append(_best_unit_per_footprint(at_level, units))
+        matched.append(_units_within_events(at_level, units))
 
     resolved = pd.concat(matched) if matched else pd.DataFrame(columns=RESOLVED_COLUMNS)
-    unplaced = len(footprints) - len(resolved)
-    if unplaced:
-        _log.warning("%d of %d %s footprints cover no GADM unit and were dropped", unplaced, len(footprints), iso)
+    # Counted on events rather than rows: one event names as many units as its footprint holds.
+    events = footprints["DisNo."].nunique()
+    placed = resolved["DisNo."].nunique()
+    if events > placed:
+        _log.warning("%d of %d %s events hold no GADM unit and were dropped", events - placed, events, iso)
 
     return (
         pd.DataFrame(resolved)
@@ -265,7 +283,7 @@ def load_resolved_units(isos: Sequence[str], cache_dir: Path, *, force_reload: b
     Returns
     -------
     DataFrame
-        The columns of :func:`resolve_to_gadm`, one row per placed footprint, across every country
+        The columns of :func:`resolve_to_gadm`, one row per event and unit, across every country
         asked for.
     """
     frames = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ test-network = "pytest --run-network -m network"
 lint = "ruff check . && ruff format --check ."
 typecheck = "mypy"
 fmt = "ruff format ."
+verify-placement = "python tools/verify_placement_against_emdat.py"
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/tests/data/test_cache.py
+++ b/tests/data/test_cache.py
@@ -95,11 +95,18 @@ def test_a_bare_name_needs_no_parameters():
 
 @pytest.mark.parametrize(
     "params",
-    [{"region": "la/os"}, {"region": "la__os"}, {"region": "la=os"}, {"gr/id": 4}],
-    ids=["slash", "parameter-separator", "value-separator", "in-the-name"],
+    [
+        {"region": "la/os"},
+        {"region": "la__os"},
+        {"region": "la=os"},
+        {"gr/id": 4},
+        {"version": "4.1"},
+    ],
+    ids=["slash", "parameter-separator", "value-separator", "in-the-name", "dot"],
 )
 def test_a_value_that_would_corrupt_the_filename_is_rejected(params):
-    """A separator in a value makes two different parameter sets collide on one cache entry."""
+    """A separator in a value makes two different parameter sets collide on one cache entry. So does
+    a dot: the artefact's suffix is taken from the last one, so `4.1` and `4.2` name the same file."""
     with pytest.raises(ValueError, match="must not contain"):
         cache_key("points", params)
 

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -6,7 +6,7 @@ import geopandas as gpd
 import pandas as pd
 import pytest
 
-from shapely.geometry import box
+from shapely.geometry import Polygon, box
 
 from climate_risk.data.geo_disasters import (
     AGREEMENT_LEVELS,
@@ -274,6 +274,126 @@ def test_the_resolved_dtypes_do_not_depend_on_which_levels_matched(write_gadm_ca
     assert both_levels["admin_level"].dtype == "Int64", "an admin level is a number the model compares"
 
 
+def footprints_over(*rectangles, level=2, disno="1999-0001-LAO", quality=None):
+    """One event's Geo-Disasters footprints, covering arbitrary rectangles of the toy GADM country."""
+    return gpd.GeoDataFrame(
+        {
+            "DisNo.": [disno] * len(rectangles),
+            "ISO": ["LAO"] * len(rectangles),
+            "admin_level": [level] * len(rectangles),
+            "geocoding_q": list(quality or [1] * len(rectangles)),
+            "ADM1_NAME": ["Attapu"] * len(rectangles),
+            "ADM2_NAME": ["Sanamxay"] * len(rectangles),
+            "geometry": [box(*rectangle) for rectangle in rectangles],
+        },
+        crs="EPSG:4326",
+    )
+
+
+def test_a_footprint_spanning_two_units_is_placed_in_both(write_gadm_cache):
+    """One GAUL unit routinely covers several GADM ones — where GAUL's admin-1 is a region and
+    GADM's is a province, a single footprint holds five or six. Naming only the largest credits the
+    whole event to one unit and records a zero for the others."""
+    cache_dir = write_gadm_cache()
+
+    resolved = resolve_to_gadm(footprints_over((0, 0, 2, 1)), cache_dir)
+
+    assert set(resolved["gid"]) == {"LAO.1.1_1", "LAO.1.2_1"}, "both districts lie inside the footprint"
+
+
+@pytest.mark.parametrize(
+    ("east_edge", "expected"),
+    [(1.6, {"LAO.1.1_1", "LAO.1.2_1"}), (1.4, {"LAO.1.1_1"})],
+    ids=["60% of the second district", "40% of the second district"],
+)
+def test_a_unit_joins_when_most_of_it_lies_inside(write_gadm_cache, east_edge, expected):
+    """Membership is the share of the unit inside the footprint, not the share of the footprint the
+    unit covers. The second district is the same size either way; what changes is how much of it the
+    footprint holds."""
+    cache_dir = write_gadm_cache()
+
+    resolved = resolve_to_gadm(footprints_over((0, 0, east_edge, 1)), cache_dir)
+
+    assert set(resolved["gid"]) == expected
+
+
+def test_a_unit_straddling_two_footprints_of_one_event_is_placed(write_gadm_cache):
+    """The two halves belong to one event, so the unit is measured against their union. Testing each
+    footprint alone finds 40% twice and places the unit nowhere, losing geography the event has."""
+    cache_dir = write_gadm_cache()
+    # Two slices of LAO.1.2_1, box(1, 0, 2, 1), covering 40% of it each and 80% together.
+    straddling = footprints_over((1.0, 0, 1.4, 1), (1.6, 0, 2.0, 1))
+
+    resolved = resolve_to_gadm(straddling, cache_dir)
+
+    assert set(resolved["gid"]) == {"LAO.1.2_1"}
+
+
+def test_a_unit_inside_two_footprints_of_one_event_is_named_once(write_gadm_cache):
+    """`build_aggregation_from_overlaps` refuses a repeated unit outright, because the same overlap
+    listed twice doubles the ground it stands for."""
+    cache_dir = write_gadm_cache()
+    covered_twice = footprints_over((0, 0, 1, 1), (0, 0, 0.9, 1))
+
+    resolved = resolve_to_gadm(covered_twice, cache_dir)
+
+    assert resolved["gid"].tolist() == ["LAO.1.1_1"]
+    assert not resolved.duplicated(subset=["DisNo.", "gid"]).any()
+
+
+def test_a_footprint_that_projects_to_an_invalid_polygon_is_repaired(write_gadm_cache):
+    """A footprint crossing the antimeridian is valid in lat/lon and self-intersecting once
+    projected, and 19 of Fiji's 108 are. Unioning one raises out of GEOS rather than returning a
+    poor answer, so a whole country's geography is lost to a topology error."""
+    cache_dir = write_gadm_cache()
+    # One event, two footprints, the first tracing the districts' extent twice over so its ring
+    # doubles back on itself. Unioning it with the second is what GEOS refuses.
+    self_overlapping = footprints_over((0, 0, 2, 1), (0, 0, 1, 1))
+    self_overlapping.geometry = [
+        Polygon([(0, 0), (2, 0), (2, 1), (0, 1), (0, 0.5), (2, 0.5), (2, 1), (0, 1)]),
+        box(0, 0, 1, 1),
+    ]
+    assert not self_overlapping.geometry.is_valid.all(), "the fixture has to be invalid to test anything"
+
+    resolved = resolve_to_gadm(self_overlapping, cache_dir)
+
+    assert set(resolved["gid"]) == {"LAO.1.1_1", "LAO.1.2_1"}
+
+
+def test_an_event_geocoded_at_both_levels_keeps_both(write_gadm_cache):
+    """Footprints are dissolved per level, not per event. Dissolving across levels would union a
+    province with a district somewhere else and place the pair against whichever level ran first."""
+    cache_dir = write_gadm_cache()
+    at_both = pd.concat([footprints_over((3, 0, 4, 1), level=1), footprints_over((0, 0, 1, 1), level=2)])
+
+    resolved = resolve_to_gadm(gpd.GeoDataFrame(at_both, crs="EPSG:4326"), cache_dir)
+
+    assert dict(zip(resolved["gid"], resolved["admin_level"], strict=True)) == {"LAO.2_1": 1, "LAO.1.1_1": 2}
+
+
+def test_the_worse_quality_flag_survives_the_dissolve(write_gadm_cache):
+    """Geo-Disasters propagates its per-location flag worst-case to the event, and collapsing the
+    footprints must not quietly improve it."""
+    cache_dir = write_gadm_cache()
+    mixed = footprints_over((0, 0, 1, 1), (0, 0, 0.9, 1), quality=[1, 3])
+
+    resolved = resolve_to_gadm(mixed, cache_dir)
+
+    assert resolved["geocoding_q"].tolist() == [3]
+
+
+def test_overlap_is_the_share_of_the_footprint_each_unit_covers(write_gadm_cache):
+    """The two ratios answer different questions and only one is membership. `overlap` reports how
+    much of the event this unit accounts for; how much of the unit the event reached decides whether
+    it is named at all."""
+    cache_dir = write_gadm_cache()
+
+    resolved = resolve_to_gadm(footprints_over((0, 0, 2, 1)), cache_dir).set_index("gid")
+
+    assert resolved["overlap"].sum() == pytest.approx(1.0), "two equal halves of the footprint"
+    assert resolved.loc["LAO.1.1_1", "overlap"] == pytest.approx(0.5)
+
+
 def test_a_footprint_that_only_borders_a_unit_is_not_placed_in_it(write_gadm_cache):
     """Two polygons meeting along an edge intersect in a line of zero area. Taking the largest
     overlap regardless would answer with a unit the footprint lies wholly outside, and answer it as
@@ -379,7 +499,8 @@ def test_a_footprint_resolves_to_the_gadm_unit_it_covers():
 
     resolved = resolve_to_gadm(footprints, REAL_CACHE_DIR)
 
-    assert len(resolved) == len(footprints), "every Laos footprint sits on a GADM unit"
+    assert set(resolved["DisNo."]) == set(footprints["DisNo."]), "every Laos event keeps its geography"
+    assert len(resolved) >= len(footprints), "a footprint spanning several units contributes several rows"
     assert set(resolved["geometry_source"]) == {"geo_disasters"}
     assert resolved["gid"].str.startswith("LAO").all()
 

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -446,6 +446,23 @@ def test_a_country_is_resolved_once_and_read_back(write_gadm_cache, write_geo_di
     pd.testing.assert_frame_equal(load_resolved_units(["LAO"], cache_dir), first)
 
 
+def test_changing_the_placement_rule_rebuilds_rather_than_serving_the_old_units(
+    monkeypatch, write_gadm_cache, write_geo_disasters_cache
+):
+    """A cached entry outlives the rule that placed it. Keyed on the country alone, every warm cache
+    would keep answering with units the current rule would not have chosen, and nothing would say so."""
+    write_gadm_cache()
+    cache_dir = write_geo_disasters_cache()
+    load_resolved_units(["LAO"], cache_dir)
+    (cache_dir / "geo_disasters" / "disaster_subnational_90_23.gpkg").unlink()
+
+    monkeypatch.setattr("climate_risk.data.geo_disasters.MIN_CONTAINMENT", 0.9)
+
+    # Reading the archive again is the point: under a rule it was not built with, the entry is unusable.
+    with pytest.raises(NotImplementedError):
+        load_resolved_units(["LAO"], cache_dir)
+
+
 def test_each_country_caches_under_its_own_key(write_gadm_cache, write_geo_disasters_cache):
     """One entry per region would make `sea` and a global run rebuild each other's members, and a
     shared key would serve Laos' units for a request about Zambia."""

--- a/tools/verify_placement_against_emdat.py
+++ b/tools/verify_placement_against_emdat.py
@@ -1,0 +1,178 @@
+import json
+import sys
+
+from collections import defaultdict
+from pathlib import Path
+
+import pandas as pd
+
+from climate_risk.config.registry import load_place, resolve_isos
+from climate_risk.data.geo_disasters import load_event_footprints, resolve_to_gadm
+from climate_risk.data_functions.emdat_processing import load_emdat_events
+
+CACHE_DIR = Path(__file__).parents[1] / "data"
+DEFAULT_PLACE = "sea"
+
+
+def read_pinned_migration(cache_dir: Path) -> dict[tuple[int, int], tuple[frozenset[str], str]]:
+    """
+    Recover EM-DAT's own GAUL-to-GADM migration for the units the workbook pins unambiguously.
+
+    EM-DAT publishes the two codings as separate lists with nothing linking a pair, so a
+    correspondence is only recoverable where an event names exactly one GAUL unit: every GADM unit
+    it names then belongs to that one, however many there are.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    dict mapping tuple to tuple
+        Keyed on GAUL code and administrative level, holding the GADM identifiers EM-DAT migrated
+        that unit to and the migration methods it used.
+    """
+    events = load_emdat_events(cache_dir)
+    pinned: dict[tuple[int, int], set[tuple[frozenset[str], str]]] = defaultdict(set)
+
+    for gaul_raw, gadm_raw in zip(events["Admin Units"], events["GADM Admin Units"], strict=True):
+        if not str(gaul_raw or "").strip() or not str(gadm_raw or "").strip():
+            continue
+        gaul, gadm = json.loads(gaul_raw), json.loads(gadm_raw)
+        if len(gaul) != 1:
+            continue
+
+        for level in (1, 2):
+            if f"adm{level}_code" not in gaul[0]:
+                continue
+            at_level = [unit for unit in gadm if f"gid_{level}" in unit and (level == 2 or "gid_2" not in unit)]
+            if not at_level:
+                continue
+            named = frozenset(unit[f"gid_{level}"] for unit in at_level)
+            methods = "+".join(sorted({str(unit.get("migration_method")) for unit in at_level}))
+            pinned[(int(gaul[0][f"adm{level}_code"]), level)].add((named, methods))
+
+    return {key: next(iter(answers)) for key, answers in pinned.items() if len({gids for gids, _ in answers}) == 1}
+
+
+def countries_with_pinned_units(expected: dict[tuple[int, int], tuple[frozenset[str], str]]) -> tuple[str, ...]:
+    """Every country EM-DAT pins at least one migrated unit in, read off the GADM identifiers."""
+    return tuple(sorted({next(iter(gids))[:3] for gids, _ in expected.values()}))
+
+
+def place_pinned_units(
+    cache_dir: Path, isos: tuple[str, ...], wanted: set[tuple[int, int]]
+) -> dict[tuple[int, int], set[str]]:
+    """
+    Place each pinned GAUL unit's footprint with the rule the library uses today.
+
+    :func:`resolve_to_gadm` groups footprints on ``DisNo.``; each group here is one GAUL unit rather
+    than one event, so the comparison is against a unit-level answer.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+    isos : tuple of str
+        Countries to read.
+    wanted : set of tuple
+        GAUL code and administrative level of every unit to place.
+
+    Returns
+    -------
+    dict mapping tuple to set of str
+        The GADM identifiers placed for each GAUL unit that had a footprint.
+    """
+    placed: dict[tuple[int, int], set[str]] = {}
+
+    for position, iso in enumerate(isos, start=1):
+        print(f"  [{position}/{len(isos)}] {iso}", file=sys.stderr, flush=True)
+        footprints = load_event_footprints(cache_dir, iso=iso)
+        codes = [
+            int(adm2) if level == 2 and adm2 is not None else (int(adm1) if adm1 is not None else -1)
+            for adm1, adm2, level in zip(
+                footprints["ADM1_CODE"], footprints["ADM2_CODE"], footprints["admin_level"], strict=True
+            )
+        ]
+        footprints = footprints.assign(gaul_code=codes)
+
+        for level in (1, 2):
+            at_level = footprints[
+                (footprints["admin_level"] == level)
+                & (footprints["gaul_code"].isin({code for code, at in wanted if at == level}))
+            ]
+            if at_level.empty:
+                continue
+
+            resolved = resolve_to_gadm(at_level.assign(**{"DisNo.": at_level["gaul_code"].astype(str)}), cache_dir)
+            for code, gids in resolved.groupby("DisNo.")["gid"]:
+                placed[(int(str(code)), level)] = set(gids)
+
+    return placed
+
+
+def compare(expected: dict[tuple[int, int], tuple[frozenset[str], str]], placed: dict[tuple[int, int], set[str]]):
+    """
+    Score the placement of every pinned unit that had a footprint.
+
+    Parameters
+    ----------
+    expected : dict mapping tuple to tuple
+        EM-DAT's own answer, as :func:`read_pinned_migration` returns it.
+    placed : dict mapping tuple to set of str
+        The library's answer, as :func:`place_pinned_units` returns it.
+
+    Returns
+    -------
+    DataFrame
+        One row per unit, with its GAUL code, level, EM-DAT migration method, the unit counts each
+        side named, and whether the two agree.
+    """
+    return pd.DataFrame(
+        [
+            {
+                "gaul": code,
+                "level": level,
+                "method": methods,
+                "em_dat": len(gids),
+                "placed": len(placed[(code, level)]),
+                "agrees": placed[(code, level)] == set(gids),
+            }
+            for (code, level), (gids, methods) in expected.items()
+            if (code, level) in placed
+        ]
+    )
+
+
+def main() -> int:
+    place = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_PLACE
+    expected = read_pinned_migration(CACHE_DIR)
+    isos = countries_with_pinned_units(expected) if place == "all" else resolve_isos(load_place(place))
+    scored = compare(expected, place_pinned_units(CACHE_DIR, isos, set(expected)))
+
+    print(f"EM-DAT pins {len(expected)} GAUL units across the whole workbook.")
+    print(f"{place}: {len(isos)} countries, {len(scored)} of those units with a footprint to place")
+    if scored.empty:
+        print("nothing to compare — the archives may be absent, or this place has no geocoded footprints")
+        return 1
+
+    print(f"agreement: {scored['agrees'].sum()}/{len(scored)} ({scored['agrees'].mean():.1%})\n")
+    by_method = (
+        scored.groupby("method")["agrees"]
+        .agg(matched="sum", units="count", share="mean")
+        .sort_values("units", ascending=False)
+    )
+    print("by the migration method EM-DAT used, which the units partition between:")
+    print(by_method.to_string(formatters={"share": "{:.0%}".format}))
+
+    disagreements = scored[~scored["agrees"]].drop(columns="agrees")
+    if not disagreements.empty:
+        print(f"\n{len(disagreements)} disagreements:")
+        print(disagreements.to_string(index=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`resolve_to_gadm` put each footprint in the single GADM unit covering most of it. But one GAUL unit routinely covers several GADM ones — in the Philippines GAUL's admin-1 is a region and GADM's is a province — so a whole event got credited to one unit and the rest recorded zeros. On the units we can check against EM-DAT's own migration that was wrong every time, a median 12 units collapsed to 1, losing 79% of the footprint.

Now every unit more than half inside the event's footprint is named. That one rule reproduces EM-DAT's nine-branch migration on 1,365 of 1,394 units across 174 countries, and `pixi run verify-placement` re-runs the check. Footprints are dissolved per event before the overlay, which is also what stops a unit arriving twice.

The resolved table grows about sixfold, 6,373 rows to 38,809 for Southeast Asia, and `overlap` changes meaning from confidence-in-the-match to the unit's share of the event's footprint.
