### PR TITLE
Transliterate unit names instead of stripping combining marks

### DIFF
--- a/climate_risk/data/geo_disasters.py
+++ b/climate_risk/data/geo_disasters.py
@@ -1,5 +1,4 @@
 import logging
-import unicodedata
 
 from collections.abc import Mapping, Sequence
 from functools import partial
@@ -7,6 +6,8 @@ from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
+
+from anyascii import anyascii
 
 from climate_risk.data.cache import cached, pandas_parquet
 from climate_risk.data.gadm import load_units_in_country
@@ -317,7 +318,8 @@ def normalise_unit_name(name: str) -> str:
     Reduce an administrative unit's name to what two gazetteers can be expected to agree on.
 
     GADM and GAUL romanise the same unit differently — accents, hyphens and casing all drift — so a
-    literal comparison reports spelling as disagreement.
+    literal comparison reports spelling as disagreement. The name is transliterated rather than
+    decomposed, because a letter like ``Đ`` or ``ł`` carries no combining mark to strip.
 
     Parameters
     ----------
@@ -327,10 +329,9 @@ def normalise_unit_name(name: str) -> str:
     Returns
     -------
     str
-        Casefolded, stripped of accents and of everything that is not a letter or digit.
+        Casefolded, transliterated to ASCII, and stripped of everything that is not a letter or digit.
     """
-    decomposed = unicodedata.normalize("NFKD", name)
-    return "".join(character for character in decomposed if character.isalnum()).casefold()
+    return "".join(character for character in anyascii(name) if character.isalnum()).casefold()
 
 
 def event_unit_ids(units: pd.DataFrame) -> dict[str, set[str]]:

--- a/pixi.lock
+++ b/pixi.lock
@@ -280,6 +280,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
@@ -402,6 +403,7 @@ environments:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
@@ -1021,6 +1023,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
@@ -1231,6 +1234,7 @@ environments:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
@@ -6474,6 +6478,19 @@ packages:
   run_exports: {}
   size: 631452
   timestamp: 1758743294412
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
+  sha256: e7e8110ada1a45fa7103704d7996c94a1e69f2ae45da17c89ca5d214a089e658
+  md5: e5438b5cd3552aca55f7ab5b25891590
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/anyascii?source=hash-mapping
+  run_exports: {}
+  size: 309748
+  timestamp: 1751323812621
 - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
   sha256: e36998c5e860e26b22e5dbcd5726dd0c4eabad949c84d383cad8512757bbf6a1
   md5: fb568fbae6908ba86a090a85a089d11f
@@ -13138,6 +13155,7 @@ packages:
 - pypi: .
   name: climate-risk
   requires_dist:
+  - anyascii>=0.3.3,<1
   - arviz>=1.2,<2
   - exactextract>=0.3,<1
   - fastexcel>=0.20,<1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "matplotlib>=3.11,<4",
     "seaborn>=0.13,<1",
     "tqdm>=4.70,<5",
+    "anyascii>=0.3.3,<1",
     "requests>=2.34,<3",
 ]
 
@@ -100,6 +101,7 @@ statsmodels = ">=0.14,<1"
 matplotlib = ">=3.11,<4"
 seaborn = ">=0.13,<1"
 tqdm = ">=4.70,<5"
+anyascii = ">=0.3.3,<1"
 requests = ">=2.34.2,<3"
 polars = ">=1.43,<2"
 pyarrow = ">=25.0,<26"

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -106,12 +106,21 @@ def test_geometry_is_left_on_disk(write_geo_disasters_cache):
 
 @pytest.mark.parametrize(
     ("published", "other"),
-    [("Attapu", "attapu"), ("Bolikhamxai", "Bolikhamxai "), ("Xekong", "Xékong"), ("Xai-somboun", "Xaisomboun")],
-    ids=["casing", "whitespace", "accent", "hyphen"],
+    [
+        ("Attapu", "attapu"),
+        ("Bolikhamxai", "Bolikhamxai "),
+        ("Xekong", "Xékong"),
+        ("Xai-somboun", "Xaisomboun"),
+        ("Da Nang", "Đà Nẵng"),
+        ("Lodz", "Łódź"),
+    ],
+    ids=["casing", "whitespace", "accent", "hyphen", "d-with-stroke", "l-with-stroke"],
 )
 def test_the_same_unit_spelled_two_ways_normalises_alike(published, other):
     """GADM and GAUL differ in casing, spacing, accents and hyphens for units that are the same one,
-    and a literal comparison would report every one of these as the sources disagreeing."""
+    and a literal comparison would report every one of these as the sources disagreeing. A stroked
+    letter carries no combining mark, so stripping accents leaves `Đ` and `ł` standing and `Đà Nẵng`
+    never meets `Da Nang`. GADM holds both, in different scripts, so one language's fix is not enough."""
     assert normalise_unit_name(published) == normalise_unit_name(other)
 
 


### PR DESCRIPTION
`normalise_unit_name` folded accents by decomposing to NFKD and dropping combining marks. That misses letters where the mark is part of the glyph — `Đ`, `ł`, `ø`, `ß` — so `Đà Nẵng` could never match `Da Nang`. GADM holds 48 such characters worldwide, mostly outside Southeast Asia, so this bites harder as the model moves past the region than it does today.

New dependency, `anyascii`, picked over `unidecode` on two counts. It's ISC rather than GPL, which an MIT package can't take. And it's more accurate on the names we have: `unidecode` deletes the Azerbaijani schwa outright, turning `Bərdə` into `brd`, and the two differ on 36 of GADM's 54,201 unit names, all in that direction.
