### PR TITLE
Resolve EM-DAT location text to GADM administrative units

### DIFF
--- a/climate_risk/data/cache.py
+++ b/climate_risk/data/cache.py
@@ -1,3 +1,5 @@
+import hashlib
+import inspect
 import logging
 import os
 
@@ -113,6 +115,33 @@ def _key_part(value: object, described_as: str) -> str:
         raise ValueError(f"{described_as} must not contain {forbidden}, got {text!r}")
 
     return text
+
+
+def builder_fingerprint(builder: Callable[[], object], *rules: object) -> str:
+    """
+    Fingerprint how an artefact is built, so a change to the builder turns over what it cached.
+
+    Parameters record what was asked for and nothing records how the answer was produced, so an
+    entry built under rules that have since changed reads back as a hit. Reformatting the builder or
+    editing a comment inside it turns the cache over as surely as changing a rule does.
+
+    Parameters
+    ----------
+    builder : callable
+        The function that produces the artefact.
+    *rules : object
+        Values the builder reads that its own source does not show — a table it consults, the
+        columns it selects. Each must repr the same way in every process, or the digest moves
+        between runs and nothing ever reads back.
+
+    Returns
+    -------
+    str
+        A short digest of the builder's source and the rules it was given.
+    """
+    declared = inspect.getsource(builder) + "".join(repr(rule) for rule in rules)
+
+    return hashlib.sha256(declared.encode()).hexdigest()[:12]
 
 
 def cached[T](

--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 
-from climate_risk.data.cache import cached, geo_parquet
+from climate_risk.data.cache import builder_fingerprint, cached, geo_parquet
 from climate_risk.data.source import ManualSource
 from climate_risk.exceptions import DataValidationError
 
@@ -146,7 +146,9 @@ def load_units_in_country(
         "units",
         build,
         geo_parquet(),
-        params={"iso": iso, "level": level},
+        # `layer` chooses what is read and the fingerprint covers how, neither of which the other
+        # parameters record.
+        params={"iso": iso, "layer": layer, "level": level, "reading": builder_fingerprint(build, GID_COLUMNS)},
         force=force_reload,
     )
 

--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 
+from climate_risk.data.cache import cached, geo_parquet
 from climate_risk.data.source import ManualSource
 from climate_risk.exceptions import DataValidationError
 
@@ -92,7 +93,9 @@ def administered_territories(iso: str, cache_dir: Path, *, layer: str = GADM_LAY
         return tuple(row[0] for row in held)
 
 
-def load_units_in_country(iso: str, level: int, cache_dir: Path, *, layer: str = GADM_LAYER) -> gpd.GeoDataFrame:
+def load_units_in_country(
+    iso: str, level: int, cache_dir: Path, *, layer: str = GADM_LAYER, force_reload: bool = False
+) -> gpd.GeoDataFrame:
     """
     Read every GADM unit one country holds at one administrative level.
 
@@ -109,6 +112,8 @@ def load_units_in_country(iso: str, level: int, cache_dir: Path, *, layer: str =
         Directory the caches live under.
     layer : str, optional
         Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+    force_reload : bool, optional
+        Rebuild even when the units are already cached. Default False.
 
     Returns
     -------
@@ -119,18 +124,31 @@ def load_units_in_country(iso: str, level: int, cache_dir: Path, *, layer: str =
     if level not in GID_COLUMNS:
         raise DataValidationError(f"Units are read at levels {sorted(GID_COLUMNS)}, not {level}")
 
-    gid_column, name_column = GID_COLUMNS[level]
-    rows = gpd.read_file(gadm_path(cache_dir), layer=layer, columns=[gid_column, name_column], where=f"GID_0 = '{iso}'")
-    rows = rows[rows[gid_column].astype(str) != ""]
-    if rows.empty:
-        return _no_units(gadm_path(cache_dir), layer)
+    def build() -> gpd.GeoDataFrame:
+        gid_column, name_column = GID_COLUMNS[level]
+        rows = gpd.read_file(
+            gadm_path(cache_dir), layer=layer, columns=[gid_column, name_column], where=f"GID_0 = '{iso}'"
+        )
+        # A country not divided at this level stores a blank identifier on every row.
+        rows = rows[rows[gid_column].astype(str) != ""]
+        if rows.empty:
+            return _no_units(gadm_path(cache_dir), layer)
 
-    # The table stores the finest level, so a unit above it spans several rows.
-    units = rows.dissolve(by=gid_column, aggfunc="first", as_index=False)
+        # The table stores the finest level, so a unit above it spans several rows.
+        units = rows.dissolve(by=gid_column, aggfunc="first", as_index=False)
 
-    return units.rename(columns={gid_column: "gid", name_column: "name"}).assign(admin_level=level)[
-        ["gid", "name", "admin_level", "geometry"]
-    ]
+        return units.rename(columns={gid_column: "gid", name_column: "name"}).assign(admin_level=level)[
+            ["gid", "name", "admin_level", "geometry"]
+        ]
+
+    return cached(
+        gadm_dir(cache_dir),
+        "units",
+        build,
+        geo_parquet(),
+        params={"iso": iso, "level": level},
+        force=force_reload,
+    )
 
 
 def _units_at_level(gids: list[str], level: int, path: Path, layer: str) -> gpd.GeoDataFrame | None:

--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from collections.abc import Collection, Iterator
 from pathlib import Path
 
@@ -54,6 +56,40 @@ def gadm_path(cache_dir: Path) -> Path:
 def _chunks(values: list[str], size: int) -> Iterator[list[str]]:
     for start in range(0, len(values), size):
         yield values[start : start + size]
+
+
+def administered_territories(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> tuple[str, ...]:
+    """
+    Name the disputed territories GADM files apart from the country administering them.
+
+    Kashmir is not filed under ``IND`` or ``PAK`` but under codes of its own, so an event named
+    there belongs to a country whose own code does not contain it. GADM records the administering
+    country on each territory, and that is what this reads.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to read.
+    cache_dir : Path
+        Directory the caches live under.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    tuple of str
+        The territory codes, empty for a country administering none.
+    """
+    with sqlite3.connect(gadm_path(cache_dir)) as connection:
+        named = connection.execute(f'SELECT COUNTRY FROM "{layer}" WHERE GID_0 = ? LIMIT 1', (iso,)).fetchone()
+        if named is None:
+            return ()
+        held = connection.execute(
+            f'SELECT DISTINCT GID_0 FROM "{layer}" WHERE COUNTRY = ? AND GID_0 <> ? ORDER BY GID_0',
+            (named[0], iso),
+        )
+
+        return tuple(row[0] for row in held)
 
 
 def load_units_in_country(iso: str, level: int, cache_dir: Path, *, layer: str = GADM_LAYER) -> gpd.GeoDataFrame:

--- a/climate_risk/data/gadm.py
+++ b/climate_risk/data/gadm.py
@@ -23,7 +23,7 @@ GADM = ManualSource(
 # One table holds every country at its finest level, so a unit above that is the union of its rows.
 GADM_LAYER = "gadm_410"
 
-GID_COLUMNS = {1: ("GID_1", "NAME_1"), 2: ("GID_2", "NAME_2")}
+GID_COLUMNS = {level: (f"GID_{level}", f"NAME_{level}") for level in (1, 2, 3, 4)}
 
 # A WHERE clause naming every id at once grows past what the driver will parse, and costs more to
 # plan than the extra passes cost to run.
@@ -68,7 +68,7 @@ def load_units_in_country(iso: str, level: int, cache_dir: Path, *, layer: str =
     iso : str
         ISO 3166-1 alpha-3 code of the country to read.
     level : int
-        Administrative level, 1 or 2.
+        Administrative level, 1 through 4.
     cache_dir : Path
         Directory the caches live under.
     layer : str, optional
@@ -77,13 +77,15 @@ def load_units_in_country(iso: str, level: int, cache_dir: Path, *, layer: str =
     Returns
     -------
     GeoDataFrame
-        Columns ``gid``, ``name``, ``admin_level`` and ``geometry``, one row per unit.
+        Columns ``gid``, ``name``, ``admin_level`` and ``geometry``, one row per unit. Empty where
+        the country is not divided at that level.
     """
     if level not in GID_COLUMNS:
         raise DataValidationError(f"Units are read at levels {sorted(GID_COLUMNS)}, not {level}")
 
     gid_column, name_column = GID_COLUMNS[level]
     rows = gpd.read_file(gadm_path(cache_dir), layer=layer, columns=[gid_column, name_column], where=f"GID_0 = '{iso}'")
+    rows = rows[rows[gid_column].astype(str) != ""]
     if rows.empty:
         return _no_units(gadm_path(cache_dir), layer)
 
@@ -141,7 +143,7 @@ def load_admin_units(
     Parameters
     ----------
     units : collection of tuple of (str, int)
-        Each a GADM identifier and its administrative level, 1 or 2. Duplicates are read once.
+        Each a GADM identifier and its administrative level, 1 through 4. Duplicates are read once.
     cache_dir : Path
         Directory the caches live under.
     layer : str, optional

--- a/climate_risk/data/geocoding.py
+++ b/climate_risk/data/geocoding.py
@@ -1,14 +1,20 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import NamedTuple
 
+import geopandas as gpd
+
 from shapely.geometry import Point
 
-from climate_risk.data.gadm import GADM_LAYER, load_admin_units
+from climate_risk.data.gadm import GADM_LAYER, load_admin_units, load_units_in_country
 from climate_risk.data.place_names import Gazetteer, resolve_place
+from climate_risk.geo.crs import GEOGRAPHIC_CRS
 
 # A geocoder answers with longitude and latitude, or with nothing where it does not know the place.
 Geocoder = Callable[[str, str], tuple[float, float] | None]
+
+# Finest first: a point says where an event was, and the smallest unit holding it says it best.
+PLACEABLE_LEVELS = (4, 3, 2, 1)
 
 IN_THE_UNIT = "in the unit"
 IN_ITS_PROVINCE = "in its province"
@@ -128,3 +134,61 @@ def score_geocoder(
         scored.append(ScoredName(name, gid, outcome))
 
     return scored
+
+
+def units_containing_points(
+    points: Mapping[str, tuple[float, float]],
+    iso: str,
+    cache_dir: Path,
+    *,
+    levels: Iterable[int] = PLACEABLE_LEVELS,
+    layer: str = GADM_LAYER,
+) -> dict[str, str]:
+    """
+    Name the finest GADM unit holding each point.
+
+    Falling back to the container a place was written in claims every unit inside it — a province
+    spans fourteen districts at the median — so a point is worth reaching for first wherever one
+    exists.
+
+    Parameters
+    ----------
+    points : mapping of str to tuple of float
+        Longitude and latitude, keyed on the written name they came from.
+    iso : str
+        ISO 3166-1 alpha-3 code of the country the points are in.
+    cache_dir : Path
+        Directory the caches live under.
+    levels : iterable of int, optional
+        Administrative levels to try, in order. Default finest to coarsest.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    dict mapping str to str
+        The GADM identifier each name's point falls in, absent where no level holds it.
+    """
+    if not points:
+        return {}
+
+    placed: dict[str, str] = {}
+    outstanding = dict(points)
+
+    for level in levels:
+        if not outstanding:
+            break
+        units = load_units_in_country(iso, level, cache_dir, layer=layer)
+        if units.empty:
+            continue
+
+        located = gpd.GeoDataFrame(
+            {"name": list(outstanding)},
+            geometry=gpd.points_from_xy(*zip(*outstanding.values(), strict=True)),
+            crs=GEOGRAPHIC_CRS,
+        )
+        inside = gpd.sjoin(located, units[["gid", "geometry"]], how="inner", predicate="within")
+        placed |= dict(zip(inside["name"], inside["gid"], strict=True))
+        outstanding = {name: point for name, point in outstanding.items() if name not in placed}
+
+    return placed

--- a/climate_risk/data/geocoding.py
+++ b/climate_risk/data/geocoding.py
@@ -3,10 +3,11 @@ from pathlib import Path
 from typing import NamedTuple
 
 import geopandas as gpd
+import pandas as pd
 
 from shapely.geometry import Point
 
-from climate_risk.data.gadm import GADM_LAYER, load_admin_units, load_units_in_country
+from climate_risk.data.gadm import GADM_LAYER, administered_territories, load_admin_units, load_units_in_country
 from climate_risk.data.place_names import Gazetteer, resolve_place
 from climate_risk.geo.crs import GEOGRAPHIC_CRS
 
@@ -175,12 +176,16 @@ def units_containing_points(
     placed: dict[str, str] = {}
     outstanding = dict(points)
 
+    held = (iso, *administered_territories(iso, cache_dir, layer=layer))
     for level in levels:
         if not outstanding:
             break
-        units = load_units_in_country(iso, level, cache_dir, layer=layer)
-        if units.empty:
+        reachable = [
+            frame for code in held if not (frame := load_units_in_country(code, level, cache_dir, layer=layer)).empty
+        ]
+        if not reachable:
             continue
+        units = gpd.GeoDataFrame(pd.concat(reachable, ignore_index=True), crs=reachable[0].crs)
 
         located = gpd.GeoDataFrame(
             {"name": list(outstanding)},

--- a/climate_risk/data/geocoding.py
+++ b/climate_risk/data/geocoding.py
@@ -1,0 +1,130 @@
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import NamedTuple
+
+from shapely.geometry import Point
+
+from climate_risk.data.gadm import GADM_LAYER, load_admin_units
+from climate_risk.data.place_names import Gazetteer, resolve_place
+
+# A geocoder answers with longitude and latitude, or with nothing where it does not know the place.
+Geocoder = Callable[[str, str], tuple[float, float] | None]
+
+IN_THE_UNIT = "in the unit"
+IN_ITS_PROVINCE = "in its province"
+ELSEWHERE = "elsewhere"
+NO_POINT = "no point"
+
+
+class ScoredName(NamedTuple):
+    """Where a geocoder put one written place, against the unit its name already resolves to.
+
+    Parameters
+    ----------
+    name : str
+        The place as written.
+    gid : str
+        The GADM identifier the name resolves to unambiguously.
+    outcome : str
+        One of ``IN_THE_UNIT``, ``IN_ITS_PROVINCE``, ``ELSEWHERE`` or ``NO_POINT``.
+    """
+
+    name: str
+    gid: str
+    outcome: str
+
+
+def unambiguous_units(places: Iterable[tuple[str, str | None]], gazetteer: Gazetteer) -> dict[str, str]:
+    """
+    Keep the written places whose name reaches exactly one GADM unit.
+
+    These are the geocoder's answer key: the name already tells us the unit, so a point that lands
+    anywhere else is wrong without anyone having to adjudicate it.
+
+    Parameters
+    ----------
+    places : iterable of tuple
+        Each a name as written and the container the prose gave, or None.
+    gazetteer : Gazetteer
+        The country's units, from :func:`~climate_risk.data.place_names.read_gazetteer`.
+
+    Returns
+    -------
+    dict mapping str to str
+        The GADM identifier each usable name reaches.
+    """
+    settled = {}
+    for name, parent in places:
+        gids = resolve_place(name, parent, gazetteer)
+        if len(gids) == 1:
+            settled[name] = next(iter(gids))
+
+    return settled
+
+
+def score_geocoder(
+    geocode: Geocoder,
+    iso: str,
+    places: Iterable[tuple[str, str | None]],
+    gazetteer: Gazetteer,
+    cache_dir: Path,
+    *,
+    layer: str = GADM_LAYER,
+) -> list[ScoredName]:
+    """
+    Score a geocoder against the places whose names already resolve to one GADM unit.
+
+    A point is judged three ways: inside the unit the name names, inside the level-1 unit containing
+    it, or somewhere else. The middle case is what a coarse but usable geocoder looks like, and
+    separating it from the last is the difference between a source worth aggregating upwards and one
+    worth discarding.
+
+    Parameters
+    ----------
+    geocode : callable
+        Takes an ISO 3166-1 alpha-3 code and a place name, and returns longitude and latitude, or
+        None where it does not know the place.
+    iso : str
+        ISO 3166-1 alpha-3 code of the country the places are in.
+    places : iterable of tuple
+        Each a name as written and the container the prose gave, or None.
+    gazetteer : Gazetteer
+        The country's units, from :func:`~climate_risk.data.place_names.read_gazetteer`.
+    cache_dir : Path
+        Directory the caches live under.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    list of ScoredName
+        One entry per name that had an answer to check against.
+    """
+    settled = unambiguous_units(places, gazetteer)
+    if not settled:
+        return []
+
+    levels = {unit.gid: unit.level for units in gazetteer.names.values() for unit in units}
+    wanted = {(gid, levels[gid]) for gid in settled.values()}
+    wanted |= {(gazetteer.top_container(gid), 1) for gid in settled.values()}
+
+    polygons = load_admin_units(wanted, cache_dir, layer=layer)
+    shapes = dict(zip(polygons["gid"], polygons.geometry, strict=True))
+
+    scored = []
+    for name, gid in settled.items():
+        located = geocode(iso, name)
+        if located is None:
+            scored.append(ScoredName(name, gid, NO_POINT))
+            continue
+
+        point = Point(*located)
+        if shapes[gid].contains(point):
+            outcome = IN_THE_UNIT
+        elif shapes[gazetteer.top_container(gid)].contains(point):
+            outcome = IN_ITS_PROVINCE
+        else:
+            outcome = ELSEWHERE
+        scored.append(ScoredName(name, gid, outcome))
+
+    return scored

--- a/climate_risk/data/geocoding.py
+++ b/climate_risk/data/geocoding.py
@@ -197,3 +197,53 @@ def units_containing_points(
         outstanding = {name: point for name, point in outstanding.items() if name not in placed}
 
     return placed
+
+
+def units_from_geocoders(
+    names: Iterable[str],
+    iso: str,
+    cache_dir: Path,
+    geocoders: Iterable[Geocoder],
+    *,
+    levels: Iterable[int] = PLACEABLE_LEVELS,
+    layer: str = GADM_LAYER,
+) -> dict[str, str]:
+    """
+    Name the GADM unit each written place falls in, asking each source in turn.
+
+    Sources are tried in the order given and the first answer for a name is kept, so the order is a
+    statement about which source is trusted: an earlier one is preferred wherever it answers at all.
+    A point that falls outside every unit is discarded rather than passed on, which is what stops a
+    place sitting offshore, or in the country next door, from reaching a unit it does not belong to.
+
+    Parameters
+    ----------
+    names : iterable of str
+        The places as written.
+    iso : str
+        ISO 3166-1 alpha-3 code of the country the places are in.
+    cache_dir : Path
+        Directory the caches live under.
+    geocoders : iterable of callable
+        Sources to ask, most trusted first.
+    levels : iterable of int, optional
+        Administrative levels to try, in order. Default finest to coarsest.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    dict mapping str to str
+        The GADM identifier each name reaches, absent where no source placed it inside a unit.
+    """
+    placed: dict[str, str] = {}
+    outstanding = list(names)
+
+    for geocode in geocoders:
+        if not outstanding:
+            break
+        points = {name: point for name in outstanding if (point := geocode(iso, name)) is not None}
+        placed |= units_containing_points(points, iso, cache_dir, levels=levels, layer=layer)
+        outstanding = [name for name in outstanding if name not in placed]
+
+    return placed

--- a/climate_risk/data/geonames.py
+++ b/climate_risk/data/geonames.py
@@ -3,10 +3,10 @@ from zipfile import ZipFile
 
 import polars as pl
 
-from climate_risk.data.cache import cached, polars_parquet
+from climate_risk.data.cache import builder_fingerprint, cached, polars_parquet
 from climate_risk.data.fetch import fetch
 from climate_risk.data.geocoding import Geocoder
-from climate_risk.data.place_names import match_key
+from climate_risk.data.place_names import keying_fingerprint, match_key
 from climate_risk.data.source import DataSource
 
 GEONAMES_URL = "https://download.geonames.org/export/dump"
@@ -127,7 +127,16 @@ def load_place_points(iso: str, cache_dir: Path, *, force_reload: bool = False) 
 
         return keyed.sort("population", descending=True).unique(subset="key", keep="first").select("key", "lon", "lat")
 
-    return cached(directory, "places", build, polars_parquet(), params={"iso": iso}, force=force_reload)
+    return cached(
+        directory,
+        "places",
+        build,
+        polars_parquet(),
+        # `keying` covers the rules that turn a name into a key, `reading` the rules that decide
+        # which spelling of a place keeps one.
+        params={"iso": iso, "keying": keying_fingerprint(), "reading": builder_fingerprint(build, DUMP_FIELDS)},
+        force=force_reload,
+    )
 
 
 def geonames_geocoder(iso: str, cache_dir: Path, *, force_reload: bool = False) -> Geocoder:

--- a/climate_risk/data/geonames.py
+++ b/climate_risk/data/geonames.py
@@ -1,0 +1,157 @@
+from pathlib import Path
+from zipfile import ZipFile
+
+import polars as pl
+
+from climate_risk.data.cache import cached, polars_parquet
+from climate_risk.data.fetch import fetch
+from climate_risk.data.geocoding import Geocoder
+from climate_risk.data.place_names import match_key
+from climate_risk.data.source import DataSource
+
+GEONAMES_URL = "https://download.geonames.org/export/dump"
+GEONAMES_SUBDIRECTORY = "geonames"
+GEONAMES_LICENCE = "CC BY 4.0"
+GEONAMES_CITATION = "GeoNames geographical database, https://www.geonames.org, licensed CC BY 4.0."
+GEONAMES_RETRIEVED = "2026-08-19"
+
+# The dump is headerless and positional; these are the fields a name-to-point lookup reads, keyed
+# on where they sit in a row.
+DUMP_FIELDS = {1: "name", 2: "ascii_name", 3: "alternates", 4: "lat", 5: "lon", 14: "population"}
+
+COUNTRY_INFO = DataSource(
+    url=f"{GEONAMES_URL}/countryInfo.txt",
+    filename="countryInfo.txt",
+    licence=GEONAMES_LICENCE,
+    citation=GEONAMES_CITATION,
+    retrieved=GEONAMES_RETRIEVED,
+)
+
+
+def geonames_dir(cache_dir: Path) -> Path:
+    return cache_dir / GEONAMES_SUBDIRECTORY
+
+
+def country_dump(alpha2: str) -> DataSource:
+    """Declare the dump for one country, which GeoNames files under its two-letter code."""
+    return DataSource(
+        url=f"{GEONAMES_URL}/{alpha2}.zip",
+        filename=f"{alpha2}.zip",
+        licence=GEONAMES_LICENCE,
+        citation=GEONAMES_CITATION,
+        retrieved=GEONAMES_RETRIEVED,
+    )
+
+
+def read_country_codes(cache_dir: Path, *, force_reload: bool = False) -> dict[str, str]:
+    """
+    Map each country's alpha-3 code to the alpha-2 code GeoNames files its dump under.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+    force_reload : bool, optional
+        Re-download even when the file is already there. Default False.
+
+    Returns
+    -------
+    dict mapping str to str
+        Alpha-2 code, keyed by alpha-3.
+    """
+    path = fetch(COUNTRY_INFO, geonames_dir(cache_dir), force=force_reload)
+    codes = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) > 1 and fields[0] and fields[1]:
+            codes[fields[1]] = fields[0]
+
+    return codes
+
+
+def load_place_points(iso: str, cache_dir: Path, *, force_reload: bool = False) -> pl.DataFrame:
+    """
+    Read one country's GeoNames places, keyed for matching against written mentions.
+
+    Every name a place is published under becomes a row — its own, its ASCII form and each
+    alternate — so a mention reaches a point whichever spelling it used. Where a name is shared, the
+    most populous place keeps it, which is what makes a written ``Manila`` the city rather than one
+    of the hamlets sharing the name.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to read.
+    cache_dir : Path
+        Directory the caches live under.
+    force_reload : bool, optional
+        Rebuild even when the cache is warm. Default False.
+
+    Returns
+    -------
+    DataFrame
+        Columns ``key``, ``lon`` and ``lat``, one row per distinct name.
+    """
+    directory = geonames_dir(cache_dir)
+
+    def build() -> pl.DataFrame:
+        alpha2 = read_country_codes(cache_dir)[iso]
+        archive = fetch(country_dump(alpha2), directory)
+
+        with ZipFile(archive) as zipped, zipped.open(f"{alpha2}.txt") as dump:
+            # Names carry unescaped quotes, which a quoting reader swallows whole lines on.
+            rows = pl.read_csv(
+                dump.read(),
+                separator="\t",
+                has_header=False,
+                quote_char=None,
+                columns=list(DUMP_FIELDS),
+                new_columns=list(DUMP_FIELDS.values()),
+                schema_overrides={"lat": pl.Float64, "lon": pl.Float64, "population": pl.Int64},
+                infer_schema_length=0,
+            )
+
+        spellings = rows.with_columns(
+            pl.concat_list(
+                pl.col("name"),
+                pl.col("ascii_name"),
+                pl.col("alternates").fill_null("").str.split(","),
+            ).alias("written")
+        ).explode("written", empty_as_null=False)
+
+        keyed = spellings.with_columns(
+            pl.col("written").map_elements(match_key, return_dtype=pl.String).alias("key")
+        ).filter(pl.col("key") != "")
+
+        return keyed.sort("population", descending=True).unique(subset="key", keep="first").select("key", "lon", "lat")
+
+    return cached(directory, "places", build, polars_parquet(), params={"iso": iso}, force=force_reload)
+
+
+def geonames_geocoder(iso: str, cache_dir: Path, *, force_reload: bool = False) -> Geocoder:
+    """
+    Build a geocoder answering from one country's GeoNames places.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to answer for.
+    cache_dir : Path
+        Directory the caches live under.
+    force_reload : bool, optional
+        Rebuild the places table even when it is cached. Default False.
+
+    Returns
+    -------
+    callable
+        Takes an ISO code and a written name, and returns longitude and latitude or None.
+    """
+    points = load_place_points(iso, cache_dir, force_reload=force_reload)
+    located = dict(zip(points["key"], zip(points["lon"], points["lat"], strict=True), strict=True))
+
+    def locate(_: str, name: str) -> tuple[float, float] | None:
+        return located.get(match_key(name))
+
+    return locate

--- a/climate_risk/data/name_corrections.csv
+++ b/climate_risk/data/name_corrections.csv
@@ -1,0 +1,611 @@
+iso,written,corrected
+AFG,- Badakshan Province,badakhshan
+AFG,Badakhstan,badakhshan
+AFG,Badakhstan province,badakhshan
+AFG,Badakhstan provinces,badakhshan
+AFG,Badakhsthan,badakhshan
+AFG,Badakshan,badakhshan
+AFG,Daikundi,daykundi
+AFG,Dara Pech,daraipech
+AFG,Kejran,kijran
+AFG,Khawahan districts,khwahan
+AFG,Nangarha,nangarhar
+AGO,Near Porto Amboin,portoamboim
+ALB,Shkadra,shkodra
+ARG,Cardoba,cordoba
+ARG,Esteban Etcheverria,estebanecheverria
+ARG,Near Santiago del Esterro,santiagodelestero
+ARG,Near sante Fe,santafe
+ARG,Sante FE,santafe
+ARG,Sante Fe,santafe
+ARG,Sante Fe provinces,santafe
+AUS,Queanreyan,queanbeyan
+AUS,Towsville Area,townsville
+AZE,Kuradamir,kurdamir
+AZE,Yardimili districts,yardimli
+BDI,Bubamza,bubanza
+BDI,Cibitoki,cibitoke
+BDI,Murumvya Province,muramvya
+BEL,Liege's province,liege
+BEN,Acomey-Calavi,abomeycalavi
+BEN,Bassilla,bassila
+BEN,Karimana,karimama
+BFA,Banfofa,banfora
+BFA,Barsologo,barsalogo
+BFA,Borono,boromo
+BFA,Diegougou,diebougou
+BFA,Koungoussi,kongoussi
+BFA,Koutitenga,kouritenga
+BFA,Mangodar,mangodara
+BFA,Near Koupèle,koupela
+BFA,Outbritenga,oubritenga
+BGD,Banderban,bandarban
+BGD,Baraguna,barguna
+BGD,Begumgang,begumganj
+BGD,Borguna districts,barguna
+BGD,Chouddagram,chauddagram
+BGD,Cox's Bazaar,coxsbazar
+BGD,Cox's Bazaar districts,coxsbazar
+BGD,Coxbazar,coxsbazar
+BGD,Habaganj,habiganj
+BGD,Jhalokath,jhalokati
+BGD,Joipurhat,joypurhat
+BGD,Kishoregang,kishoreganj
+BGD,Lalmohon,lalmohan
+BGD,Lalmonirat,lalmonirhat
+BGD,Manikanj,manikganj
+BGD,Munshigan,munshiganj
+BGD,Narayangani,narayanganj
+BGD,Near Dhamrei,dhamrai
+BGD,Near Sirajgang,sirajganj
+BGD,Netrokona,netrakona
+BGD,Nilhamari,nilphamari
+BGD,Nilpamari,nilphamari
+BGD,Pathuakhali,patuakhali
+BGD,Potuakhali,patuakhali
+BGD,Rajshai,rajshahi
+BGD,Sadwip,sandwip
+BGD,Sathkhira,satkhira
+BGD,Siranjganj,sirajganj
+BGD,Sitakundu,sitakunda
+BGD,Sitakundu districts,sitakunda
+BGD,Swandwip,sandwip
+BGR,Dupnitsca district,dupnitsa
+BGR,Near Svogué,svoge
+BGR,Roussa,rousse
+BGR,Silista,silistra
+BIH,Novo Saranevo,novosarajevo
+BLR,Stollin,stolin
+BOL,Ascension De Guarayos,ascenciondeguarayos
+BOL,Chuquisoca departments,chuquisaca
+BOL,Near AQuile,aiquile
+BOL,Near Achicachi,achacachi
+BOL,Toraque,tiraque
+BOL,Tortora,totora
+BRA,Angra do Reis,angradosreis
+BRA,Barraeiras,barreiras
+BRA,Campos de Jordao,camposdojordao
+BRA,Caraguatauba,caraguatatuba
+BRA,Faznda Rio Grande,fazendariogrande
+BRA,Mina Gerais states,minasgerais
+BRA,Near Manacupuru,manacapuru
+BRA,Pernabuco,pernambuco
+BRA,Pobo Branco,pocobranco
+BRA,Santa Caterina,santacatarina
+BRA,Santa Caterina state,santacatarina
+BRA,Sau Paulo,saopaulo
+CAF,Bangui 1,bangui
+CAF,Bé-Mbari,bambari
+CAF,Haute Katto,hautekotto
+CAF,Ouaham-Pende,ouhampende
+CAN,Bristish Columbia,britishcolumbia
+CAN,Britsh Columbia province,britishcolumbia
+CAN,Missisauga,mississauga
+CAN,Niva Scotia,novascotia
+CHL,Antogagasta,antofagasta
+CHL,Arica y Painacota province,aricayparinacota
+CHL,Arucania,araucania
+CHL,Atacamo,atacama
+CHL,Melipouco,melipeuco
+CHL,Puerto Monte,puertomontt
+CHL,Rancegua,rancagua
+CHL,Salamnca,salamanca
+CHL,Santago,santiago
+CHL,Traiguan,traiguen
+CHL,Villarica,villarrica
+CHN,Chondqing,chongqing
+CHN,Chongquing,chongqing
+CHN,Fengzen,fengzhen
+CHN,Ghizhou,guizhou
+CHN,Guangdon province,guangdong
+CHN,Guangdon provinces,guangdong
+CHN,Guangxci,guangxi
+CHN,Gueizhou province,guizhou
+CHN,Gungdong provinces,guangdong
+CHN,Jiangsy,jiangsu
+CHN,Pingdingsham,pingdingshan
+CHN,Quinghai,qinghai
+CHN,Quinghai province,qinghai
+CHN,Sichuang,sichuan
+CHN,Tianjian,tianjin
+CHN,Xinjiang-Uygar Region,xinjianguygur
+CHN,Zangbei County,zhangbei
+CHN,Zhejian,zhejiang
+CHN,Zhejian provinces,zhejiang
+CHN,Zhengzou,zhengzhou
+CIV,Toouba,touba
+CMR,Mogobe,mogode
+COG,Bazzaville,brazzaville
+COG,Point-Noire,pointenoire
+COK,Palmeston,palmerston
+COL,Amboledas,arboledas
+COL,Atlantic,atlantico
+COL,Barrranquilla,barranquilla
+COL,Fresdonia,fredonia
+COL,Guainiaz,guainia
+COL,Marizales,manizales
+COL,Near Carthagena,cartagena
+COL,Quindiio,quindio
+COL,Santa Rose de Cabal,santarosadecabal
+COL,Tolina Department,tolima
+COL,Villavicencia,villavicencio
+COL,valle de Cauca,valledelcauca
+COM,Grande Comores,grandecomore
+CUB,Las Tuna,lastunas
+CUB,Mantanzas,matanzas
+CUB,Monati,manati
+CUB,Sancti Spiritu,sanctispiritus
+CUB,Santigo de Cuba,santiagodecuba
+DEU,Ahlsfeld,alsfeld
+DEU,Near Heildelberg,heidelberg
+DEU,Searbrucken,saarbrucken
+DOM,Barhona,barahona
+DOM,Barohona,barahona
+DOM,Duarrte,duarte
+DOM,Maria Trinidad Sanches,mariatrinidadsanchez
+DZA,Aïn Témuchent,aintemouchent
+DZA,Beni Illmane,beniilmane
+DZA,Bodj-Bou-Arreridj,bordjbouarreridj
+DZA,Boussaada,bousaada
+DZA,El Elma,eleulma
+DZA,Tlemcem,tlemcen
+ECU,Chinchippe.,chinchipe
+ECU,Cotapaxi,cotopaxi
+ECU,Cotopax,cotopaxi
+ECU,Gualapagos,galapagos
+ECU,Tunguraha,tungurahua
+ECU,Zamora Chincipe,zamorachinchipe
+EGY,Al Aiyat,alayyat
+EGY,Al-Saff region,assaff
+EGY,Beni Soueif,benisouef
+EGY,Beni Soueif Region,benisouef
+EGY,Beni-Soueif governorate,benisouef
+EGY,Helwane,helwan
+EGY,Manfalout,manfalut
+EGY,Near Manfalout,manfalut
+EGY,Ras Sedr,rassidr
+EGY,Sadata,sadat
+ETH,Benshangul-Gumuz,benshangulgumaz
+ETH,Haregele,hargele
+ETH,Kalafo,kelafo
+ETH,Kprahe,korahe
+ETH,Near Libo-Kemke,libokemkem
+ETH,Southern Nation Nationalities,southernnationsnationalities
+FRA,Charentes Departments,charente
+FRA,Haure-Savoie,hautesavoie
+GBR,Bigin Hill,bigginhill
+GEO,Kvemo Kartii district,kvemokartli
+GEO,Tsalendjikha district,tsalenjikha
+GHA,Asekuma Odoben Brakwa,asikumaodobenbrakwa
+GHA,Bawku M.,bawku
+GHA,Komenda Edina Eguafo Abrem,komendaedinaeguafoabirem
+GHA,Talensi N,talensi
+GIN,Balandougoubal,balandougouba
+GIN,Conakri,conakry
+GNB,Bissay City,bissau
+GNB,Quinira,quinara
+GNB,Tombalia,tombali
+GRC,Aguistri Isl.,agistri
+GRC,Cretes,crete
+GRC,Ionians Isl.,ionian
+GRC,Near Cretes,crete
+GTM,Chamaltenango area,chimaltenango
+GTM,Chinaltenango,chimaltenango
+GTM,El Progresso,elprogreso
+GTM,Jutlapa,jutiapa
+GTM,Ratalhuleu,retalhuleu
+GTM,Sacatepeguez,sacatepequez
+GUM,Taimuning,tamuning
+HND,Cholima,choloma
+HND,El Progresso,elprogreso
+HTI,Grand Riviare du Nord,grandrivieredunord
+HTI,Jeremlie,jeremie
+HTI,Port-au-Pince,portauprince
+HTI,Port-de-Pauix,portdepaix
+HUN,Gyor Monson Sopron,gyormosonsopron
+IDN,Bangkejeren,blangkejeren
+IDN,Cilicap district,cilacap
+IDN,Gresick,gresik
+IDN,Grobongan,grobogan
+IDN,Lhoksemawe,lhokseumawe
+IDN,Majalenga,majalengka
+IDN,Masalembo Isl.,masalembu
+IDN,Mauraba,mauramba
+IDN,Nusa Tenggara Timor,nusatenggaratimur
+IDN,Paletoang,paleteang
+IDN,Pandelang District,pandeglang
+IDN,Parasanga,parsanga
+IDN,Pesisir Selaten,pesisirselatan
+IDN,Piddie,pidie
+IDN,Rajabassa,rajabasa
+IDN,Woosobo,wonosobo
+IND,Andhra Prasdesh,andhrapradesh
+IND,Bengalore,bangalore
+IND,Gajapathi,gajapati
+IND,Gwaltior,gwalior
+IND,Kalhandi,kalahandi
+IND,Madhya Prasdesh,madhyapradesh
+IND,Maduri,madurai
+IND,Madya Pradesh,madhyapradesh
+IND,Mayurbhang,mayurbhanj
+IND,Mizorem,mizoram
+IND,Murshidabab district,murshidabad
+IND,Near Vijaywada,vijayawada
+IND,Raigarth,raigarh
+IND,Ramanathapurum,ramanathapuram
+IND,Tami Nadu,tamilnadu
+IND,Tami Nadu state,tamilnadu
+IND,Uttarkhand state,uttarakhand
+IND,Vishakhapatam,vishakhapatnam
+IND,West Bangal,westbengal
+IND,West Begal,westbengal
+IRN,Andimechk region,andimeshk
+IRN,Bachtaran,bakhtaran
+IRN,Bahbahan,behbahan
+IRN,Boroujerd,borujerd
+IRN,Boushehr,bushehr
+IRN,Buchehr,bushehr
+IRN,Damaghan,damghan
+IRN,Damavond,damavand
+IRN,Ferdow,ferdows
+IRN,Gillan,gilan
+IRN,Gonobad area,gonabad
+IRN,Khoram Abad,khorramabad
+IRN,Khouzestan,khuzestan
+IRN,Khouzestan provinces,khuzestan
+IRN,Langroud,langrud
+IRN,Macshhad,mashhad
+IRN,Near Behchahr,behshahr
+IRN,Near Korramabad,khorramabad
+IRN,Near Maschad,mashhad
+IRN,Near Oroumiyeh,orumiyeh
+IRN,Near Sardacht,sardasht
+IRN,Oroumiyeh,orumiyeh
+IRN,Poldakhtar cities,poldokhtar
+IRN,Roudan,rudan
+IRN,Samirom region,semirom
+IRN,Shoushtar,shushtar
+IRN,Somesara,someesara
+IRQ,Nassiriyah,nasiriyah
+IRQ,Near Diwanijah,diwaniyah
+IRQ,Wassit provinces,wasit
+ISL,Olafsfjfordur,olafsfjordur
+ISR,Jeresalem,jerusalem
+ITA,Carmons,cormons
+ITA,Castellanata,castellaneta
+ITA,Manfradonia,manfredonia
+ITA,Novarra,novara
+ITA,Pascara,pescara
+ITA,Senigalia,senigallia
+ITA,near Arigente,agrigente
+JAM,Trehawny,trelawny
+JPN,Fukuchiama,fukuchiyama
+JPN,Fukuoaka prefectures,fukuoka
+JPN,Hokkaiso Isl.,hokkaido
+JPN,Marioka,morioka
+JPN,Muruto,muroto
+JPN,Niigita,niigata
+JPN,Shizuoaka,shizuoka
+KAZ,Kurchumsky,kurchumskiy
+KAZ,Ulansky,ulanskiy
+KEN,Mandea,mandera
+KEN,Murunga district,muranga
+KEN,Roongo,rongo
+KEN,West Poko,westpokot
+KGZ,Jala-Abad,jalalabad
+KHM,Kampong Spen,kampongspeu
+KOR,Gyeongiu,gyeongju
+KOR,Gyeongu,gyeongju
+KOR,Kangwon-Don,kangwondo
+KOR,Kanwon Do,kangwondo
+LAO,Atsaphon district,atsaphone
+LAO,Borlikhamxay,bolikhamxay
+LAO,Luanprabang,luangprabang
+LBN,Qalmoun,qalamoun
+LBY,Az Zawia provinces,azzawiya
+LBY,Zawija,zawiya
+LCA,Castries-B,castries
+LKA,Battocaloa,batticaloa
+LKA,Gampaka,gampaha
+LKA,Kamunai districts,kalmunai
+LKA,Kegalce,kegalle
+LKA,Nuwera Eliya,nuwaraeliya
+LKA,Puttlam,puttalam
+LKA,Rathnapura,ratnapura
+LKA,Tricomalee,trincomalee
+LKA,Vavuniy districts,vavuniya
+MAR,Chefchaoun,chefchaouen
+MAR,Essaouirra,essaouira
+MAR,Imouzzer-Handar,imouzzerkandar
+MAR,Near Aïn Harrounda,ainharrouda
+MAR,Near Guelmin,guelmim
+MAR,Tetsuan province,tetouan
+MDA,Calaras,calarasi
+MDA,Calarashi,calarasi
+MDA,Unghni,ungheni
+MDG,Alaotra Mangora,alaotramangoro
+MDG,Ambiloe,ambilobe
+MDG,Ampaniy,ampanihy
+MDG,Bamanevika,bemanevika
+MDG,Morondova,morondava
+MDG,Toamisina,toamasina
+MDG,Tomasina province,toamasina
+MDG,Tsiroanomandity,tsiroanomandidy
+MDG,Vaingaindrano,vangaindrano
+MDG,Vakinakaratra,vakinankaratra
+MDG,Vakinankarata,vakinankaratra
+MDG,Vangaidrano,vangaindrano
+MEX,Chichuahua,chihuahua
+MEX,Gudalajara,guadalajara
+MEX,San Joaquim,sanjoaquin
+MEX,San Luis Pontosi,sanluispotosi
+MEX,Sinalda province,sinaloa
+MEX,Sinoloa State,sinaloa
+MEX,Tamaulpas,tamaulipas
+MEX,Tampulipas,tamaulipas
+MEX,Teotitlan de Flores Magan areas,teotitlandefloresmagon
+MEX,Veracrur,veracruz
+MKD,Bosilevo districts,bosilovo
+MKD,Kumanavo,kumanovo
+MKD,Kumanavo cities,kumanovo
+MKD,Suto Orizarei,sutoorizari
+MLI,Koulikorou,koulikoro
+MLI,Tombuctou,tombouctou
+MMR,Arrakan,arakan
+MMR,Meikthila,meiktila
+MMR,Yamenthin district,yamethin
+MOZ,Cano Delgado,cabodelgado
+MOZ,Zambesia,zambezia
+MRT,Boutilinit,boutilimit
+MRT,Kandossa,kankossa
+MWI,Nasanje,nsanje
+MYS,Sarikey,sarikei
+NER,Madarounda,madarounfa
+NER,Madoua,madaoua
+NER,Madoua districts,madaoua
+NER,Miradi,maradi
+NER,Tahqua,tahoua
+NER,Tillaberib,tillaberi
+NER,Tilleberi,tillaberi
+NGA,Akawa Ibom,akwaibom
+NGA,Amambra,anambra
+NGA,Ebonyl,ebonyi
+NGA,Ikorudu,ikorodu
+NGA,Jogawa,jigawa
+NGA,Kaduma,kaduna
+NGA,Laogos,lagos
+NIC,Corazo,carazo
+NPL,Accham,achham
+NPL,Kanchampur,kanchanpur
+NPL,Kavrepalan-chowk,kavrepalanchok
+NPL,Kavrepalanchowk,kavrepalanchok
+NPL,Mahottaari,mahottari
+NPL,Markwanpur,makwanpur
+NPL,Pantchthar,panchthar
+NPL,Pyunthan,pyuthan
+NPL,Rautahar,rautahat
+NPL,Sariahi,sarlahi
+NPL,Sharlahi,sarlahi
+NPL,Soluklumbu,solukhumbu
+NPL,Sunsaro,sunsari
+NZL,Invercargil,invercargill
+OMN,Al Dakhiliyah,addakhiliyah
+OMN,Al Dhahirah,aldhahira
+PAK,Abottabad,abbottabad
+PAK,Blochistan,balochistan
+PAK,Khyber Pakhtunkawa,khyberpakhtunkhwa
+PAK,Near Nawasbshah,nawabshah
+PAK,Pashawar,peshawar
+PAN,Los Santo province,lossantos
+PAN,San Miguelit,sanmiguelito
+PER,Acpbamba,acobamba
+PER,Albancay,abancay
+PER,Calleo,callao
+PER,Huanugo provinces,huanuco
+PER,Huaochiri,huarochiri
+PER,Huarez,huaraz
+PER,Loretto department,loreto
+PER,Moyoyamba,moyobamba
+PER,Near Punta Hermoza,puntahermosa
+PER,Nueva Cajamarea,nuevacajamarca
+PER,Sans Martin,sanmartin
+PER,Victoc,vitoc
+PHL,Barangas,batangas
+PHL,Camatines Sur,camarinessur
+PHL,Cantanduanes,catanduanes
+PHL,Guiayangan,guinayangan
+PHL,Ilailo,iloilo
+PHL,Ilocios Sur,ilocossur
+PHL,La Cariota,lacarlota
+PHL,Languindingan,laguindingan
+PHL,Marippi Isl.,maripipi
+PHL,Massara,masara
+PHL,Near Bisling,bislig
+PHL,Nueva Viscaya,nuevavizcaya
+PHL,Nueva Viscayas provinces,nuevavizcaya
+PHL,Pagbileo,pagbilao
+PHL,Papoay,paoay
+PHL,Quenzon,quezon
+PHL,Zaboanga city,zamboanga
+PHL,Zamboaga city,zamboanga
+PNG,Hengonofi area,henganofi
+PNG,Southern higlands,southernhighlands
+PNG,Telefumin,telefomin
+POL,Malopolske,malopolskie
+POL,Opolski,opolskie
+PRI,Nagabo,naguabo
+PRK,Huichun,huichon
+PRK,Jongpyong,jonpyong
+PRK,Ryangang provinces,ryanggang
+PRT,Castel Branco,castelobranco
+PRT,Near Vila Velha do Rodao,vilavelhaderodao
+PRY,Amabay,amambay
+PRY,Boqueon,boqueron
+PRY,Neembuco,neembucu
+ROU,Hundedoara,hunedoara
+ROU,Hundoara,hunedoara
+ROU,Near Galatzi,galati
+ROU,Orosova area,orsova
+ROU,Vaskui,vaslui
+RUS,Arkhanguelsk,arkhangelsk
+RUS,Bachkortostan,bashkortostan
+RUS,Bashkortosan,bashkortostan
+RUS,Blagoveshchansk,blagoveshchensk
+RUS,Kamchatkam,kamchatka
+RUS,Kaspiisk,kaspiysk
+RUS,Khavarovsk region,khabarovsk
+RUS,Magadam,magadan
+RUS,Sibary,sibay
+RUS,Tartarstan,tatarstan
+RUS,Ulyanosk,ulyanovsk
+RUS,Volgograde region,volgograd
+RUS,Volgorgrad,volgograd
+RUS,Yaroslovl,yaroslavl
+RUS,near Prokopievsk,prokopevsk
+RWA,Kubuga,kabuga
+RWA,Mwiulire region,mwulire
+SAU,Najrane,najran
+SDN,Aj Jazirah,aljazirah
+SDN,Gazira,gezira
+SDN,Near Al-Gutayna,algutaina
+SDN,Near El Kamlien,elkamlin
+SDN,North Dafur State,northdarfur
+SDN,Um-Sayala,ummsayala
+SDN,While Nile,whitenile
+SDN,White Nil,whitenile
+SEN,Makayopp,makayop
+SEN,Tivaoune,tivaouane
+SLB,Guadacanal,guadalcanal
+SLB,Utupia,utupua
+SLE,Kenuma,kenema
+SLE,Porto LOko,portloko
+SLV,Illobasco,ilobasco
+SLV,Usulatan,usulutan
+SOM,Belet Hawo,belethawa
+SOM,Boroma,borama
+SOM,Jalalaxsi,jalalaqsi
+SOM,Lower Shabelle,lowershabele
+SOM,Middle,middlej
+SOM,Nugall,nugaal
+SOM,Toghdheer,togdheer
+SRB,Para?in,paracin
+STP,Aguas Grande,aguagrande
+SVN,Bojinj,bohinj
+SVN,Jugovzodna Slovenija,jugovzhodnaslovenija
+SYR,Al-Hassakeh,alhassake
+SYR,Ar-Raqqa,arraqqah
+TCD,Aboudea,aboudeia
+TCD,Aboudia,aboudeia
+TCD,Bebeto,beboto
+TCD,Bébidjia,bebedjia
+TCD,Flanga,fianga
+TCD,Mangaime,mangalme
+TCD,Moyen-Char,moyenchari
+TCD,Wadi Fara,wadifira
+TGO,Aflao-Gakali,aflaogakli
+TGO,Amoutieve,amoutive
+TGO,Soutouboua,sotouboua
+THA,Ayudhaya,ayudhya
+THA,Nakhov Ratchasima,nakhonratchasima
+THA,Nakkhon Si Thammarat,nakhonsithammarat
+THA,Phangnaga,phangnga
+THA,Samut Pakan province,samutprakan
+THA,Ubol Ratchathani Provinces,ubonratchathani
+TJK,Farhor,farkhor
+TJK,Jilikkul,jilikul
+TJK,Rudaky,rudaki
+TKL,Nukunono,nukunonu
+TUN,Kairoun,kairouan
+TUR,Antalaya,antalya
+TUR,Diyarbajir,diyarbakir
+TUR,Dursunvey,dursunbey
+TUR,Erzican,erzincan
+TUR,Erzican province,erzincan
+TUR,Erzunum Province,erzurum
+TUR,Gazantep,gaziantep
+TUR,Gazientep,gaziantep
+TUR,Hundek,hendek
+TUR,Kastomonu,kastamonu
+TUR,Near Sonkaya,senkaya
+TUR,Near Trabson,trabzon
+TUR,Near Zonduldak,zonguldak
+TUV,Vaitupo Isl.,vaitupu
+TWN,Hsinch,hsinchu
+TWN,Near Kach Siung,kaohsiung
+TWN,Pintung,pingtung
+TZA,Bagamovo,bagamoyo
+TZA,Kilewa district,kilwa
+TZA,Mondulli region,monduli
+TZA,Mucheza,muheza
+TZA,Pembar,pemba
+UGA,Lupulingi,lopulingi
+UGA,Panymur,panyimur
+UGA,Ruunga,ruhunga
+UKR,Lougansk,lugansk
+UKR,Uzhgoro districts,uzhgorod
+URY,Cero Largo,cerrolargo
+USA,Arkanasas,arkansas
+USA,Arkensas,arkansas
+USA,Iadaho,idaho
+USA,Indianaa,indiana
+USA,Indiania,indiana
+USA,Kittias,kittitas
+USA,Lousiana,louisiana
+USA,Massachussetts,massachusetts
+USA,Michgigan,michigan
+USA,Minnessota,minnesota
+USA,Missisippi,mississippi
+USA,Missourri,missouri
+USA,Montania,montana
+USA,New Halpshire,newhampshire
+USA,New Hamshire,newhampshire
+USA,New Yprk,newyork
+USA,North Caroline,northcarolina
+USA,Ohlahoma,oklahoma
+USA,Okhahoma,oklahoma
+USA,Okhlahoma,oklahoma
+USA,Soith Carolina,southcarolina
+USA,South Caroline,southcarolina
+USA,South Dacota,southdakota
+USA,Virgina,virginia
+VEN,Langunillas,lagunillas
+VEN,Yaracury,yaracuy
+VNM,Hoa They,hoathuy
+VNM,Hoi Nan,hoian
+VNM,Kien Gang,kiengiang
+VNM,Kon Tun provinces,kontum
+YEM,Abyane province,abyan
+YEM,Al Bayada,albayda
+YEM,Al Dhale's,aldhalee
+YEM,Al-Dhale,aldhalee
+YEM,Al-Dhale',aldhalee
+YEM,Amamat Al Asimah,amanatalasimah
+YEM,Hadramout,hadhramout
+YEM,Haijah,hajjah
+YEM,Near Dhoubab,dhubab
+ZAF,Stellenbosh,stellenbosch
+ZMB,Chiegi Districts,chiengi
+ZMB,Kapiri Mphoshi,kapirimposhi
+ZMB,Linvingstone,livingstone
+ZMB,Mulfulira,mufulira
+ZWE,Chegetu,chegutu

--- a/climate_risk/data/name_corrections.csv
+++ b/climate_risk/data/name_corrections.csv
@@ -315,7 +315,9 @@ KEN,West Poko,westpokot
 KGZ,Jala-Abad,jalalabad
 KHM,Kampong Spen,kampongspeu
 KOR,Gyeongiu,gyeongju
+KOR,Gyeongsang,gyeongsangbukdo|gyeongsangnamdo
 KOR,Gyeongu,gyeongju
+KOR,Jeolla,jeollabukdo|jeollanamdo
 KOR,Kangwon-Don,kangwondo
 KOR,Kanwon Do,kangwondo
 LAO,Atsaphon district,atsaphone
@@ -504,6 +506,7 @@ SLV,Usulatan,usulutan
 SOM,Belet Hawo,belethawa
 SOM,Boroma,borama
 SOM,Jalalaxsi,jalalaqsi
+SOM,Jubaland,gedo|jubbadahoose|jubbadadhexe
 SOM,Lower Shabelle,lowershabele
 SOM,Middle,middlej
 SOM,Nugall,nugaal
@@ -590,10 +593,13 @@ USA,South Dacota,southdakota
 USA,Virgina,virginia
 VEN,Langunillas,lagunillas
 VEN,Yaracury,yaracuy
+VNM,Binh Tri Thien,quangbinh|quangtri|thuathienhue
+VNM,Ha Nam Ninh,hanam|namdinh|ninhbinh
 VNM,Hoa They,hoathuy
 VNM,Hoi Nan,hoian
 VNM,Kien Gang,kiengiang
 VNM,Kon Tun provinces,kontum
+VNM,Nghe Tinh,nghean|hatinh
 YEM,Abyane province,abyan
 YEM,Al Bayada,albayda
 YEM,Al Dhale's,aldhalee
@@ -604,6 +610,7 @@ YEM,Hadramout,hadhramout
 YEM,Haijah,hajjah
 YEM,Near Dhoubab,dhubab
 ZAF,Stellenbosh,stellenbosch
+ZAF,Transvaal,gauteng|limpopo|mpumalanga|northwest
 ZMB,Chiegi Districts,chiengi
 ZMB,Kapiri Mphoshi,kapirimposhi
 ZMB,Linvingstone,livingstone

--- a/climate_risk/data/osm.py
+++ b/climate_risk/data/osm.py
@@ -1,0 +1,224 @@
+import json
+import logging
+import time
+import urllib.parse
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import NamedTuple
+
+import polars as pl
+import requests
+
+from climate_risk.data.cache import cache_key, cached, polars_parquet
+from climate_risk.data.fetch import TIMEOUT_SECONDS, USER_AGENT
+from climate_risk.data.geocoding import Geocoder
+from climate_risk.data.place_names import match_key
+from climate_risk.exceptions import UpstreamUnavailableError
+
+_log = logging.getLogger(__name__)
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+OSM_SUBDIRECTORY = "osm"
+OSM_LICENCE = "ODbL 1.0"
+OSM_CITATION = "OpenStreetMap contributors, https://www.openstreetmap.org/copyright, licensed ODbL 1.0."
+
+# The public instance allows one request a second for a job of this length, and requires results to
+# be cached rather than re-requested. Both are conditions of use, not tuning.
+RATE_LIMIT_SECONDS = 1.1
+
+# What Nominatim answers with is whatever carries the name, so a village and the pharmacy named
+# after it score alike. Only these two categories describe somewhere an event can happen; the rest
+# are buildings, roads and amenities that share a name with the place around them.
+PLACE_CATEGORIES = ("place", "boundary")
+
+# One row per name asked about, whether or not it was found. A miss is a result: without recording
+# it, every rebuild asks the whole question again. `kind` is Nominatim's `type`, renamed off the
+# builtin.
+LOOKUP_COLUMNS = {
+    "key": pl.String,
+    "written": pl.String,
+    "lon": pl.Float64,
+    "lat": pl.Float64,
+    "category": pl.String,
+    "kind": pl.String,
+}
+
+
+class NominatimAnswer(NamedTuple):
+    """
+    One place Nominatim reports, reduced to what the cache keeps.
+
+    Parameters
+    ----------
+    lon : float
+        Longitude of the point.
+    lat : float
+        Latitude of the point.
+    category : str
+        What kind of thing carries the name.
+    kind : str
+        The narrower type within that category, as Nominatim names it.
+    """
+
+    lon: float
+    lat: float
+    category: str
+    kind: str
+
+
+def osm_dir(cache_dir: Path) -> Path:
+    return cache_dir / OSM_SUBDIRECTORY
+
+
+def search_nominatim(
+    name: str, alpha2: str | None = None, *, session: requests.Session | None = None
+) -> NominatimAnswer | None:
+    """
+    Ask Nominatim where one written name is, waiting out the rate limit before returning.
+
+    The wait is here rather than in the caller because it is a condition of using the public
+    instance: a loop that forgets it is one that gets the project blocked.
+
+    A name Nominatim has no place for and a name it was never asked about are different answers.
+    Only the first is None; a request that failed raises, because recording it as a miss would cache
+    a permanent absence that nothing afterwards could tell apart from a real one.
+
+    Parameters
+    ----------
+    name : str
+        The place as written.
+    alpha2 : str, optional
+        ISO 3166-1 alpha-2 code to confine the search to. Default None, which searches everywhere.
+    session : requests.Session, optional
+        Session to make the request on, so a crawl reuses one connection. Default None, which makes
+        a request of its own.
+
+    Returns
+    -------
+    NominatimAnswer or None
+        The best answer, or None where Nominatim has no place of that name.
+    """
+    query = {"q": name, "format": "jsonv2", "limit": 1}
+    if alpha2:
+        query["countrycodes"] = alpha2.lower()
+
+    get = session.get if session else requests.get
+    try:
+        response = get(
+            f"{NOMINATIM_URL}?{urllib.parse.urlencode(query)}",
+            headers={"User-Agent": USER_AGENT},
+            timeout=TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        answers = response.json()
+    except (requests.RequestException, json.JSONDecodeError) as error:
+        raise UpstreamUnavailableError(f"Nominatim could not be asked about {name!r}: {error}") from error
+    finally:
+        time.sleep(RATE_LIMIT_SECONDS)
+
+    if not answers:
+        return None
+
+    best = answers[0]
+
+    return NominatimAnswer(
+        float(best["lon"]), float(best["lat"]), str(best.get("category", "")), str(best.get("type", ""))
+    )
+
+
+def read_osm_places(iso: str, cache_dir: Path) -> pl.DataFrame:
+    """
+    Read the answers Nominatim has already given for one country.
+
+    Reads only what is cached. Filling the cache is the job of ``tools/fetch_osm_places.py``, which
+    keeps the crawl out of every code path that merely wants to look a name up.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to read.
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    DataFrame
+        Columns ``key``, ``written``, ``lon``, ``lat``, ``category`` and ``kind``, one row per name
+        asked about. Empty where nothing has been asked for this country yet.
+    """
+    stored = polars_parquet()
+    path = (osm_dir(cache_dir) / cache_key("lookups", {"iso": iso})).with_suffix(stored.suffix)
+
+    return stored.read(path) if path.exists() else pl.DataFrame(schema=LOOKUP_COLUMNS)
+
+
+def osm_geocoder(iso: str, cache_dir: Path) -> Geocoder:
+    """
+    Build a geocoder answering from the OpenStreetMap points cached for one country.
+
+    Only answers Nominatim described as a place or a boundary are offered. Filtering on the name
+    alone accepts a pharmacy for the village it is named after, which lands a point somewhere
+    plausible and wrong.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to answer for.
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    callable
+        Takes an ISO code and a written name, and returns longitude and latitude or None.
+    """
+    found = read_osm_places(iso, cache_dir).filter(
+        pl.col("lon").is_not_null() & pl.col("category").is_in(PLACE_CATEGORIES)
+    )
+    located = dict(zip(found["key"], zip(found["lon"], found["lat"], strict=True), strict=True))
+
+    def locate(_: str, name: str) -> tuple[float, float] | None:
+        return located.get(match_key(name))
+
+    return locate
+
+
+def record_lookups(iso: str, cache_dir: Path, answers: Mapping[str, NominatimAnswer | None]) -> pl.DataFrame:
+    """
+    Add answers to a country's cache, keeping whatever is already there.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code the names belong to.
+    cache_dir : Path
+        Directory the caches live under.
+    answers : mapping of str to NominatimAnswer or None
+        What Nominatim said about each written name, None where it said nothing.
+
+    Returns
+    -------
+    DataFrame
+        The country's whole cache, as it now stands on disk.
+    """
+    fresh = pl.DataFrame(
+        [
+            {
+                "key": match_key(written),
+                "written": written,
+                "lon": answer.lon if answer else None,
+                "lat": answer.lat if answer else None,
+                "category": answer.category if answer else None,
+                "kind": answer.kind if answer else None,
+            }
+            for written, answer in answers.items()
+        ],
+        schema=LOOKUP_COLUMNS,
+        orient="row",
+    )
+
+    def merged() -> pl.DataFrame:
+        return pl.concat([read_osm_places(iso, cache_dir), fresh]).unique(subset="written", keep="last")
+
+    return cached(osm_dir(cache_dir), "lookups", merged, polars_parquet(), params={"iso": iso}, force=True)

--- a/climate_risk/data/osm.py
+++ b/climate_risk/data/osm.py
@@ -34,9 +34,9 @@ PLACE_CATEGORIES = ("place", "boundary")
 
 # One row per name asked about, whether or not it was found. A miss is a result: without recording
 # it, every rebuild asks the whole question again. `kind` is Nominatim's `type`, renamed off the
-# builtin.
+# builtin. The name is stored as written and keyed at read time, so a change to the keying rules
+# costs a lookup rather than another crawl.
 LOOKUP_COLUMNS = {
-    "key": pl.String,
     "written": pl.String,
     "lon": pl.Float64,
     "lat": pl.Float64,
@@ -144,8 +144,8 @@ def read_osm_places(iso: str, cache_dir: Path) -> pl.DataFrame:
     Returns
     -------
     DataFrame
-        Columns ``key``, ``written``, ``lon``, ``lat``, ``category`` and ``kind``, one row per name
-        asked about. Empty where nothing has been asked for this country yet.
+        Columns ``written``, ``lon``, ``lat``, ``category`` and ``kind``, one row per name asked
+        about. Empty where nothing has been asked for this country yet.
     """
     stored = polars_parquet()
     path = (osm_dir(cache_dir) / cache_key("lookups", {"iso": iso})).with_suffix(stored.suffix)
@@ -176,7 +176,8 @@ def osm_geocoder(iso: str, cache_dir: Path) -> Geocoder:
     found = read_osm_places(iso, cache_dir).filter(
         pl.col("lon").is_not_null() & pl.col("category").is_in(PLACE_CATEGORIES)
     )
-    located = dict(zip(found["key"], zip(found["lon"], found["lat"], strict=True), strict=True))
+    points = zip(found["lon"], found["lat"], strict=True)
+    located = {match_key(written): point for written, point in zip(found["written"], points, strict=True)}
 
     def locate(_: str, name: str) -> tuple[float, float] | None:
         return located.get(match_key(name))
@@ -205,7 +206,6 @@ def record_lookups(iso: str, cache_dir: Path, answers: Mapping[str, NominatimAns
     fresh = pl.DataFrame(
         [
             {
-                "key": match_key(written),
                 "written": written,
                 "lon": answer.lon if answer else None,
                 "lat": answer.lat if answer else None,

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -667,6 +667,45 @@ def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[st
     return set()
 
 
+def _place_one(
+    name: str,
+    parent: str | None,
+    named: set[str],
+    located: Mapping[str, str],
+    pinned: set[str],
+    gazetteer: Gazetteer,
+) -> Placement:
+    """
+    Place one written place, taking the first reading that holds.
+
+    The order is what the readings are worth: the name itself, then a point, then a correction
+    someone checked, then a slip the event vouches for, then the unit a direction qualified, and
+    last the container, which claims everything inside it.
+    """
+    if named:
+        return Placement(_narrowed(named, pinned, gazetteer), NAMED)
+
+    if by_point := located.get(name):
+        return Placement({by_point}, LOCATED)
+
+    published = gazetteer.corrections.get(match_key(name), ())
+    stands_for = {unit.gid for stood_for in published for unit in gazetteer.names.get(stood_for, set())}
+    if stands_for:
+        return Placement(_narrowed(_outermost(stands_for, gazetteer), pinned, gazetteer), CORRECTED)
+
+    container = _innermost_container(parent, gazetteer)
+    if inferred := _corroborated_slip(name, container, pinned, gazetteer):
+        return Placement(inferred, INFERRED)
+
+    if qualified := _qualified_unit(name, gazetteer):
+        return Placement(qualified, QUALIFIED)
+
+    if container:
+        return Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY)
+
+    return Placement(set(), NAMES_NO_UNIT if names_no_unit(name) else NAMED)
+
+
 def resolve_event_places(
     places: Iterable[tuple[str, str | None]],
     gazetteer: Gazetteer,
@@ -711,33 +750,10 @@ def resolve_event_places(
         if len(gids) == 1:
             pinned |= gazetteer.ancestry(next(iter(gids)))
 
-    placed = []
-    for (name, parent), gids in zip(written, resolved, strict=True):
-        if gids:
-            placed.append(Placement(_narrowed(gids, pinned, gazetteer), NAMED))
-            continue
-        by_point = (located or {}).get(name)
-        if by_point:
-            placed.append(Placement({by_point}, LOCATED))
-            continue
-        published = gazetteer.corrections.get(match_key(name), ())
-        stands_for = {unit.gid for stood_for in published for unit in gazetteer.names.get(stood_for, set())}
-        if stands_for:
-            placed.append(Placement(_narrowed(_outermost(stands_for, gazetteer), pinned, gazetteer), CORRECTED))
-            continue
-        container = _innermost_container(parent, gazetteer)
-        if inferred := _corroborated_slip(name, container, pinned, gazetteer):
-            placed.append(Placement(inferred, INFERRED))
-            continue
-        if qualified := _qualified_unit(name, gazetteer):
-            placed.append(Placement(qualified, QUALIFIED))
-            continue
-        if container:
-            placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))
-            continue
-        placed.append(Placement(set(), NAMES_NO_UNIT if names_no_unit(name) else NAMED))
-
-    return placed
+    return [
+        _place_one(name, parent, gids, located or {}, pinned, gazetteer)
+        for (name, parent), gids in zip(written, resolved, strict=True)
+    ]
 
 
 def successor_state(

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -1,0 +1,220 @@
+import re
+import sqlite3
+
+from collections import defaultdict
+from collections.abc import Iterable
+from itertools import batched
+from pathlib import Path
+from typing import NamedTuple
+
+from anyascii import anyascii
+
+from climate_risk.data.gadm import GADM_LAYER, gadm_path
+
+# Words naming what a unit is rather than which one it is. EM-DAT writes them inconsistently and
+# GADM does not carry them, so `Kalin-Aapayo province` has to reach `Kalin-Aapayo`.
+UNIT_NOUNS = re.compile(
+    r"\b(provinces?|districts?|regencies|regency|regions?|cities|city|states?|towns?|"
+    r"municipalit(?:y|ies)|islands?|isl|departments?|counties|county|governorates?|prefectures?)\b",
+    re.IGNORECASE,
+)
+
+
+# GADM publishes a level 5, for Belgium and Rwanda only.
+INDEXABLE_LEVELS = (1, 2, 3, 4)
+
+
+class Unit(NamedTuple):
+    """A GADM unit a name can refer to.
+
+    Parameters
+    ----------
+    gid : str
+        The GADM identifier.
+    level : int
+        Administrative level, 1 through 4.
+    parent : str or None
+        The identifier of the unit one level up, or None at level 1.
+    """
+
+    gid: str
+    level: int
+    parent: str | None
+
+
+class Gazetteer(NamedTuple):
+    """One country's units, searchable by name and walkable upwards.
+
+    Parameters
+    ----------
+    names : dict mapping str to set of Unit
+        Units keyed on :func:`match_key` of every name they are published under.
+    parent_of : dict mapping str to str or None
+        The unit one level up from each identifier.
+    """
+
+    names: dict[str, set[Unit]]
+    parent_of: dict[str, str | None]
+
+    def ancestry(self, gid: str) -> set[str]:
+        """Name the unit and every unit containing it."""
+        chain: set[str] = set()
+        current: str | None = gid
+        # GADM's placeholder identifier appears at two levels and so parents itself.
+        while current and current not in chain:
+            chain.add(current)
+            current = self.parent_of.get(current)
+
+        return chain
+
+
+_NAME_FIELDS = ("GID", "NAME", "VARNAME")
+
+
+def _name_columns(level: int, available: set[str]) -> str:
+    """Select one level's identifier and names, substituting an empty literal for an absent column."""
+    return ", ".join(f"{field}_{level}" if f"{field}_{level}" in available else "''" for field in _NAME_FIELDS)
+
+
+def match_key(name: str) -> str:
+    """
+    Reduce a place name to what a written mention and a GADM name can be expected to share.
+
+    Transliterated, stripped of the noun saying what kind of unit it is, and reduced to letters and
+    digits, so ``Kalin-Aapayo province`` and ``Kalin Aapayo`` meet.
+
+    Parameters
+    ----------
+    name : str
+        A place as written, from either source.
+
+    Returns
+    -------
+    str
+        The comparison key, empty where the name was only a unit noun.
+    """
+    return "".join(character for character in anyascii(UNIT_NOUNS.sub(" ", name)) if character.isalnum()).casefold()
+
+
+def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gazetteer:
+    """
+    Read one country's GADM units into a gazetteer.
+
+    Every level the archive publishes is indexed, because written mentions reach all of them: a
+    location string names provinces, districts and villages in the same breath. A name reaches a
+    set rather than a unit because names repeat — a province and its capital district often share
+    one, and a village name recurs freely.
+
+    Parentage comes from the row rather than from the shape of the identifier. Identifiers usually
+    nest, but 37 rows across five countries do not, and a prefix test would place those units
+    outside their own province.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to read.
+    cache_dir : Path
+        Directory the caches live under.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    Gazetteer
+        The country's units.
+    """
+    names: dict[str, set[Unit]] = defaultdict(set)
+    parent_of: dict[str, str | None] = {}
+
+    with sqlite3.connect(gadm_path(cache_dir)) as connection:
+        available = {row[1] for row in connection.execute(f'PRAGMA table_info("{layer}")')}
+        # A variant-name column is optional; an identifier and a name are what make a level readable.
+        levels = [level for level in INDEXABLE_LEVELS if {f"GID_{level}", f"NAME_{level}"} <= available]
+        columns = ", ".join(_name_columns(level, available) for level in levels)
+        query = f'SELECT DISTINCT {columns} FROM "{layer}" WHERE GID_0 = ?'
+
+        for row in connection.execute(query, (iso,)):
+            parent = None
+            for level, (gid, name, variants) in zip(levels, batched(row, len(_NAME_FIELDS)), strict=True):
+                if not gid:
+                    break
+                parent_of[gid] = parent
+                for field in (name, variants):
+                    for alternative in str(field or "").split("|"):
+                        if key := match_key(alternative):
+                            names[key].add(Unit(gid, level, parent))
+                parent = gid
+
+    return Gazetteer(dict(names), parent_of)
+
+
+def _outermost(gids: set[str], gazetteer: Gazetteer) -> set[str]:
+    """Drop every unit another candidate already contains, leaving what the name can mean at its coarsest."""
+    return {gid for gid in gids if not (gazetteer.ancestry(gid) - {gid}) & gids}
+
+
+def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[str]:
+    """
+    Name the GADM units a written place refers to, using its stated container to choose between them.
+
+    Where the prose gives a container, only units it holds at any depth survive — which is what
+    separates one ``Pitogo`` from the other without a similarity threshold. A container that names
+    nothing, or that holds none of the candidates, is ignored rather than treated as a
+    contradiction: the prose routinely names a region GADM does not model.
+
+    Parameters
+    ----------
+    name : str
+        The place as written.
+    parent : str or None
+        The container the prose gave, or None.
+    gazetteer : Gazetteer
+        The country's units, from :func:`read_gazetteer`.
+
+    Returns
+    -------
+    set of str
+        The GADM identifiers the name reaches, empty where it reaches none.
+    """
+    gids = {unit.gid for unit in gazetteer.names.get(match_key(name), set())}
+    if gids and parent is not None:
+        containers = {unit.gid for unit in gazetteer.names.get(match_key(parent), set())}
+        inside = {gid for gid in gids if (gazetteer.ancestry(gid) - {gid}) & containers}
+        gids = inside or gids
+
+    return _outermost(gids, gazetteer)
+
+
+def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Gazetteer) -> list[set[str]]:
+    """
+    Resolve the places one event names together, letting the unambiguous ones narrow the rest.
+
+    An event's places share a footprint, so a mention that lands on exactly one unit tells the
+    ambiguous mentions beside it where to look. Candidates outside everything the event has already
+    pinned are dropped, and a mention narrowed to nothing keeps its candidates.
+
+    Parameters
+    ----------
+    places : iterable of tuple
+        Each a name as written and the container the prose gave, or None.
+    gazetteer : Gazetteer
+        The country's units, from :func:`read_gazetteer`.
+
+    Returns
+    -------
+    list of set of str
+        The GADM identifiers each place reaches, in the order the places were given.
+    """
+    resolved = [resolve_place(name, parent, gazetteer) for name, parent in places]
+
+    pinned: set[str] = set()
+    for gids in resolved:
+        if len(gids) == 1:
+            pinned |= gazetteer.ancestry(next(iter(gids)))
+
+    narrowed = []
+    for gids in resolved:
+        inside = {gid for gid in gids if gazetteer.ancestry(gid) & pinned} if len(gids) > 1 else gids
+        narrowed.append(inside or gids)
+
+    return narrowed

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -31,51 +31,24 @@ CONJUNCTION = re.compile(r"\s+(?:and|&)\s+", re.IGNORECASE)
 RELATIONAL = re.compile(r"^\s*(?:between|off|offshore|au large)\b", re.IGNORECASE)
 
 
+# A sea, a river or a mountain range is not an administrative unit, whatever it is one edit from.
+# Units named after a feature — `River Nile State`, `Bay of Plenty` — still match exactly; only the
+# approximate lookup refuses them.
+FEATURE = re.compile(
+    r"\b(seas?|oceans?|rivers?|lakes?|gulfs?|straits?|detroit|bays?|mountains?|mts?|mount|peaks?|"
+    r"valleys?|deltas?|peninsulas?|channels?|canals?|reservoirs?|dams?|volcanoe?s?|glaciers?|"
+    r"basins?|capes?|sounds?|fjords?|lagoons?|swamps?|forests?|deserts?)\b",
+    re.IGNORECASE,
+)
+
+# Below this a single edit is a large share of the name and the match stops meaning anything:
+# `Arora` sits one edit from both `Aurora` and `Arora` in half the countries that have either.
+MIN_APPROXIMATE_LENGTH = 6
+
 # Corrections a person or a model has checked one at a time. Approximate matching proposes them;
 # only what is written here is ever applied, so an unreviewed near miss leaves a place unplaced
 # rather than renaming it.
 NAME_CORRECTIONS = Path(__file__).parent / "name_corrections.csv"
-
-# EM-DAT files an event under the country that existed at the time, and GADM only models the ones
-# that exist now. Where a state left one successor the mapping is settled; where it left several
-# the location text has to choose between them.
-SUCCEEDED_BY = {
-    "AZO": ("PRT",),
-    "CSK": ("CZE", "SVK"),
-    "DDR": ("DEU",),
-    "DFR": ("DEU",),
-    "SUN": (
-        "ARM",
-        "AZE",
-        "BLR",
-        "EST",
-        "GEO",
-        "KAZ",
-        "KGZ",
-        "LTU",
-        "LVA",
-        "MDA",
-        "RUS",
-        "TJK",
-        "TKM",
-        "UKR",
-        "UZB",
-    ),
-    "YMD": ("YEM",),
-    "YMN": ("YEM",),
-    "YUG": ("BIH", "HRV", "MKD", "MNE", "SRB", "SVN", "XKO"),
-}
-
-# Written places that name no administrative unit and never will: a compass point covering the
-# whole country, a position between two others, a stretch of water, or nothing at all. They are
-# recorded rather than counted as failures, because no source can place them.
-QUALIFIER = re.compile(
-    r"^(?:north|south|east|west|central|centre|center|northern|southern|eastern|western|"
-    r"north[- ]?(?:east|west)|south[- ]?(?:east|west)|countrywide|nationwide|whole country|"
-    r"all country|widespread|unknown|not available|no information|n\.?a\.?(?: on the source)?)$",
-    re.IGNORECASE,
-)
-NOTHING_LEGIBLE = re.compile(r"^[\W\d\s]*$")
 
 # EM-DAT files an event under the country that existed at the time, and GADM only models the ones
 # that exist now. Where a state left one successor the mapping is settled; where it left several
@@ -123,21 +96,8 @@ NAMED = "named"
 LOCATED = "located"
 CONTAINED_BY = "container"
 CORRECTED = "corrected"
+NAMES_NO_UNIT = "names no unit"
 
-
-# A sea, a river or a mountain range is not an administrative unit, whatever it is one edit from.
-# Units named after a feature — `River Nile State`, `Bay of Plenty` — still match exactly; only the
-# approximate lookup refuses them.
-FEATURE = re.compile(
-    r"\b(seas?|oceans?|rivers?|lakes?|gulfs?|straits?|detroit|bays?|mountains?|mts?|mount|peaks?|"
-    r"valleys?|deltas?|peninsulas?|channels?|canals?|reservoirs?|dams?|volcanoe?s?|glaciers?|"
-    r"basins?|capes?|sounds?|fjords?|lagoons?|swamps?|forests?|deserts?)\b",
-    re.IGNORECASE,
-)
-
-# Below this a single edit is a large share of the name and the match stops meaning anything:
-# `Arora` sits one edit from both `Aurora` and `Arora` in half the countries that have either.
-MIN_APPROXIMATE_LENGTH = 6
 
 # GADM publishes a level 5, for Belgium and Rwanda only.
 INDEXABLE_LEVELS = (1, 2, 3, 4)
@@ -477,8 +437,8 @@ def resolve_event_places(
     A place naming nothing takes the unit a point put it in where one is offered. Failing that it
     falls back to the container the prose wrote it in — ``Pesisir Selaten (West Sumatra province)``
     becomes the province, which spans fourteen districts at the median — so the result records
-    which of the two it was reached by. A place with no container that the corrections table names
-    is read as the misspelling it was checked to be.
+    which of the two it was reached by. A place with no container that is one edit from
+    exactly one published name is taken as a misspelling of it, recorded as such.
 
     Parameters
     ----------
@@ -517,8 +477,11 @@ def resolve_event_places(
             placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))
             continue
         published = gazetteer.corrections.get(match_key(name))
-        corrected = _outermost({unit.gid for unit in gazetteer.names[published]}, gazetteer) if published else set()
-        placed.append(Placement(_narrowed(corrected, pinned, gazetteer), CORRECTED if corrected else NAMED))
+        if published:
+            corrected = _outermost({unit.gid for unit in gazetteer.names[published]}, gazetteer)
+            placed.append(Placement(_narrowed(corrected, pinned, gazetteer), CORRECTED))
+            continue
+        placed.append(Placement(set(), NAMES_NO_UNIT if names_no_unit(name) else NAMED))
 
     return placed
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -169,6 +169,25 @@ QUALIFIER = re.compile(
 )
 NOTHING_LEGIBLE = re.compile(r"^[\W\d\s]*$")
 
+# A country that still exists but no longer contains what it did when the event was recorded. The
+# text names a real place; GADM files it under the state that holds it now.
+FORMERLY_INCLUDED = {
+    "ETH": ("ERI",),
+    "IDN": ("TLS",),
+    "PAK": ("BGD",),
+    "SDN": ("SSD",),
+    "SRB": ("MNE", "XKO"),
+}
+
+# `South Bihar` and `Ontario Central` qualify a unit rather than naming one. The words are part of
+# plenty of real names — Lower Shabelle, West Bengal, Northern Territory — so the qualifier only
+# comes off once the name as written has failed.
+DIRECTIONAL_QUALIFIER = re.compile(
+    r"^(?:north|south|east|west|central|centre|upper|lower|greater)(?:ern)?(?:\s+of)?\s+"
+    r"|\s+(?:north|south|east|west|central|centre|upper|lower)(?:ern)?$",
+    re.IGNORECASE,
+)
+
 # How a written place reached the units it did.
 NAMED = "named"
 LOCATED = "located"
@@ -332,8 +351,13 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
             # A variant-name column is optional; an identifier and a name are what make a level readable.
             levels = [level for level in INDEXABLE_LEVELS if {f"GID_{level}", f"NAME_{level}"} <= available]
             columns = ", ".join(_name_columns(level, available) for level in levels)
-            # Kashmir is filed under codes of its own, not under the country administering it.
-            held = (iso, *administered_territories(iso, cache_dir, layer=layer))
+            # Kashmir is filed under codes of its own rather than under the country administering
+            # it, and a pre-secession event names places the country no longer contains.
+            held = (
+                iso,
+                *administered_territories(iso, cache_dir, layer=layer),
+                *FORMERLY_INCLUDED.get(iso, ()),
+            )
             placeholders = ", ".join("?" * len(held))
             query = f'SELECT DISTINCT {columns} FROM "{layer}" WHERE GID_0 IN ({placeholders})'
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -402,10 +402,16 @@ def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[st
 
 
 def name_shapes(gazetteer: Gazetteer) -> dict[tuple[str, int], set[str]]:
-    """Group a country's names by first character and length, which is what :func:`nearest_name` scans."""
+    """
+    Group a country's names for approximate lookup, by length and by each of their first two letters.
+
+    Filing a name under its second letter as well as its first is what makes a slip in the first one
+    reachable: ``llinois`` has lost the letter its bucket would otherwise be chosen by.
+    """
     shapes: dict[tuple[str, int], set[str]] = defaultdict(set)
     for key in gazetteer.names:
-        shapes[(key[0], len(key))].add(key)
+        for letter in {key[0], key[1] if len(key) > 1 else key[0]}:
+            shapes[(letter, len(key))].add(key)
 
     return dict(shapes)
 
@@ -469,11 +475,14 @@ def nearest_name(name: str, gazetteer: Gazetteer, shapes: dict[tuple[str, int], 
     if len(key) < MIN_APPROXIMATE_LENGTH or key in gazetteer.names:
         return None
 
-    # A typo rarely changes the first character, and scanning by it keeps the search local.
+    # Names are filed under each of their first two letters, so a slip in either one still finds
+    # them while the search stays local.
+    opening = {key[0], key[1]} if len(key) > 1 else {key[0]}
     nearby = {
         candidate
+        for letter in opening
         for length in range(len(key) - 1, len(key) + 2)
-        for candidate in shapes.get((key[0], length), ())
+        for candidate in shapes.get((letter, length), ())
         if _one_slip_apart(key, candidate)
     }
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -14,8 +14,9 @@ from climate_risk.data.gadm import GADM_LAYER, gadm_path
 # Words naming what a unit is rather than which one it is. EM-DAT writes them inconsistently and
 # GADM does not carry them, so `Kalin-Aapayo province` has to reach `Kalin-Aapayo`.
 UNIT_NOUNS = re.compile(
-    r"\b(provinces?|districts?|regencies|regency|regions?|cities|city|states?|towns?|"
-    r"municipalit(?:y|ies)|islands?|isl|departments?|counties|county|governorates?|prefectures?)\b",
+    r"\b(provinces?|prov|districts?|regencies|regency|regions?|cities|city of|city|states?|towns?|"
+    r"municipalit(?:y|ies)|islands?|isl|departments?|counties|county|governorates?|prefectures?|"
+    r"areas?|near|around|outskirts of|vicinity of|coast of)\b\.?",
     re.IGNORECASE,
 )
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -178,7 +178,9 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gaz
         for row in connection.execute(query, (iso,)):
             parent = None
             for level, (gid, name, variants) in zip(levels, batched(row, len(_NAME_FIELDS)), strict=True):
-                if not gid:
+                # GADM writes an unnamed unit as `?` at every level it spans, and a unit cannot
+                # contain itself: the chain ends where the identifier stops changing.
+                if not gid or gid == parent:
                     break
                 parent_of[gid] = parent
                 for field in (name, variants):

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -578,11 +578,34 @@ def _corroborated_slip(name: str, container: set[str], pinned: set[str], gazette
     return inside if len(inside) == 1 else set()
 
 
-def _innermost_container(parent: str | None, gazetteer: Gazetteer) -> set[str]:
-    """Name the units the finest resolving part of a container reaches, so a district beats the state beside it."""
-    for part in container_parts(parent or ""):
-        if found := resolve_place(part, None, gazetteer):
-            return found
+def _corrected_units(name: str, gazetteer: Gazetteer) -> set[str]:
+    """Name the units a checked entry says this name stands for."""
+    published = gazetteer.corrections.get(match_key(name), ())
+
+    return _outermost(
+        {unit.gid for stood_for in published for unit in gazetteer.names.get(stood_for, set())}, gazetteer
+    )
+
+
+def _innermost_container(parent: str | None, pinned: set[str], gazetteer: Gazetteer) -> set[str]:
+    """
+    Name the units a container reaches, reading it the same way a written place is read.
+
+    Stronger evidence wins over finer granularity: an exact match on the state is taken before a
+    misspelling of the district beside it. Within a reading the finest part wins, since the prose
+    writes the container finest first.
+    """
+    parts = container_parts(parent or "")
+    readings = (
+        lambda part: resolve_place(part, None, gazetteer),
+        lambda part: _corrected_units(part, gazetteer),
+        lambda part: _corroborated_slip(part, set(), pinned, gazetteer),
+        lambda part: _qualified_unit(part, gazetteer),
+    )
+    for reading in readings:
+        for part in parts:
+            if found := reading(part):
+                return found
 
     return set()
 
@@ -674,12 +697,10 @@ def _place_one(
     if by_point := located.get(name):
         return Placement({by_point}, LOCATED)
 
-    published = gazetteer.corrections.get(match_key(name), ())
-    stands_for = {unit.gid for stood_for in published for unit in gazetteer.names.get(stood_for, set())}
-    if stands_for:
-        return Placement(_narrowed(_outermost(stands_for, gazetteer), pinned, gazetteer), CORRECTED)
+    if stands_for := _corrected_units(name, gazetteer):
+        return Placement(_narrowed(stands_for, pinned, gazetteer), CORRECTED)
 
-    container = _innermost_container(parent, gazetteer)
+    container = _innermost_container(parent, pinned, gazetteer)
     if inferred := _corroborated_slip(name, container, pinned, gazetteer):
         return Placement(inferred, INFERRED)
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -66,6 +66,10 @@ _STANDS_ALONE = (
     "kec",
     "kab",
     "desa",
+    "roads?",
+    "highways?",
+    "airports?",
+    "pass(?:es)?",
 )
 
 # Prepositional phrases, which have no bare form.
@@ -86,6 +90,18 @@ UNIT_NOUNS = re.compile(
 # before its parts.
 CONJUNCTION = re.compile(r"\s+(?:and|et)\s+|\s*[&+/]\s*", re.IGNORECASE)
 
+
+# A road runs between places rather than sitting in one. The noun comes off like any other, so
+# `Bankass road` reaches Bankass, but a route naming two places is a line and splitting it puts
+# the event on both ends of a journey it only crossed.
+ROUTE = re.compile(r"\b(?:roads?|highways?)\b", re.IGNORECASE)
+
+# A part of a dash-joined name shorter than this is a syllable rather than a place: splitting
+# `Ali-Shan` yields two Chinese counties and the event was in neither.
+MIN_SPLIT_LENGTH = 4
+
+# A dash joins two places as often as it sits inside one name, so the whole is always read first.
+DASH = re.compile(r"\s*[-\u2013\u2014]\s*")
 
 # `Wayanad district, Kerala state` names the same place twice over, finest first. Read whole it
 # matches nothing; read in parts each one matches a unit.
@@ -572,6 +588,23 @@ def container_parts(parent: str) -> list[str]:
     return [part for part in CONTAINER_PARTS.split(parent) if part.strip()]
 
 
+def _dashed_units(name: str, parent: str | None, gazetteer: Gazetteer) -> set[str]:
+    """
+    Name the units a dash-joined list reaches, where every one of its parts names a unit.
+
+    A dash joins two places as often as it belongs inside a single name, and nothing in the text
+    tells them apart. Unanimity does: ``Grevena-Kozani`` is a pair because both halves are
+    prefectures, while a name that only half resolves is one name the gazetteer spells differently.
+    """
+    parts = [part.strip() for part in DASH.split(name) if part.strip()]
+    if len(parts) < 2 or any(len(match_key(part)) < MIN_SPLIT_LENGTH for part in parts):
+        return set()
+
+    reached = [_units_named(part, parent, gazetteer) for part in parts]
+
+    return _outermost(set().union(*reached), gazetteer) if all(reached) else set()
+
+
 def _qualified_unit(name: str, gazetteer: Gazetteer) -> set[str]:
     """
     Name the unit a directional qualifier was applied to, where it names exactly one.
@@ -678,9 +711,10 @@ def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[st
     contradiction: the prose routinely names a region GADM does not model.
 
     A name joined by ``and`` is split only where the whole fails, so ``Newfoundland and Labrador``
-    stays one unit while ``Aceh and West Sumatra`` becomes two. Every part that names something is
-    kept, except where the name opens with a word placing the event between its parts rather than
-    in them.
+    stays one unit while ``Aceh and West Sumatra`` becomes two, and every part that names something
+    is kept. A dash is weaker evidence of a list and is split only where every part names a unit.
+    Neither is split where the name places the event between its parts rather than in them, or along
+    a route running through both.
 
     Parameters
     ----------
@@ -700,13 +734,16 @@ def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[st
     if gids:
         return _outermost(gids, gazetteer)
 
+    if RELATIONAL.match(name) or ROUTE.search(name):
+        return set()
+
     parts = [part.strip() for part in CONJUNCTION.split(name) if part.strip()]
-    if len(parts) > 1 and not RELATIONAL.match(name):
+    if len(parts) > 1:
         reached = [found for part in parts if (found := _units_named(part, parent, gazetteer))]
         if reached:
             return _outermost(set().union(*reached), gazetteer)
 
-    return set()
+    return _dashed_units(name, parent, gazetteer)
 
 
 def _place_one(

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -107,7 +107,11 @@ RELATIONAL = re.compile(r"^\s*(?:between|off|offshore|au large)\b", re.IGNORECAS
 FEATURE = re.compile(
     r"\b(seas?|oceans?|rivers?|lakes?|gulfs?|straits?|detroit|bays?|mountains?|mts?|mount|peaks?|"
     r"valleys?|deltas?|peninsulas?|channels?|canals?|reservoirs?|dams?|volcanoe?s?|glaciers?|"
-    r"basins?|capes?|sounds?|fjords?|lagoons?|swamps?|forests?|deserts?)\b",
+    r"basins?|capes?|sounds?|fjords?|lagoons?|swamps?|forests?|deserts?|"
+    # EM-DAT carries a good deal of French, and some Spanish and Portuguese.
+    r"mers?|oc[ée]ans?|fleuves?|rivi[èe]res?|golfes?|golfos?|estrechos?|baies?|bah[ía]as?|"
+    r"montagnes?|monta[ñn]as?|vall[ée]es?|massifs?|presqu.[îi]les?|"
+    r"bights?|collines?|quebradas?|himalayas?|andes|atlantique|pacifique|m[ée]diterran[ée]e|alps)\b",
     re.IGNORECASE,
 )
 
@@ -153,10 +157,14 @@ SUCCEEDED_BY = {
 # Written places that name no administrative unit and never will: a compass point covering the
 # whole country, a position between two others, a stretch of water, or nothing at all. They are
 # recorded rather than counted as failures, because no source can place them.
+_COMPASS = r"(?:north|south|east|west|central|centre|center)(?:ern)?"
+
 QUALIFIER = re.compile(
-    r"^(?:north|south|east|west|central|centre|center|northern|southern|eastern|western|"
-    r"north[- ]?(?:east|west)|south[- ]?(?:east|west)|countrywide|nationwide|whole country|"
-    r"all country|widespread|unknown|not available|no information|n\.?a\.?(?: on the source)?)$",
+    rf"^(?:{_COMPASS}(?:[-\s]*{_COMPASS})?"
+    r"(?:\s+(?:coast|coastal|regions?|areas?|parts?|provinces?|districts?|states?|counties))?"
+    r"|country[- ]?wide|nation[- ]?wide|entire (?:country|nation).*|whole country|all country"
+    r"|much of (?:the )?(?:country|nation)|widespread|unknown|not available|no information"
+    r"|n\.?a\.?(?: on the source)?)$",
     re.IGNORECASE,
 )
 NOTHING_LEGIBLE = re.compile(r"^[\W\d\s]*$")

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -2,7 +2,7 @@ import re
 import sqlite3
 
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from itertools import batched
 from pathlib import Path
 from typing import NamedTuple
@@ -88,16 +88,26 @@ class Gazetteer(NamedTuple):
     names: dict[str, set[Unit]]
     parent_of: dict[str, str | None]
 
-    def ancestry(self, gid: str) -> set[str]:
-        """Name the unit and every unit containing it."""
-        chain: set[str] = set()
+    def _upwards(self, gid: str) -> Iterator[str]:
+        """Yield the unit and each container above it, outwards."""
+        seen: set[str] = set()
         current: str | None = gid
-        # GADM's placeholder identifier appears at two levels and so parents itself.
-        while current and current not in chain:
-            chain.add(current)
+        # A Gazetteer can be built by hand as well as read, so the walk does not assume acyclic
+        # parentage even though :func:`read_gazetteer` refuses to record it.
+        while current and current not in seen:
+            seen.add(current)
+            yield current
             current = self.parent_of.get(current)
 
-        return chain
+    def ancestry(self, gid: str) -> set[str]:
+        """Name the unit and every unit containing it."""
+        return set(self._upwards(gid))
+
+    def top_container(self, gid: str) -> str:
+        """Name the outermost unit holding this one, which is the unit itself where it has no parent."""
+        *_, outermost = self._upwards(gid)
+
+        return outermost
 
 
 _NAME_FIELDS = ("GID", "NAME", "VARNAME")

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -1,4 +1,5 @@
 import csv
+import hashlib
 import re
 import sqlite3
 
@@ -211,6 +212,13 @@ def match_key(name: str) -> str:
     return "".join(character for character in anyascii(UNIT_NOUNS.sub(" ", name)) if character.isalnum()).casefold()
 
 
+def _keying_fingerprint() -> str:
+    """Fingerprint the rules that turn a name into a key, so a change to them invalidates the cache."""
+    rules = "|".join((UNIT_NOUNS.pattern, str(INDEXABLE_LEVELS)))
+
+    return hashlib.sha256(rules.encode()).hexdigest()[:12]
+
+
 def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_reload: bool = False) -> Gazetteer:
     """
     Read one country's GADM units into a gazetteer.
@@ -277,7 +285,8 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
         build,
         polars_parquet(),
         # The index is keyed by `match_key`, so the cache turns over when those rules change.
-        params={"iso": iso},
+        # The index is keyed by `match_key`, so the cache turns over when those rules change.
+        params={"iso": iso, "keying": _keying_fingerprint()},
         force=force_reload,
     )
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -368,7 +368,7 @@ def match_key(name: str) -> str:
     return "".join(character for character in anyascii(repaired) if character.isalnum()).casefold()
 
 
-def _keying_fingerprint() -> str:
+def keying_fingerprint() -> str:
     """Fingerprint the rules that turn a name into a key, so a change to them invalidates the cache."""
     rules = "|".join((UNIT_NOUNS.pattern, str(INDEXABLE_LEVELS), match_key(_KEYING_PROBE)))
 
@@ -446,7 +446,7 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
         build,
         polars_parquet(),
         # The index is keyed by `match_key`, so the cache turns over when those rules change.
-        params={"iso": iso, "keying": _keying_fingerprint()},
+        params={"iso": iso, "keying": keying_fingerprint()},
         force=force_reload,
     )
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -203,6 +203,11 @@ DIRECTIONAL_QUALIFIER = re.compile(
     re.IGNORECASE,
 )
 
+# EM-DAT writes a Polish powiat as the adjective built from its seat — `Sieradzki` for the powiat
+# of Sieradz — while GADM publishes the seat. Suffixing reshapes the stem as well as ending it,
+# so what the strip leaves opens the published name rather than equalling it.
+DERIVED_ADJECTIVE = {"POL": re.compile(r"(?:owski|inski|icki|ecki|eski|ski|cki|zki|ki)$")}
+
 # How a written place reached the units it did.
 NAMED = "named"
 LOCATED = "located"
@@ -211,6 +216,7 @@ CORRECTED = "corrected"
 INFERRED = "inferred"
 QUALIFIED = "qualified"
 NAMES_NO_UNIT = "names no unit"
+DERIVED = "derived"
 
 
 # GADM publishes a level 5, for Belgium and Rwanda only.
@@ -271,12 +277,16 @@ class Gazetteer(NamedTuple):
         The published names each checked entry stands for, keyed on :func:`match_key`. A misspelling
         gives one; a name GADM never carried as a unit — a merged province since split, a
         statistical region — gives the several it covers.
+    adjective : re.Pattern or None
+        The suffix this country's language builds a place adjective with, where written mentions use
+        one. None where they do not.
     """
 
     names: dict[str, set[Unit]]
     parent_of: dict[str, str | None]
     shapes: dict[tuple[str, int], set[str]]
     corrections: dict[str, tuple[str, ...]]
+    adjective: re.Pattern[str] | None = None
 
     def _upwards(self, gid: str) -> Iterator[str]:
         """Yield the unit and each container above it, outwards."""
@@ -447,7 +457,9 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
             names[key].add(Unit(gid, level, parent))
         parent_of[gid] = parent
 
-    return Gazetteer(dict(names), parent_of, _shape_index(names), read_name_corrections(iso))
+    return Gazetteer(
+        dict(names), parent_of, _shape_index(names), read_name_corrections(iso), DERIVED_ADJECTIVE.get(iso)
+    )
 
 
 def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[str, tuple[str, ...]]:
@@ -588,6 +600,29 @@ def container_parts(parent: str) -> list[str]:
     return [part for part in CONTAINER_PARTS.split(parent) if part.strip()]
 
 
+def _derived_unit(name: str, gazetteer: Gazetteer) -> set[str]:
+    """
+    Name the unit an adjective was built from, where the stem it leaves belongs to exactly one.
+
+    ``Tarnobrzeski`` is built from Tarnobrzeg, so the suffix takes part of the stem with it and what
+    remains opens the published name rather than equalling it. A stem opening several names is not a
+    reading, so it is refused.
+    """
+    if gazetteer.adjective is None:
+        return set()
+
+    key = match_key(name)
+    stem = gazetteer.adjective.sub("", key)
+    if not stem or stem == key:
+        return set()
+
+    built_on = {published for published in gazetteer.names if published != key and published.startswith(stem)}
+    if len(built_on) != 1:
+        return set()
+
+    return _outermost({unit.gid for unit in gazetteer.names[next(iter(built_on))]}, gazetteer)
+
+
 def _dashed_units(name: str, parent: str | None, gazetteer: Gazetteer) -> set[str]:
     """
     Name the units a dash-joined list reaches, where every one of its parts names a unit.
@@ -666,6 +701,7 @@ def _innermost_container(parent: str | None, pinned: set[str], gazetteer: Gazett
         lambda part: resolve_place(part, None, gazetteer),
         lambda part: _corrected_units(part, gazetteer),
         lambda part: _corroborated_slip(part, set(), pinned, gazetteer),
+        lambda part: _derived_unit(part, gazetteer),
         lambda part: _qualified_unit(part, gazetteer),
     )
     for reading in readings:
@@ -758,8 +794,8 @@ def _place_one(
     Place one written place, taking the first reading that holds.
 
     The order is what the readings are worth: the name itself, then a point, then a correction
-    someone checked, then a slip the event vouches for, then the unit a direction qualified, and
-    last the container, which claims everything inside it.
+    someone checked, then a slip the event vouches for, then the unit an adjective was built from or
+    a direction qualified, and last the container, which claims everything inside it.
     """
     if named:
         return Placement(_narrowed(named, pinned, gazetteer), NAMED)
@@ -773,6 +809,9 @@ def _place_one(
     container = _innermost_container(parent, pinned, gazetteer)
     if inferred := _corroborated_slip(name, container, pinned, gazetteer):
         return Placement(inferred, INFERRED)
+
+    if built_on := _derived_unit(name, gazetteer):
+        return Placement(built_on, DERIVED)
 
     if qualified := _qualified_unit(name, gazetteer):
         return Placement(qualified, QUALIFIED)

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -21,6 +21,15 @@ UNIT_NOUNS = re.compile(
 )
 
 
+# EM-DAT writes `Aceh and West Sumatra Provinces` for two units and `Newfoundland and Labrador` for
+# one, so the whole string has to be tried before its parts.
+CONJUNCTION = re.compile(r"\s+(?:and|&)\s+", re.IGNORECASE)
+
+# `Between Java and Bali` names a stretch of sea by its shores. Splitting it puts the event on
+# whichever shore happens to resolve.
+RELATIONAL = re.compile(r"^\s*(?:between|off|offshore|au large)\b", re.IGNORECASE)
+
+
 # GADM publishes a level 5, for Belgium and Rwanda only.
 INDEXABLE_LEVELS = (1, 2, 3, 4)
 
@@ -154,6 +163,18 @@ def _outermost(gids: set[str], gazetteer: Gazetteer) -> set[str]:
     return {gid for gid in gids if not (gazetteer.ancestry(gid) - {gid}) & gids}
 
 
+def _units_named(name: str, parent: str | None, gazetteer: Gazetteer) -> set[str]:
+    """Name the units one written place reaches, narrowed by its stated container where it has one."""
+    gids = {unit.gid for unit in gazetteer.names.get(match_key(name), set())}
+    if not gids or parent is None:
+        return gids
+
+    containers = {unit.gid for unit in gazetteer.names.get(match_key(parent), set())}
+    inside = {gid for gid in gids if (gazetteer.ancestry(gid) - {gid}) & containers}
+
+    return inside or gids
+
+
 def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[str]:
     """
     Name the GADM units a written place refers to, using its stated container to choose between them.
@@ -162,6 +183,11 @@ def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[st
     separates one ``Pitogo`` from the other without a similarity threshold. A container that names
     nothing, or that holds none of the candidates, is ignored rather than treated as a
     contradiction: the prose routinely names a region GADM does not model.
+
+    A name joined by ``and`` is split only where the whole fails, so ``Newfoundland and Labrador``
+    stays one unit while ``Aceh and West Sumatra`` becomes two. Every part that names something is
+    kept, except where the name opens with a word placing the event between its parts rather than
+    in them.
 
     Parameters
     ----------
@@ -177,13 +203,17 @@ def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[st
     set of str
         The GADM identifiers the name reaches, empty where it reaches none.
     """
-    gids = {unit.gid for unit in gazetteer.names.get(match_key(name), set())}
-    if gids and parent is not None:
-        containers = {unit.gid for unit in gazetteer.names.get(match_key(parent), set())}
-        inside = {gid for gid in gids if (gazetteer.ancestry(gid) - {gid}) & containers}
-        gids = inside or gids
+    gids = _units_named(name, parent, gazetteer)
+    if gids:
+        return _outermost(gids, gazetteer)
 
-    return _outermost(gids, gazetteer)
+    parts = [part.strip() for part in CONJUNCTION.split(name) if part.strip()]
+    if len(parts) > 1 and not RELATIONAL.match(name):
+        reached = [found for part in parts if (found := _units_named(part, parent, gazetteer))]
+        if reached:
+            return _outermost(set().union(*reached), gazetteer)
+
+    return set()
 
 
 def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Gazetteer) -> list[set[str]]:

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -193,6 +193,7 @@ NAMED = "named"
 LOCATED = "located"
 CONTAINED_BY = "container"
 CORRECTED = "corrected"
+INFERRED = "inferred"
 NAMES_NO_UNIT = "names no unit"
 
 
@@ -247,6 +248,9 @@ class Gazetteer(NamedTuple):
         Units keyed on :func:`match_key` of every name they are published under.
     parent_of : dict mapping str to str or None
         The unit one level up from each identifier.
+    shapes : dict mapping tuple to set of str
+        The keys sharing a first character and a length, which is what an approximate lookup scans
+        instead of every name in the country.
     corrections : dict mapping str to tuple of str
         The published names each checked entry stands for, keyed on :func:`match_key`. A misspelling
         gives one; a name GADM never carried as a unit — a merged province since split, a
@@ -255,6 +259,7 @@ class Gazetteer(NamedTuple):
 
     names: dict[str, set[Unit]]
     parent_of: dict[str, str | None]
+    shapes: dict[tuple[str, int], set[str]]
     corrections: dict[str, tuple[str, ...]]
 
     def _upwards(self, gid: str) -> Iterator[str]:
@@ -397,7 +402,12 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
             names[key].add(Unit(gid, level, parent))
         parent_of[gid] = parent
 
-    return Gazetteer(dict(names), parent_of, read_name_corrections(iso))
+    shapes: dict[tuple[str, int], set[str]] = defaultdict(set)
+    for key in names:
+        for letter in {key[0], key[1] if len(key) > 1 else key[0]}:
+            shapes[(letter, len(key))].add(key)
+
+    return Gazetteer(dict(names), parent_of, dict(shapes), read_name_corrections(iso))
 
 
 def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[str, tuple[str, ...]]:
@@ -533,6 +543,28 @@ def container_parts(parent: str) -> list[str]:
     return [part for part in CONTAINER_PARTS.split(parent) if part.strip()]
 
 
+def _corroborated_slip(name: str, container: set[str], pinned: set[str], gazetteer: Gazetteer) -> set[str]:
+    """
+    Take a one-slip match only where the rest of the event agrees with it.
+
+    One edit from a published name is a guess on its own — ``Lynmouth`` sits one edit from Lynemouth,
+    four hundred miles away. Where the container the prose gave, or a place the event named
+    unambiguously, holds exactly one of the candidates, the guess stops being one.
+    """
+    near = nearest_name(name, gazetteer, gazetteer.shapes)
+    if near is None:
+        return set()
+
+    vouching = pinned | {above for gid in container for above in gazetteer.ancestry(gid)}
+    if not vouching:
+        return set()
+
+    candidates = _outermost({unit.gid for unit in gazetteer.names[near]}, gazetteer)
+    inside = {gid for gid in candidates if gazetteer.ancestry(gid) & vouching}
+
+    return inside if len(inside) == 1 else set()
+
+
 def _innermost_container(parent: str | None, gazetteer: Gazetteer) -> set[str]:
     """Name the units the finest resolving part of a container reaches, so a district beats the state beside it."""
     for part in container_parts(parent or ""):
@@ -625,8 +657,8 @@ def resolve_event_places(
     falls back to the container the prose wrote it in — ``Pesisir Selaten (West Sumatra province)``
     becomes the province, which spans fourteen districts at the median — so the result records
     which of the two it was reached by. A container naming several places, as ``Wayanad district,
-    Kerala state`` does, gives the finest of them that resolves. A place with no container that is one edit from
-    exactly one published name is taken as a misspelling of it, recorded as such.
+    Kerala state`` does, gives the finest of them that resolves. A name one edit from a published one
+    is taken only where the container or an unambiguous sibling holds exactly one candidate.
 
     Parameters
     ----------
@@ -660,14 +692,17 @@ def resolve_event_places(
         if by_point:
             placed.append(Placement({by_point}, LOCATED))
             continue
-        container = _innermost_container(parent, gazetteer)
-        if container:
-            placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))
-            continue
         published = gazetteer.corrections.get(match_key(name), ())
         stands_for = {unit.gid for stood_for in published for unit in gazetteer.names.get(stood_for, set())}
         if stands_for:
             placed.append(Placement(_narrowed(_outermost(stands_for, gazetteer), pinned, gazetteer), CORRECTED))
+            continue
+        container = _innermost_container(parent, gazetteer)
+        if inferred := _corroborated_slip(name, container, pinned, gazetteer):
+            placed.append(Placement(inferred, INFERRED))
+            continue
+        if container:
+            placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))
             continue
         placed.append(Placement(set(), NAMES_NO_UNIT if names_no_unit(name) else NAMED))
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -228,13 +228,15 @@ class Gazetteer(NamedTuple):
         Units keyed on :func:`match_key` of every name they are published under.
     parent_of : dict mapping str to str or None
         The unit one level up from each identifier.
-    corrections : dict mapping str to str
-        The published name each checked misspelling stands for, keyed on :func:`match_key`.
+    corrections : dict mapping str to tuple of str
+        The published names each checked entry stands for, keyed on :func:`match_key`. A misspelling
+        gives one; a name GADM never carried as a unit — a merged province since split, a
+        statistical region — gives the several it covers.
     """
 
     names: dict[str, set[Unit]]
     parent_of: dict[str, str | None]
-    corrections: dict[str, str]
+    corrections: dict[str, tuple[str, ...]]
 
     def _upwards(self, gid: str) -> Iterator[str]:
         """Yield the unit and each container above it, outwards."""
@@ -374,7 +376,7 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
     return Gazetteer(dict(names), parent_of, read_name_corrections(iso))
 
 
-def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[str, str]:
+def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[str, tuple[str, ...]]:
     """
     Read the checked corrections for one country.
 
@@ -387,15 +389,16 @@ def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[st
 
     Returns
     -------
-    dict mapping str to str
-        The published name each misspelling stands for, both keyed by :func:`match_key`.
+    dict mapping str to tuple of str
+        The published names each entry stands for, keyed by :func:`match_key`. An entry naming
+        several units, as a merged province since split does, separates them with a pipe.
     """
     if not path.exists():
         return {}
 
     with path.open(encoding="utf-8", newline="") as handle:
         return {
-            match_key(row["written"]): row["corrected"]
+            match_key(row["written"]): tuple(row["corrected"].split("|"))
             for row in csv.DictReader(handle)
             if row["iso"] == iso and row["corrected"]
         }
@@ -637,10 +640,10 @@ def resolve_event_places(
         if container:
             placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))
             continue
-        published = gazetteer.corrections.get(match_key(name))
-        if published:
-            corrected = _outermost({unit.gid for unit in gazetteer.names[published]}, gazetteer)
-            placed.append(Placement(_narrowed(corrected, pinned, gazetteer), CORRECTED))
+        published = gazetteer.corrections.get(match_key(name), ())
+        stands_for = {unit.gid for stood_for in published for unit in gazetteer.names.get(stood_for, set())}
+        if stands_for:
+            placed.append(Placement(_narrowed(_outermost(stands_for, gazetteer), pinned, gazetteer), CORRECTED))
             continue
         placed.append(Placement(set(), NAMES_NO_UNIT if names_no_unit(name) else NAMED))
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -1,3 +1,4 @@
+import csv
 import re
 import sqlite3
 
@@ -30,10 +31,57 @@ CONJUNCTION = re.compile(r"\s+(?:and|&)\s+", re.IGNORECASE)
 RELATIONAL = re.compile(r"^\s*(?:between|off|offshore|au large)\b", re.IGNORECASE)
 
 
+# Corrections a person or a model has checked one at a time. Approximate matching proposes them;
+# only what is written here is ever applied, so an unreviewed near miss leaves a place unplaced
+# rather than renaming it.
+NAME_CORRECTIONS = Path(__file__).parent / "name_corrections.csv"
+
+# EM-DAT files an event under the country that existed at the time, and GADM only models the ones
+# that exist now. Where a state left one successor the mapping is settled; where it left several
+# the location text has to choose between them.
+SUCCEEDED_BY = {
+    "AZO": ("PRT",),
+    "CSK": ("CZE", "SVK"),
+    "DDR": ("DEU",),
+    "DFR": ("DEU",),
+    "SUN": (
+        "ARM",
+        "AZE",
+        "BLR",
+        "EST",
+        "GEO",
+        "KAZ",
+        "KGZ",
+        "LTU",
+        "LVA",
+        "MDA",
+        "RUS",
+        "TJK",
+        "TKM",
+        "UKR",
+        "UZB",
+    ),
+    "YMD": ("YEM",),
+    "YMN": ("YEM",),
+    "YUG": ("BIH", "HRV", "MKD", "MNE", "SRB", "SVN", "XKO"),
+}
+
+# Written places that name no administrative unit and never will: a compass point covering the
+# whole country, a position between two others, a stretch of water, or nothing at all. They are
+# recorded rather than counted as failures, because no source can place them.
+QUALIFIER = re.compile(
+    r"^(?:north|south|east|west|central|centre|center|northern|southern|eastern|western|"
+    r"north[- ]?(?:east|west)|south[- ]?(?:east|west)|countrywide|nationwide|whole country|"
+    r"all country|widespread|unknown|not available|no information|n\.?a\.?(?: on the source)?)$",
+    re.IGNORECASE,
+)
+NOTHING_LEGIBLE = re.compile(r"^[\W\d\s]*$")
+
 # How a written place reached the units it did.
 NAMED = "named"
 LOCATED = "located"
 CONTAINED_BY = "container"
+CORRECTED = "corrected"
 
 
 # A sea, a river or a mountain range is not an administrative unit, whatever it is one edit from.
@@ -98,10 +146,13 @@ class Gazetteer(NamedTuple):
         Units keyed on :func:`match_key` of every name they are published under.
     parent_of : dict mapping str to str or None
         The unit one level up from each identifier.
+    corrections : dict mapping str to str
+        The published name each checked misspelling stands for, keyed on :func:`match_key`.
     """
 
     names: dict[str, set[Unit]]
     parent_of: dict[str, str | None]
+    corrections: dict[str, str]
 
     def _upwards(self, gid: str) -> Iterator[str]:
         """Yield the unit and each container above it, outwards."""
@@ -204,7 +255,34 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gaz
                             names[key].add(Unit(gid, level, parent))
                 parent = gid
 
-    return Gazetteer(dict(names), parent_of)
+    return Gazetteer(dict(names), parent_of, read_name_corrections(iso))
+
+
+def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[str, str]:
+    """
+    Read the checked corrections for one country.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to read.
+    path : Path, optional
+        The corrections table. Default the one shipped with the package.
+
+    Returns
+    -------
+    dict mapping str to str
+        The published name each misspelling stands for, both keyed by :func:`match_key`.
+    """
+    if not path.exists():
+        return {}
+
+    with path.open(encoding="utf-8", newline="") as handle:
+        return {
+            match_key(row["written"]): row["corrected"]
+            for row in csv.DictReader(handle)
+            if row["iso"] == iso and row["corrected"]
+        }
 
 
 def name_shapes(gazetteer: Gazetteer) -> dict[tuple[str, int], set[str]]:
@@ -355,7 +433,8 @@ def resolve_event_places(
     A place naming nothing takes the unit a point put it in where one is offered. Failing that it
     falls back to the container the prose wrote it in — ``Pesisir Selaten (West Sumatra province)``
     becomes the province, which spans fourteen districts at the median — so the result records
-    which of the two it was reached by.
+    which of the two it was reached by. A place with no container that the corrections table names
+    is read as the misspelling it was checked to be.
 
     Parameters
     ----------
@@ -390,7 +469,11 @@ def resolve_event_places(
             placed.append(Placement({by_point}, LOCATED))
             continue
         container = resolve_place(parent, None, gazetteer) if parent else set()
-        how = CONTAINED_BY if container else NAMED
-        placed.append(Placement(_narrowed(container, pinned, gazetteer), how))
+        if container:
+            placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))
+            continue
+        published = gazetteer.corrections.get(match_key(name))
+        corrected = _outermost({unit.gid for unit in gazetteer.names[published]}, gazetteer) if published else set()
+        placed.append(Placement(_narrowed(corrected, pinned, gazetteer), CORRECTED if corrected else NAMED))
 
     return placed

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -36,6 +36,20 @@ LOCATED = "located"
 CONTAINED_BY = "container"
 
 
+# A sea, a river or a mountain range is not an administrative unit, whatever it is one edit from.
+# Units named after a feature — `River Nile State`, `Bay of Plenty` — still match exactly; only the
+# approximate lookup refuses them.
+FEATURE = re.compile(
+    r"\b(seas?|oceans?|rivers?|lakes?|gulfs?|straits?|detroit|bays?|mountains?|mts?|mount|peaks?|"
+    r"valleys?|deltas?|peninsulas?|channels?|canals?|reservoirs?|dams?|volcanoe?s?|glaciers?|"
+    r"basins?|capes?|sounds?|fjords?|lagoons?|swamps?|forests?|deserts?)\b",
+    re.IGNORECASE,
+)
+
+# Below this a single edit is a large share of the name and the match stops meaning anything:
+# `Arora` sits one edit from both `Aurora` and `Arora` in half the countries that have either.
+MIN_APPROXIMATE_LENGTH = 6
+
 # GADM publishes a level 5, for Belgium and Rwanda only.
 INDEXABLE_LEVELS = (1, 2, 3, 4)
 
@@ -191,6 +205,72 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gaz
                 parent = gid
 
     return Gazetteer(dict(names), parent_of)
+
+
+def name_shapes(gazetteer: Gazetteer) -> dict[tuple[str, int], set[str]]:
+    """Group a country's names by first character and length, which is what :func:`nearest_name` scans."""
+    shapes: dict[tuple[str, int], set[str]] = defaultdict(set)
+    for key in gazetteer.names:
+        shapes[(key[0], len(key))].add(key)
+
+    return dict(shapes)
+
+
+def _one_edit_apart(written: str, published: str) -> bool:
+    """Whether one insertion, deletion or substitution turns one key into the other."""
+    if abs(len(written) - len(published)) > 1:
+        return False
+    if len(written) == len(published):
+        return sum(a != b for a, b in zip(written, published, strict=True)) <= 1
+
+    longer, shorter = (written, published) if len(written) > len(published) else (published, written)
+    skipped = next(
+        (position for position, pair in enumerate(zip(longer, shorter, strict=False)) if pair[0] != pair[1]),
+        len(shorter),
+    )
+
+    return longer[skipped + 1 :] == shorter[skipped:]
+
+
+def nearest_name(name: str, gazetteer: Gazetteer, shapes: dict[tuple[str, int], set[str]]) -> str | None:
+    """
+    Find the one published name a written place is a misspelling of.
+
+    A match is only offered where the written name is long enough for a single edit to be a small
+    part of it, does not name a physical feature, and is one edit from exactly one published name. Two names equally close is not a near miss, it is a
+    choice, and this makes none.
+
+    Parameters
+    ----------
+    name : str
+        The place as written.
+    gazetteer : Gazetteer
+        The country's units, from :func:`read_gazetteer`.
+    shapes : dict mapping tuple to set of str
+        The country's names grouped for searching, from :func:`name_shapes`.
+
+    Returns
+    -------
+    str or None
+        The matching key in ``gazetteer.names``, or None where the gates reject the name or no
+        single published name is close enough.
+    """
+    if FEATURE.search(name):
+        return None
+
+    key = match_key(name)
+    if len(key) < MIN_APPROXIMATE_LENGTH or key in gazetteer.names:
+        return None
+
+    # A typo rarely changes the first character, and scanning by it keeps the search local.
+    nearby = {
+        candidate
+        for length in range(len(key) - 1, len(key) + 2)
+        for candidate in shapes.get((key[0], length), ())
+        if _one_edit_apart(key, candidate)
+    }
+
+    return next(iter(nearby)) if len(nearby) == 1 else None
 
 
 def _narrowed(gids: set[str], pinned: set[str], gazetteer: Gazetteer) -> set[str]:

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -77,6 +77,47 @@ QUALIFIER = re.compile(
 )
 NOTHING_LEGIBLE = re.compile(r"^[\W\d\s]*$")
 
+# EM-DAT files an event under the country that existed at the time, and GADM only models the ones
+# that exist now. Where a state left one successor the mapping is settled; where it left several
+# the location text has to choose between them.
+SUCCEEDED_BY = {
+    "AZO": ("PRT",),
+    "CSK": ("CZE", "SVK"),
+    "DDR": ("DEU",),
+    "DFR": ("DEU",),
+    "SUN": (
+        "ARM",
+        "AZE",
+        "BLR",
+        "EST",
+        "GEO",
+        "KAZ",
+        "KGZ",
+        "LTU",
+        "LVA",
+        "MDA",
+        "RUS",
+        "TJK",
+        "TKM",
+        "UKR",
+        "UZB",
+    ),
+    "YMD": ("YEM",),
+    "YMN": ("YEM",),
+    "YUG": ("BIH", "HRV", "MKD", "MNE", "SRB", "SVN", "XKO"),
+}
+
+# Written places that name no administrative unit and never will: a compass point covering the
+# whole country, a position between two others, a stretch of water, or nothing at all. They are
+# recorded rather than counted as failures, because no source can place them.
+QUALIFIER = re.compile(
+    r"^(?:north|south|east|west|central|centre|center|northern|southern|eastern|western|"
+    r"north[- ]?(?:east|west)|south[- ]?(?:east|west)|countrywide|nationwide|whole country|"
+    r"all country|widespread|unknown|not available|no information|n\.?a\.?(?: on the source)?)$",
+    re.IGNORECASE,
+)
+NOTHING_LEGIBLE = re.compile(r"^[\W\d\s]*$")
+
 # How a written place reached the units it did.
 NAMED = "named"
 LOCATED = "located"
@@ -477,3 +518,85 @@ def resolve_event_places(
         placed.append(Placement(_narrowed(corrected, pinned, gazetteer), CORRECTED if corrected else NAMED))
 
     return placed
+
+
+def successor_state(
+    places: Iterable[tuple[str, str | None]],
+    iso: str,
+    cache_dir: Path,
+    *,
+    layer: str = GADM_LAYER,
+) -> str | None:
+    """
+    Name the modern country whose gazetteer an event's places belong to.
+
+    A state that left one successor needs no evidence. Where it left several, the successor placing
+    strictly more of the written places than any other takes the event: a Soviet flood naming
+    Tashkent is Uzbek, and one naming nothing recognisable stays unplaced rather than being assigned
+    to the largest successor.
+
+    Parameters
+    ----------
+    places : iterable of tuple
+        Each a name as written and the container the prose gave, or None.
+    iso : str
+        ISO 3166-1 alpha-3 code EM-DAT filed the event under.
+    cache_dir : Path
+        Directory the caches live under.
+    layer : str, optional
+        Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+
+    Returns
+    -------
+    str or None
+        The successor's ISO code, or None where the state has no successor recorded or its
+        successors cannot be told apart.
+    """
+    successors = SUCCEEDED_BY.get(iso)
+    if not successors:
+        return None
+    if len(successors) == 1:
+        return successors[0]
+
+    written = list(places)
+    placed: dict[str, int] = {}
+    for successor in successors:
+        gazetteer = read_gazetteer(successor, cache_dir, layer=layer)
+        if gazetteer.names:
+            placed[successor] = sum(bool(resolve_place(name, parent, gazetteer)) for name, parent in written)
+
+    best = max(placed.values(), default=0)
+    if best == 0:
+        return None
+
+    winners = [successor for successor, count in placed.items() if count == best]
+
+    return winners[0] if len(winners) == 1 else None
+
+
+def names_no_unit(name: str) -> bool:
+    """
+    Whether a written place can never name an administrative unit.
+
+    A compass point standing in for the whole country, a position between two other places, a sea
+    or a river, and a string with no letters in it are all beyond any gazetteer. Counting them as
+    coverage failures understates what the resolver reaches, so they are told apart.
+
+    Parameters
+    ----------
+    name : str
+        The place as written.
+
+    Returns
+    -------
+    bool
+        True where no administrative unit could answer to this name.
+    """
+    written = name.strip()
+
+    return bool(
+        NOTHING_LEGIBLE.match(written)
+        or QUALIFIER.match(written)
+        or RELATIONAL.match(written)
+        or FEATURE.search(written)
+    )

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -30,8 +30,30 @@ CONJUNCTION = re.compile(r"\s+(?:and|&)\s+", re.IGNORECASE)
 RELATIONAL = re.compile(r"^\s*(?:between|off|offshore|au large)\b", re.IGNORECASE)
 
 
+# How a written place reached the units it did.
+NAMED = "named"
+CONTAINED_BY = "container"
+
+
 # GADM publishes a level 5, for Belgium and Rwanda only.
 INDEXABLE_LEVELS = (1, 2, 3, 4)
+
+
+class Placement(NamedTuple):
+    """Where one written place put an event.
+
+    Parameters
+    ----------
+    gids : set of str
+        The GADM identifiers reached, empty where the place reached none.
+    how : str
+        ``NAMED`` where the written place itself resolved, ``CONTAINED_BY`` where only the container
+        it was written in did, which is coarser than the prose supports. ``NAMED`` where ``gids`` is
+        empty and nothing was reached at all.
+    """
+
+    gids: set[str]
+    how: str
 
 
 class Unit(NamedTuple):
@@ -158,6 +180,14 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gaz
     return Gazetteer(dict(names), parent_of)
 
 
+def _narrowed(gids: set[str], pinned: set[str], gazetteer: Gazetteer) -> set[str]:
+    """Keep the candidates inside something the event already pinned, or all of them if none are."""
+    if len(gids) < 2:
+        return gids
+
+    return {gid for gid in gids if gazetteer.ancestry(gid) & pinned} or gids
+
+
 def _outermost(gids: set[str], gazetteer: Gazetteer) -> set[str]:
     """Drop every unit another candidate already contains, leaving what the name can mean at its coarsest."""
     return {gid for gid in gids if not (gazetteer.ancestry(gid) - {gid}) & gids}
@@ -216,13 +246,17 @@ def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[st
     return set()
 
 
-def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Gazetteer) -> list[set[str]]:
+def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Gazetteer) -> list[Placement]:
     """
     Resolve the places one event names together, letting the unambiguous ones narrow the rest.
 
     An event's places share a footprint, so a mention that lands on exactly one unit tells the
     ambiguous mentions beside it where to look. Candidates outside everything the event has already
     pinned are dropped, and a mention narrowed to nothing keeps its candidates.
+
+    A place naming nothing falls back to the container the prose wrote it in — ``Pesisir Selaten
+    (West Sumatra province)`` becomes the province — which is coarser than the prose supports, so
+    the result records that it was reached that way.
 
     Parameters
     ----------
@@ -233,19 +267,24 @@ def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Ga
 
     Returns
     -------
-    list of set of str
-        The GADM identifiers each place reaches, in the order the places were given.
+    list of Placement
+        Where each place put the event, in the order the places were given.
     """
-    resolved = [resolve_place(name, parent, gazetteer) for name, parent in places]
+    written = list(places)
+    resolved = [resolve_place(name, parent, gazetteer) for name, parent in written]
 
     pinned: set[str] = set()
     for gids in resolved:
         if len(gids) == 1:
             pinned |= gazetteer.ancestry(next(iter(gids)))
 
-    narrowed = []
-    for gids in resolved:
-        inside = {gid for gid in gids if gazetteer.ancestry(gid) & pinned} if len(gids) > 1 else gids
-        narrowed.append(inside or gids)
+    placed = []
+    for (_, parent), gids in zip(written, resolved, strict=True):
+        if gids:
+            placed.append(Placement(_narrowed(gids, pinned, gazetteer), NAMED))
+            continue
+        container = resolve_place(parent, None, gazetteer) if parent else set()
+        how = CONTAINED_BY if container else NAMED
+        placed.append(Placement(_narrowed(container, pinned, gazetteer), how))
 
-    return narrowed
+    return placed

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -110,6 +110,10 @@ FEATURE = re.compile(
     re.IGNORECASE,
 )
 
+# Written through the keying rules, so the cache fingerprint moves when any of them does, whether
+# or not the rule can be expressed as a pattern.
+_KEYING_PROBE = "SÃƒÂ©dhiou province & Kalin-Aapayo district"
+
 # Below this a single edit is a large share of the name and the match stops meaning anything:
 # `Arora` sits one edit from both `Aurora` and `Arora` in half the countries that have either.
 MIN_APPROXIMATE_LENGTH = 6
@@ -288,12 +292,40 @@ def _name_columns(level: int, available: set[str]) -> str:
     return ", ".join(f"{field}_{level}" if f"{field}_{level}" in available else "''" for field in _NAME_FIELDS)
 
 
+def repair_mojibake(text: str) -> str:
+    """
+    Undo text that was decoded as cp1252 after being written as UTF-8, however many times.
+
+    ``SÃ©dhiou`` is Sédhiou read through the wrong codec, and EM-DAT carries names that went
+    through it twice. The repair is its own guard: text that was never mangled does not survive
+    the round trip, because the bytes a correct name encodes to are not valid UTF-8.
+
+    Parameters
+    ----------
+    text : str
+        The name as written.
+
+    Returns
+    -------
+    str
+        The name with the mangling undone, or unchanged where there was none.
+    """
+    while True:
+        try:
+            once = text.encode("cp1252").decode("utf-8")
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            return text
+        if once == text:
+            return text
+        text = once
+
+
 def match_key(name: str) -> str:
     """
     Reduce a place name to what a written mention and a GADM name can be expected to share.
 
-    Transliterated, stripped of the noun saying what kind of unit it is, and reduced to letters and
-    digits, so ``Kalin-Aapayo province`` and ``Kalin Aapayo`` meet.
+    Repaired of any mis-decoding, transliterated, stripped of the noun saying what kind of unit it
+    is, and reduced to letters and digits, so ``Kalin-Aapayo province`` and ``Kalin Aapayo`` meet.
 
     Parameters
     ----------
@@ -305,12 +337,14 @@ def match_key(name: str) -> str:
     str
         The comparison key, empty where the name was only a unit noun.
     """
-    return "".join(character for character in anyascii(UNIT_NOUNS.sub(" ", name)) if character.isalnum()).casefold()
+    repaired = UNIT_NOUNS.sub(" ", repair_mojibake(name))
+
+    return "".join(character for character in anyascii(repaired) if character.isalnum()).casefold()
 
 
 def _keying_fingerprint() -> str:
     """Fingerprint the rules that turn a name into a key, so a change to them invalidates the cache."""
-    rules = "|".join((UNIT_NOUNS.pattern, str(INDEXABLE_LEVELS)))
+    rules = "|".join((UNIT_NOUNS.pattern, str(INDEXABLE_LEVELS), match_key(_KEYING_PROBE)))
 
     return hashlib.sha256(rules.encode()).hexdigest()[:12]
 
@@ -385,7 +419,6 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
         "gazetteer",
         build,
         polars_parquet(),
-        # The index is keyed by `match_key`, so the cache turns over when those rules change.
         # The index is keyed by `match_key`, so the cache turns over when those rules change.
         params={"iso": iso, "keying": _keying_fingerprint()},
         force=force_reload,

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -13,7 +13,7 @@ import polars as pl
 
 from anyascii import anyascii
 
-from climate_risk.data.cache import cached, polars_parquet
+from climate_risk.data.cache import builder_fingerprint, cached, polars_parquet
 from climate_risk.data.gadm import GADM_LAYER, administered_territories, gadm_dir, gadm_path
 
 # Words naming what a unit is rather than which one it is. EM-DAT writes them inconsistently and
@@ -445,8 +445,14 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
         "gazetteer",
         build,
         polars_parquet(),
-        # The index is keyed by `match_key`, so the cache turns over when those rules change.
-        params={"iso": iso, "keying": keying_fingerprint()},
+        # `layer` chooses what is read; `keying` covers the rules that turn a name into a key,
+        # and `reading` the rules that decide which rows carry one.
+        params={
+            "iso": iso,
+            "keying": keying_fingerprint(),
+            "layer": layer,
+            "reading": builder_fingerprint(build, _NAME_FIELDS, FORMERLY_INCLUDED.get(iso, ())),
+        },
         force=force_reload,
     )
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -8,9 +8,12 @@ from itertools import batched
 from pathlib import Path
 from typing import NamedTuple
 
+import polars as pl
+
 from anyascii import anyascii
 
-from climate_risk.data.gadm import GADM_LAYER, administered_territories, gadm_path
+from climate_risk.data.cache import cached, polars_parquet
+from climate_risk.data.gadm import GADM_LAYER, administered_territories, gadm_dir, gadm_path
 
 # Words naming what a unit is rather than which one it is. EM-DAT writes them inconsistently and
 # GADM does not carry them, so `Kalin-Aapayo province` has to reach `Kalin-Aapayo`.
@@ -101,6 +104,9 @@ NAMES_NO_UNIT = "names no unit"
 
 # GADM publishes a level 5, for Belgium and Rwanda only.
 INDEXABLE_LEVELS = (1, 2, 3, 4)
+
+# The flattened index, as it is cached: one row per name a unit is published under.
+INDEX_COLUMNS = {"key": pl.String, "gid": pl.String, "level": pl.Int8, "parent": pl.String}
 
 
 class Placement(NamedTuple):
@@ -205,7 +211,7 @@ def match_key(name: str) -> str:
     return "".join(character for character in anyascii(UNIT_NOUNS.sub(" ", name)) if character.isalnum()).casefold()
 
 
-def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gazetteer:
+def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_reload: bool = False) -> Gazetteer:
     """
     Read one country's GADM units into a gazetteer.
 
@@ -226,38 +232,61 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gaz
         Directory the caches live under.
     layer : str, optional
         Layer to read inside the GeoPackage. Default ``GADM_LAYER``.
+    force_reload : bool, optional
+        Rebuild even when the index is already cached. Default False.
 
     Returns
     -------
     Gazetteer
         The country's units.
     """
+
+    def build() -> pl.DataFrame:
+        indexed: list[tuple[str, str, int, str | None]] = []
+        with sqlite3.connect(gadm_path(cache_dir)) as connection:
+            available = {row[1] for row in connection.execute(f'PRAGMA table_info("{layer}")')}
+            # A variant-name column is optional; an identifier and a name are what make a level readable.
+            levels = [level for level in INDEXABLE_LEVELS if {f"GID_{level}", f"NAME_{level}"} <= available]
+            columns = ", ".join(_name_columns(level, available) for level in levels)
+            # Kashmir is filed under codes of its own, not under the country administering it.
+            held = (iso, *administered_territories(iso, cache_dir, layer=layer))
+            placeholders = ", ".join("?" * len(held))
+            query = f'SELECT DISTINCT {columns} FROM "{layer}" WHERE GID_0 IN ({placeholders})'
+
+            for row in connection.execute(query, held):
+                parent = None
+                for level, (gid, name, variants) in zip(levels, batched(row, len(_NAME_FIELDS)), strict=True):
+                    # GADM writes an unnamed unit as `?` at every level it spans, and a unit cannot
+                    # contain itself: the chain ends where the identifier stops changing.
+                    if not gid or gid == parent:
+                        break
+                    # A row without a key still records the unit's parentage: GADM leaves some
+                    # units unnamed, and a walk upwards passes through them.
+                    indexed.append(("", gid, level, parent))
+                    for field in (name, variants):
+                        for alternative in str(field or "").split("|"):
+                            if key := match_key(alternative):
+                                indexed.append((key, gid, level, parent))
+                    parent = gid
+
+        return pl.DataFrame(indexed, schema=INDEX_COLUMNS, orient="row")
+
+    indexed = cached(
+        gadm_dir(cache_dir),
+        "gazetteer",
+        build,
+        polars_parquet(),
+        # The index is keyed by `match_key`, so the cache turns over when those rules change.
+        params={"iso": iso},
+        force=force_reload,
+    )
+
     names: dict[str, set[Unit]] = defaultdict(set)
     parent_of: dict[str, str | None] = {}
-
-    with sqlite3.connect(gadm_path(cache_dir)) as connection:
-        available = {row[1] for row in connection.execute(f'PRAGMA table_info("{layer}")')}
-        # A variant-name column is optional; an identifier and a name are what make a level readable.
-        levels = [level for level in INDEXABLE_LEVELS if {f"GID_{level}", f"NAME_{level}"} <= available]
-        columns = ", ".join(_name_columns(level, available) for level in levels)
-        # Kashmir is filed under codes of its own, not under the country administering it.
-        held = (iso, *administered_territories(iso, cache_dir, layer=layer))
-        placeholders = ", ".join("?" * len(held))
-        query = f'SELECT DISTINCT {columns} FROM "{layer}" WHERE GID_0 IN ({placeholders})'
-
-        for row in connection.execute(query, held):
-            parent = None
-            for level, (gid, name, variants) in zip(levels, batched(row, len(_NAME_FIELDS)), strict=True):
-                # GADM writes an unnamed unit as `?` at every level it spans, and a unit cannot
-                # contain itself: the chain ends where the identifier stops changing.
-                if not gid or gid == parent:
-                    break
-                parent_of[gid] = parent
-                for field in (name, variants):
-                    for alternative in str(field or "").split("|"):
-                        if key := match_key(alternative):
-                            names[key].add(Unit(gid, level, parent))
-                parent = gid
+    for key, gid, level, parent in indexed.iter_rows():
+        if key:
+            names[key].add(Unit(gid, level, parent))
+        parent_of[gid] = parent
 
     return Gazetteer(dict(names), parent_of, read_name_corrections(iso))
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -188,12 +188,22 @@ DIRECTIONAL_QUALIFIER = re.compile(
     re.IGNORECASE,
 )
 
+# `South Bihar` and `Ontario Central` qualify a unit rather than naming one. The words are part of
+# plenty of real names — Lower Shabelle, West Bengal, Northern Territory — so the qualifier only
+# comes off once the name as written has failed.
+DIRECTIONAL_QUALIFIER = re.compile(
+    r"^(?:north|south|east|west|central|centre|upper|lower|greater)(?:ern)?(?:\s+of)?\s+"
+    r"|\s+(?:north|south|east|west|central|centre|upper|lower)(?:ern)?$",
+    re.IGNORECASE,
+)
+
 # How a written place reached the units it did.
 NAMED = "named"
 LOCATED = "located"
 CONTAINED_BY = "container"
 CORRECTED = "corrected"
 INFERRED = "inferred"
+QUALIFIED = "qualified"
 NAMES_NO_UNIT = "names no unit"
 
 
@@ -543,6 +553,23 @@ def container_parts(parent: str) -> list[str]:
     return [part for part in CONTAINER_PARTS.split(parent) if part.strip()]
 
 
+def _qualified_unit(name: str, gazetteer: Gazetteer) -> set[str]:
+    """
+    Name the unit a directional qualifier was applied to, where it names exactly one.
+
+    ``South Bihar`` is part of Bihar and reaches it once the qualifier comes off, which is coarser
+    than the prose but the only reading GADM can hold. A base naming several units is not a reading,
+    so it is refused.
+    """
+    base = DIRECTIONAL_QUALIFIER.sub(" ", name).strip()
+    if not base or base == name.strip():
+        return set()
+
+    qualified = _outermost(_units_named(base, None, gazetteer), gazetteer)
+
+    return qualified if len(qualified) == 1 else set()
+
+
 def _corroborated_slip(name: str, container: set[str], pinned: set[str], gazetteer: Gazetteer) -> set[str]:
     """
     Take a one-slip match only where the rest of the event agrees with it.
@@ -658,7 +685,8 @@ def resolve_event_places(
     becomes the province, which spans fourteen districts at the median — so the result records
     which of the two it was reached by. A container naming several places, as ``Wayanad district,
     Kerala state`` does, gives the finest of them that resolves. A name one edit from a published one
-    is taken only where the container or an unambiguous sibling holds exactly one candidate.
+    is taken only where the container or an unambiguous sibling holds exactly one candidate, and a
+    name that only qualifies a unit by direction reaches the whole of it.
 
     Parameters
     ----------
@@ -700,6 +728,9 @@ def resolve_event_places(
         container = _innermost_container(parent, gazetteer)
         if inferred := _corroborated_slip(name, container, pinned, gazetteer):
             placed.append(Placement(inferred, INFERRED))
+            continue
+        if qualified := _qualified_unit(name, gazetteer):
+            placed.append(Placement(qualified, QUALIFIED))
             continue
         if container:
             placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -30,6 +30,10 @@ UNIT_NOUNS = re.compile(
 # one, so the whole string has to be tried before its parts.
 CONJUNCTION = re.compile(r"\s+(?:and|&)\s+", re.IGNORECASE)
 
+# `Wayanad district, Kerala state` names the same place twice over, finest first. Read whole it
+# matches nothing; read in parts each one matches a unit.
+CONTAINER_PARTS = re.compile(r"\s*[,;]\s*")
+
 # `Between Java and Bali` names a stretch of sea by its shores. Splitting it puts the event on
 # whichever shore happens to resolve.
 RELATIONAL = re.compile(r"^\s*(?:between|off|offshore|au large)\b", re.IGNORECASE)
@@ -393,6 +397,32 @@ def nearest_name(name: str, gazetteer: Gazetteer, shapes: dict[tuple[str, int], 
     return next(iter(nearby)) if len(nearby) == 1 else None
 
 
+def container_parts(parent: str) -> list[str]:
+    """
+    Split a container into the places it names, finest first.
+
+    Parameters
+    ----------
+    parent : str
+        The container as the prose wrote it.
+
+    Returns
+    -------
+    list of str
+        Each place it names, in the order written.
+    """
+    return [part for part in CONTAINER_PARTS.split(parent) if part.strip()]
+
+
+def _innermost_container(parent: str | None, gazetteer: Gazetteer) -> set[str]:
+    """Name the units the finest resolving part of a container reaches, so a district beats the state beside it."""
+    for part in container_parts(parent or ""):
+        if found := resolve_place(part, None, gazetteer):
+            return found
+
+    return set()
+
+
 def _narrowed(gids: set[str], pinned: set[str], gazetteer: Gazetteer) -> set[str]:
     """Keep the candidates inside something the event already pinned, or all of them if none are."""
     if len(gids) < 2:
@@ -412,7 +442,7 @@ def _units_named(name: str, parent: str | None, gazetteer: Gazetteer) -> set[str
     if not gids or parent is None:
         return gids
 
-    containers = {unit.gid for unit in gazetteer.names.get(match_key(parent), set())}
+    containers = {unit.gid for part in container_parts(parent) for unit in gazetteer.names.get(match_key(part), set())}
     inside = {gid for gid in gids if (gazetteer.ancestry(gid) - {gid}) & containers}
 
     return inside or gids
@@ -475,7 +505,8 @@ def resolve_event_places(
     A place naming nothing takes the unit a point put it in where one is offered. Failing that it
     falls back to the container the prose wrote it in — ``Pesisir Selaten (West Sumatra province)``
     becomes the province, which spans fourteen districts at the median — so the result records
-    which of the two it was reached by. A place with no container that is one edit from
+    which of the two it was reached by. A container naming several places, as ``Wayanad district,
+    Kerala state`` does, gives the finest of them that resolves. A place with no container that is one edit from
     exactly one published name is taken as a misspelling of it, recorded as such.
 
     Parameters
@@ -510,7 +541,7 @@ def resolve_event_places(
         if by_point:
             placed.append(Placement({by_point}, LOCATED))
             continue
-        container = resolve_place(parent, None, gazetteer) if parent else set()
+        container = _innermost_container(parent, gazetteer)
         if container:
             placed.append(Placement(_narrowed(container, pinned, gazetteer), CONTAINED_BY))
             continue

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -2,7 +2,7 @@ import re
 import sqlite3
 
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from itertools import batched
 from pathlib import Path
 from typing import NamedTuple
@@ -32,6 +32,7 @@ RELATIONAL = re.compile(r"^\s*(?:between|off|offshore|au large)\b", re.IGNORECAS
 
 # How a written place reached the units it did.
 NAMED = "named"
+LOCATED = "located"
 CONTAINED_BY = "container"
 
 
@@ -258,7 +259,12 @@ def resolve_place(name: str, parent: str | None, gazetteer: Gazetteer) -> set[st
     return set()
 
 
-def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Gazetteer) -> list[Placement]:
+def resolve_event_places(
+    places: Iterable[tuple[str, str | None]],
+    gazetteer: Gazetteer,
+    *,
+    located: Mapping[str, str] | None = None,
+) -> list[Placement]:
     """
     Resolve the places one event names together, letting the unambiguous ones narrow the rest.
 
@@ -266,9 +272,10 @@ def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Ga
     ambiguous mentions beside it where to look. Candidates outside everything the event has already
     pinned are dropped, and a mention narrowed to nothing keeps its candidates.
 
-    A place naming nothing falls back to the container the prose wrote it in — ``Pesisir Selaten
-    (West Sumatra province)`` becomes the province — which is coarser than the prose supports, so
-    the result records that it was reached that way.
+    A place naming nothing takes the unit a point put it in where one is offered. Failing that it
+    falls back to the container the prose wrote it in — ``Pesisir Selaten (West Sumatra province)``
+    becomes the province, which spans fourteen districts at the median — so the result records
+    which of the two it was reached by.
 
     Parameters
     ----------
@@ -276,6 +283,9 @@ def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Ga
         Each a name as written and the container the prose gave, or None.
     gazetteer : Gazetteer
         The country's units, from :func:`read_gazetteer`.
+    located : mapping of str to str, optional
+        The unit a point put a written place in, keyed on the name. Default None. A point beats the
+        container because it names one unit where the container names everything inside it.
 
     Returns
     -------
@@ -291,9 +301,13 @@ def resolve_event_places(places: Iterable[tuple[str, str | None]], gazetteer: Ga
             pinned |= gazetteer.ancestry(next(iter(gids)))
 
     placed = []
-    for (_, parent), gids in zip(written, resolved, strict=True):
+    for (name, parent), gids in zip(written, resolved, strict=True):
         if gids:
             placed.append(Placement(_narrowed(gids, pinned, gazetteer), NAMED))
+            continue
+        by_point = (located or {}).get(name)
+        if by_point:
+            placed.append(Placement({by_point}, LOCATED))
             continue
         container = resolve_place(parent, None, gazetteer) if parent else set()
         how = CONTAINED_BY if container else NAMED

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -87,11 +87,6 @@ UNIT_NOUNS = re.compile(
 CONJUNCTION = re.compile(r"\s+(?:and|et)\s+|\s*[&+/]\s*", re.IGNORECASE)
 
 
-# EM-DAT joins places with `and`, its French `et`, and the bare `&`, `+` and `/`. GADM writes
-# `Newfoundland and Labrador` and `Komenda/Edina/Eguafo/Abirem`, so the whole string has to be tried
-# before its parts.
-CONJUNCTION = re.compile(r"\s+(?:and|et)\s+|\s*[&+/]\s*", re.IGNORECASE)
-
 # `Wayanad district, Kerala state` names the same place twice over, finest first. Read whole it
 # matches nothing; read in parts each one matches a unit.
 CONTAINER_PARTS = re.compile(r"\s*[,;]\s*")
@@ -178,15 +173,6 @@ FORMERLY_INCLUDED = {
     "SDN": ("SSD",),
     "SRB": ("MNE", "XKO"),
 }
-
-# `South Bihar` and `Ontario Central` qualify a unit rather than naming one. The words are part of
-# plenty of real names — Lower Shabelle, West Bengal, Northern Territory — so the qualifier only
-# comes off once the name as written has failed.
-DIRECTIONAL_QUALIFIER = re.compile(
-    r"^(?:north|south|east|west|central|centre|upper|lower|greater)(?:ern)?(?:\s+of)?\s+"
-    r"|\s+(?:north|south|east|west|central|centre|upper|lower)(?:ern)?$",
-    re.IGNORECASE,
-)
 
 # `South Bihar` and `Ontario Central` qualify a unit rather than naming one. The words are part of
 # plenty of real names — Lower Shabelle, West Bengal, Northern Territory — so the qualifier only
@@ -412,12 +398,7 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER, force_
             names[key].add(Unit(gid, level, parent))
         parent_of[gid] = parent
 
-    shapes: dict[tuple[str, int], set[str]] = defaultdict(set)
-    for key in names:
-        for letter in {key[0], key[1] if len(key) > 1 else key[0]}:
-            shapes[(letter, len(key))].add(key)
-
-    return Gazetteer(dict(names), parent_of, dict(shapes), read_name_corrections(iso))
+    return Gazetteer(dict(names), parent_of, _shape_index(names), read_name_corrections(iso))
 
 
 def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[str, tuple[str, ...]]:
@@ -448,6 +429,16 @@ def read_name_corrections(iso: str, *, path: Path = NAME_CORRECTIONS) -> dict[st
         }
 
 
+def _shape_index(keys: Iterable[str]) -> dict[tuple[str, int], set[str]]:
+    """File each key under its length and each of its first two letters."""
+    shapes: dict[tuple[str, int], set[str]] = defaultdict(set)
+    for key in keys:
+        for letter in {key[0], key[1] if len(key) > 1 else key[0]}:
+            shapes[(letter, len(key))].add(key)
+
+    return dict(shapes)
+
+
 def name_shapes(gazetteer: Gazetteer) -> dict[tuple[str, int], set[str]]:
     """
     Group a country's names for approximate lookup, by length and by each of their first two letters.
@@ -455,12 +446,7 @@ def name_shapes(gazetteer: Gazetteer) -> dict[tuple[str, int], set[str]]:
     Filing a name under its second letter as well as its first is what makes a slip in the first one
     reachable: ``llinois`` has lost the letter its bucket would otherwise be chosen by.
     """
-    shapes: dict[tuple[str, int], set[str]] = defaultdict(set)
-    for key in gazetteer.names:
-        for letter in {key[0], key[1] if len(key) > 1 else key[0]}:
-            shapes[(letter, len(key))].add(key)
-
-    return dict(shapes)
+    return _shape_index(gazetteer.names)
 
 
 def _one_slip_apart(written: str, published: str) -> bool:

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -26,9 +26,10 @@ UNIT_NOUNS = re.compile(
 )
 
 
-# EM-DAT writes `Aceh and West Sumatra Provinces` for two units and `Newfoundland and Labrador` for
-# one, so the whole string has to be tried before its parts.
-CONJUNCTION = re.compile(r"\s+(?:and|&)\s+", re.IGNORECASE)
+# EM-DAT joins places with `and`, its French `et`, and the bare `&`, `+` and `/`. GADM writes
+# `Newfoundland and Labrador` and `Komenda/Edina/Eguafo/Abirem`, so the whole string has to be tried
+# before its parts.
+CONJUNCTION = re.compile(r"\s+(?:and|et)\s+|\s*[&+/]\s*", re.IGNORECASE)
 
 # `Wayanad district, Kerala state` names the same place twice over, finest first. Read whole it
 # matches nothing; read in parts each one matches a unit.

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -18,12 +18,73 @@ from climate_risk.data.gadm import GADM_LAYER, administered_territories, gadm_di
 
 # Words naming what a unit is rather than which one it is. EM-DAT writes them inconsistently and
 # GADM does not carry them, so `Kalin-Aapayo province` has to reach `Kalin-Aapayo`.
+# Nouns that can join to a name with `of`, as `towns of Kauswagan` does.
+_JOINED_BY_OF = (
+    "towns?",
+    "villages?",
+    "districts?",
+    "provinces?",
+    "regions?",
+    "states?",
+    "departments?",
+    "cities",
+    "city",
+    "municipalit(?:y|ies)",
+    "governorates?",
+    "prefectures?",
+    "woredas?",
+)
+
+# Nouns written on their own, before or after the name, and the abbreviations they appear as.
+_STANDS_ALONE = (
+    "sub[- ]?districts?",
+    "local government areas?",
+    "divisions?",
+    "territor(?:y|ies)",
+    "emirates?",
+    "upazillas?",
+    "upazilas?",
+    "communes?",
+    "markets?",
+    "cc",
+    "prov",
+    "regencies",
+    "regency",
+    "islands?",
+    "isl",
+    "archipel(?:ago)?",
+    "counties",
+    "county",
+    "areas?",
+    "near",
+    "around",
+    "arrond",
+    "arr",
+    "barangay",
+    "brgy",
+    "kel",
+    "kec",
+    "kab",
+    "desa",
+)
+
+# Prepositional phrases, which have no bare form.
+_LOCATES = ("outskirts of", "vicinity of", "coast of")
+
+# Alternation is leftmost-first, so the `of` forms have to precede the bare nouns they contain:
+# a bare `town` would otherwise match inside `towns of` and strand the preposition.
 UNIT_NOUNS = re.compile(
-    r"\b(provinces?|prov|districts?|regencies|regency|regions?|cities|city of|city|states?|towns?|"
-    r"municipalit(?:y|ies)|islands?|isl|departments?|counties|county|governorates?|prefectures?|"
-    r"areas?|near|around|outskirts of|vicinity of|coast of)\b\.?",
+    r"\b("
+    + "|".join((*(f"{noun}\\s+of" for noun in _JOINED_BY_OF), *_LOCATES, *_JOINED_BY_OF, *_STANDS_ALONE))
+    + r")\b\.?",
     re.IGNORECASE,
 )
+
+
+# EM-DAT joins places with `and`, its French `et`, and the bare `&`, `+` and `/`. GADM writes
+# `Newfoundland and Labrador` and `Komenda/Edina/Eguafo/Abirem`, so the whole string has to be tried
+# before its parts.
+CONJUNCTION = re.compile(r"\s+(?:and|et)\s+|\s*[&+/]\s*", re.IGNORECASE)
 
 
 # EM-DAT joins places with `and`, its French `et`, and the bare `&`, `+` and `/`. GADM writes

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -410,12 +410,24 @@ def name_shapes(gazetteer: Gazetteer) -> dict[tuple[str, int], set[str]]:
     return dict(shapes)
 
 
-def _one_edit_apart(written: str, published: str) -> bool:
-    """Whether one insertion, deletion or substitution turns one key into the other."""
+def _one_slip_apart(written: str, published: str) -> bool:
+    """Whether one insertion, deletion, substitution or transposition turns one key into the other."""
     if abs(len(written) - len(published)) > 1:
         return False
     if len(written) == len(published):
-        return sum(a != b for a, b in zip(written, published, strict=True)) <= 1
+        differing = [
+            position for position, pair in enumerate(zip(written, published, strict=True)) if pair[0] != pair[1]
+        ]
+        if len(differing) <= 1:
+            return True
+        first, second = differing[0], differing[-1]
+
+        return (
+            len(differing) == 2
+            and second == first + 1
+            and written[first] == published[second]
+            and written[second] == published[first]
+        )
 
     longer, shorter = (written, published) if len(written) > len(published) else (published, written)
     skipped = next(
@@ -431,7 +443,8 @@ def nearest_name(name: str, gazetteer: Gazetteer, shapes: dict[tuple[str, int], 
     Find the one published name a written place is a misspelling of.
 
     A match is only offered where the written name is long enough for a single edit to be a small
-    part of it, does not name a physical feature, and is one edit from exactly one published name. Two names equally close is not a near miss, it is a
+    part of it, does not name a physical feature, and is one slip — an insertion, deletion,
+    substitution or transposition — from exactly one published name. Two names equally close is not a near miss, it is a
     choice, and this makes none.
 
     Parameters
@@ -461,7 +474,7 @@ def nearest_name(name: str, gazetteer: Gazetteer, shapes: dict[tuple[str, int], 
         candidate
         for length in range(len(key) - 1, len(key) + 2)
         for candidate in shapes.get((key[0], length), ())
-        if _one_edit_apart(key, candidate)
+        if _one_slip_apart(key, candidate)
     }
 
     return next(iter(nearby)) if len(nearby) == 1 else None

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -10,7 +10,7 @@ from typing import NamedTuple
 
 from anyascii import anyascii
 
-from climate_risk.data.gadm import GADM_LAYER, gadm_path
+from climate_risk.data.gadm import GADM_LAYER, administered_territories, gadm_path
 
 # Words naming what a unit is rather than which one it is. EM-DAT writes them inconsistently and
 # GADM does not carry them, so `Kalin-Aapayo province` has to reach `Kalin-Aapayo`.
@@ -280,9 +280,12 @@ def read_gazetteer(iso: str, cache_dir: Path, *, layer: str = GADM_LAYER) -> Gaz
         # A variant-name column is optional; an identifier and a name are what make a level readable.
         levels = [level for level in INDEXABLE_LEVELS if {f"GID_{level}", f"NAME_{level}"} <= available]
         columns = ", ".join(_name_columns(level, available) for level in levels)
-        query = f'SELECT DISTINCT {columns} FROM "{layer}" WHERE GID_0 = ?'
+        # Kashmir is filed under codes of its own, not under the country administering it.
+        held = (iso, *administered_territories(iso, cache_dir, layer=layer))
+        placeholders = ", ".join("?" * len(held))
+        query = f'SELECT DISTINCT {columns} FROM "{layer}" WHERE GID_0 IN ({placeholders})'
 
-        for row in connection.execute(query, (iso,)):
+        for row in connection.execute(query, held):
             parent = None
             for level, (gid, name, variants) in zip(levels, batched(row, len(_NAME_FIELDS)), strict=True):
                 # GADM writes an unnamed unit as `?` at every level it spans, and a unit cannot

--- a/climate_risk/data/placement.py
+++ b/climate_risk/data/placement.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterator
+from pathlib import Path
+
+from climate_risk.data.geocoding import Geocoder
+from climate_risk.data.geonames import geonames_geocoder
+from climate_risk.data.osm import osm_geocoder
+
+
+def available_geocoders(iso: str, cache_dir: Path) -> Iterator[Geocoder]:
+    """
+    Yield every point source that can answer for one country, most trusted first.
+
+    GeoNames comes first: it is a gazetteer of populated places, so a name it knows is a settlement
+    rather than whatever object happened to carry the name. OpenStreetMap answers second, reaching
+    the villages and statistical regions GeoNames has no row for. A source with nothing cached for
+    this country is skipped rather than raised over, because most countries have only some of them.
+
+    Parameters
+    ----------
+    iso : str
+        ISO 3166-1 alpha-3 code of the country to answer for.
+    cache_dir : Path
+        Directory the caches live under.
+
+    Yields
+    ------
+    callable
+        Takes an ISO code and a written name, and returns longitude and latitude or None.
+    """
+    try:
+        yield geonames_geocoder(iso, cache_dir)
+    except (KeyError, OSError):
+        pass
+
+    yield osm_geocoder(iso, cache_dir)

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -1,7 +1,9 @@
 import datetime as dt
 import json
+import re
 
 from pathlib import Path
+from typing import NamedTuple
 
 import polars as pl
 
@@ -268,6 +270,103 @@ def load_emdat_events(cache_dir: Path) -> pl.DataFrame:
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     return _read_workbook(EMDAT.require(cache_dir))
+
+
+LOCATION_SEPARATORS = ",;"
+
+# `X, and Y` splits on the comma and strands the conjunction on the second span. No GADM unit is
+# named with a leading `and`, so a span that starts with one is an artifact of the split.
+STRANDED_CONJUNCTION = re.compile(r"^(?:and|&)\b\s*", re.IGNORECASE)
+
+
+class NamedPlace(NamedTuple):
+    """A place an event's location text names, and the place the text says contains it.
+
+    Parameters
+    ----------
+    name : str
+        The place as written, whitespace collapsed and nothing else changed.
+    parent : str or None
+        The containing place the prose gave in parentheses, or None where it gave none.
+    """
+
+    name: str
+    parent: str | None
+
+
+def named_places(location: str | None) -> list[NamedPlace]:
+    """
+    Explode an event's location text into the places it names.
+
+    EM-DAT writes a list of places, optionally followed by a parenthesised container that applies
+    to every place since the last one — ``Muang Nakhon Si Thammarat, Hua Sai, Pak Phanang, Ron
+    Phibun districts (Nakhon Si Thammarat province)`` names four districts of one province. The
+    parent is what tells a repeated district name which province it belongs to, so it is carried
+    rather than flattened into a sibling.
+
+    Separators are commas and semicolons outside parentheses. ``and`` is not one: 75 GADM units are
+    named like ``Newfoundland and Labrador``, and splitting on it would destroy them. Where the
+    prose writes ``X, and Y`` the comma splits and the conjunction is left stranded, so a leading
+    one is dropped from each place.
+
+    Parameters
+    ----------
+    location : str or None
+        The ``Location`` column as EM-DAT writes it.
+
+    Returns
+    -------
+    list of NamedPlace
+        One entry per place named, in the order written, without repeats. Empty when the text names
+        nothing.
+    """
+    spans: list[str] = []
+    places: list[NamedPlace] = []
+    written: list[str] = []
+    container: list[str] = []
+    depth = 0
+
+    def close_span() -> None:
+        collapsed = " ".join("".join(written).split())
+        if trimmed := STRANDED_CONJUNCTION.sub("", collapsed).strip():
+            spans.append(trimmed)
+        written.clear()
+
+    def close_group() -> None:
+        # Nested parentheses gloss the container rather than nesting inside it — `Region I (Ilocos
+        # region)` is one place under two names — so the inner text is dropped, not treated as a
+        # further parent.
+        parent = " ".join(re.sub(r"\([^()]*\)", " ", "".join(container)).split()) or None
+        places.extend(NamedPlace(span, parent) for span in spans)
+        spans.clear()
+        container.clear()
+
+    for character in str(location or ""):
+        if character == "(":
+            depth += 1
+            if depth == 1:
+                close_span()
+                continue
+        elif character == ")":
+            if depth == 0:
+                continue
+            depth -= 1
+            if depth == 0:
+                close_group()
+                continue
+
+        if depth:
+            container.append(character)
+        elif character in LOCATION_SEPARATORS:
+            close_span()
+        else:
+            written.append(character)
+
+    close_span()
+    # An unclosed parenthesis still names a container; the text was truncated, not unstructured.
+    close_group()
+
+    return list(dict.fromkeys(places))
 
 
 GADM_UNITS_COLUMN = "GADM Admin Units"

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -371,6 +371,54 @@ def named_places(location: str | None) -> list[NamedPlace]:
 
 GADM_UNITS_COLUMN = "GADM Admin Units"
 
+
+class UncodedEvent(NamedTuple):
+    """An event EM-DAT recorded a location for without coding any administrative unit.
+
+    Parameters
+    ----------
+    disno : str
+        The EM-DAT event identifier.
+    iso : str
+        ISO 3166-1 alpha-3 code of the country the event is filed under.
+    places : list of NamedPlace
+        The places its location text names, never empty.
+    """
+
+    disno: str
+    iso: str
+    places: list[NamedPlace]
+
+
+def events_missing_units(events: pl.DataFrame) -> list[UncodedEvent]:
+    """
+    Collect the events whose geography has to be recovered from their location text.
+
+    Two thirds of the workbook carries no administrative units, and an event whose text names
+    nothing is left out: there is nothing to resolve and no reason to fetch a gazetteer for it.
+
+    Parameters
+    ----------
+    events : DataFrame
+        The workbook, from :func:`load_emdat_events`.
+
+    Returns
+    -------
+    list of UncodedEvent
+        One entry per event with places to place, in workbook order.
+    """
+    uncoded = []
+    for disno, iso, location, units in zip(
+        events["DisNo."], events["ISO"], events["Location"], events[GADM_UNITS_COLUMN], strict=True
+    ):
+        if str(units or "").strip() and json.loads(units):
+            continue
+        if places := named_places(location):
+            uncoded.append(UncodedEvent(str(disno), str(iso), places))
+
+    return uncoded
+
+
 # One row per affected administrative unit. `name` and `migration_method` are absent on some units:
 # EM-DAT omits the name where GADM has none, and the method where the unit was never migrated.
 EVENT_UNIT_SCHEMA = {

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -278,6 +278,9 @@ LOCATION_SEPARATORS = ",;"
 # named with a leading `and`, so a span that starts with one is an artifact of the split.
 STRANDED_CONJUNCTION = re.compile(r"^(?:and|&)\b\s*", re.IGNORECASE)
 
+# A spreadsheet label EM-DAT leaks into the location field, as `Level 1 = Uttar Pradesh`.
+FIELD_LABEL = re.compile(r"^\s*level\s*\d+\s*=\s*", re.IGNORECASE)
+
 # `Montgomery County in (Tennessee state)` joins a place to its container with a preposition, which
 # the split leaves dangling on the end of the name.
 DANGLING_PREPOSITION = re.compile(r"\s+(?:in|of|at|on)$", re.IGNORECASE)
@@ -311,7 +314,8 @@ def named_places(location: str | None) -> list[NamedPlace]:
     Separators are commas and semicolons outside parentheses. ``and`` is not one: 75 GADM units are
     named like ``Newfoundland and Labrador``, and splitting on it would destroy them. Where the
     prose writes ``X, and Y`` the comma splits and the conjunction is left stranded, so a leading
-    one is dropped from each place, as is a preposition left dangling on the end by ``X in (Y)``.
+    one is dropped from each place, as is a preposition left dangling on the end by ``X in (Y)`` and
+    the ``Level 1 =`` label the workbook leaks into the column.
 
     Parameters
     ----------
@@ -332,7 +336,7 @@ def named_places(location: str | None) -> list[NamedPlace]:
 
     def close_span() -> None:
         collapsed = " ".join("".join(written).split())
-        without_conjunction = STRANDED_CONJUNCTION.sub("", collapsed)
+        without_conjunction = STRANDED_CONJUNCTION.sub("", FIELD_LABEL.sub("", collapsed))
         if trimmed := DANGLING_PREPOSITION.sub("", without_conjunction).strip():
             spans.append(trimmed)
         written.clear()

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -278,6 +278,10 @@ LOCATION_SEPARATORS = ",;"
 # named with a leading `and`, so a span that starts with one is an artifact of the split.
 STRANDED_CONJUNCTION = re.compile(r"^(?:and|&)\b\s*", re.IGNORECASE)
 
+# `Montgomery County in (Tennessee state)` joins a place to its container with a preposition, which
+# the split leaves dangling on the end of the name.
+DANGLING_PREPOSITION = re.compile(r"\s+(?:in|of|at|on)$", re.IGNORECASE)
+
 
 class NamedPlace(NamedTuple):
     """A place an event's location text names, and the place the text says contains it.
@@ -307,7 +311,7 @@ def named_places(location: str | None) -> list[NamedPlace]:
     Separators are commas and semicolons outside parentheses. ``and`` is not one: 75 GADM units are
     named like ``Newfoundland and Labrador``, and splitting on it would destroy them. Where the
     prose writes ``X, and Y`` the comma splits and the conjunction is left stranded, so a leading
-    one is dropped from each place.
+    one is dropped from each place, as is a preposition left dangling on the end by ``X in (Y)``.
 
     Parameters
     ----------
@@ -328,7 +332,8 @@ def named_places(location: str | None) -> list[NamedPlace]:
 
     def close_span() -> None:
         collapsed = " ".join("".join(written).split())
-        if trimmed := STRANDED_CONJUNCTION.sub("", collapsed).strip():
+        without_conjunction = STRANDED_CONJUNCTION.sub("", collapsed)
+        if trimmed := DANGLING_PREPOSITION.sub("", without_conjunction).strip():
             spans.append(trimmed)
         written.clear()
 

--- a/climate_risk/exceptions.py
+++ b/climate_risk/exceptions.py
@@ -4,3 +4,7 @@ class DataValidationError(Exception):
 
 class ISOCodeValidationError(DataValidationError):
     """Raised when ISO codes are not one-to-one with the geometries they label."""
+
+
+class UpstreamUnavailableError(Exception):
+    """Raised when a source could not be reached, as distinct from having no answer to give."""

--- a/docs/locating-events.md
+++ b/docs/locating-events.md
@@ -1,0 +1,67 @@
+# Locating events
+
+EM-DAT gives most events a country and nothing finer. About 28% carry administrative units it
+coded itself; the rest carry a free-text `Location` column, or nothing at all. This is how that
+text becomes GADM units, and what to run to reproduce it from a fresh clone.
+
+## The path a location takes
+
+```
+"Muang Nakhon Si Thammarat, Hua Sai districts (Nakhon Si Thammarat province)"
+        |
+        |  named_places        climate_risk/data_functions/emdat_processing.py
+        v
+[("Muang Nakhon Si Thammarat", "Nakhon Si Thammarat province"), ("Hua Sai districts", ...)]
+        |
+        |  resolve_place       climate_risk/data/place_names.py
+        v
+{"THA.40.5_1"}, {"THA.40.3_1"}
+```
+
+`named_places` splits on commas and semicolons outside parentheses, and treats a parenthesised
+group as the container of every place since the last one. It never splits on `and`: 75 GADM units
+are named like `Newfoundland and Labrador`.
+
+`resolve_place` matches a name against every name GADM publishes a unit under, having stripped the
+noun saying what kind of unit it is. It resolves ambiguity three ways, in order: a unit contained by
+another candidate is dropped, the container from the prose narrows what is left, and
+`resolve_event_places` lets the places an event names unambiguously narrow the ones it does not.
+Where the whole string reaches nothing and every part of an `and` does, the parts are taken instead.
+
+What is left over goes to a gazetteer of points. `geonames_geocoder` answers with a longitude and
+latitude, and the point is placed in whichever GADM unit contains it.
+
+## Getting the data
+
+Two archives are placed by hand, because their terms forbid automated download:
+
+| file | where it goes | obtained from |
+|---|---|---|
+| `emdat.xlsx` | `data/` | https://public.emdat.be — a free account, non-commercial use |
+| `gadm_410.gpkg` | `data/gadm/` | https://gadm.org/download_world.html — non-commercial use |
+
+Everything else downloads itself:
+
+```
+pixi run fetch-geonames          # every country EM-DAT names, ~200 dumps
+pixi run fetch-geonames PHL IDN  # or just the ones you need
+```
+
+Each dump is indexed into `data/geonames/places__iso=XXX.parquet`, one row per distinct name, the
+most populous place keeping a name where several share it. Re-running skips whatever is already
+there.
+
+## Checking it still works
+
+```
+pixi run verify-geocoder             # how many names have a unit to be scored against
+pixi run verify-geocoder geonames    # score the geocoder against them
+```
+
+The answer key is every written name that already resolves to exactly one GADM unit. A point is
+scored as landing in that unit, in the level-1 unit containing it, or somewhere else. Names
+reaching more than one unit are excluded — whichever the geocoder picked, the other was available,
+so they cannot judge anything.
+
+This is a check, not a test: it needs both hand-placed archives and takes minutes, so it is a
+script rather than part of the suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ files = [
     "climate_risk/sample.py",
     "climate_risk/stats",
     "tests",
+    "tools",
 ]
 python_version = "3.12"
 disallow_untyped_defs = true
@@ -212,6 +213,9 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_ignores = true
 strict_equality = true
+
+# A name bound on only some paths reads as defined and raises at runtime. Off by default in mypy.
+enable_error_code = ["possibly-undefined"]
 
 # No stubs exist for these, on the index or in the packages themselves.
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ fmt = "ruff format ."
 verify-placement = "python tools/verify_placement_against_emdat.py"
 verify-geocoder = "python tools/verify_geocoder_against_gadm.py"
 fetch-geonames = "python tools/fetch_geonames.py"
+check-corrections = "python tools/verify_name_corrections.py check"
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ lint = "ruff check . && ruff format --check ."
 typecheck = "mypy"
 fmt = "ruff format ."
 verify-placement = "python tools/verify_placement_against_emdat.py"
+verify-geocoder = "python tools/verify_geocoder_against_gadm.py"
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ typecheck = "mypy"
 fmt = "ruff format ."
 verify-placement = "python tools/verify_placement_against_emdat.py"
 verify-geocoder = "python tools/verify_geocoder_against_gadm.py"
+fetch-geonames = "python tools/fetch_geonames.py"
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,6 +439,9 @@ def toy_gadm() -> gpd.GeoDataFrame:
         # 111 ambiguous mentions in the workbook are a province and a same-named district.
         ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", "", "", box(4, 0, 5, 1)),
         ("ZMB", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", "", "", box(6, 0, 7, 1)),
+        # `Nam Bay` is one edit from this district and names a bay, which is the collision an
+        # approximate match has to refuse: `Manila Bay` reaches a barangay called Manlabay.
+        ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.3_1", "Nambak", "", "", "", "", "", box(5, 0, 6, 1)),
         # 75 GADM units carry a conjunction in their own name, which a split on `and` destroys.
         (
             "CAN",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -380,15 +380,62 @@ def toy_gadm() -> gpd.GeoDataFrame:
     Ghana is included because GADM numbers it unlike everywhere else — `GHA11_2` for a province and
     `GHA7.13_2` for a district, with no dot after the country code. Any code inferring the level
     from the shape of the id gets Ghana wrong.
+
+    `LAO.1.2.1_1` is the seat named after the district holding it, which is what most ambiguous
+    mentions turn out to be: candidates on one nesting chain rather than places in two locations.
+
+    Ukraine carries GADM's placeholder identifier, which is the string `?` at both levels and
+    therefore parents itself. Walking a unit's containers without a visited set never terminates.
+
+    `VARNAME` carries the alternative spellings GADM publishes, pipe-separated, and is empty for
+    most units. A name lookup that reads only `NAME` misses whichever spelling the mention used.
     """
     rows = [
-        ("LAO", "LAO.1_1", "Attapu", "LAO.1.1_1", "Sanamxay", box(0, 0, 1, 1)),
-        ("LAO", "LAO.1_1", "Attapu", "LAO.1.2_1", "Samakhixay", box(1, 0, 2, 1)),
-        ("LAO", "LAO.2_1", "Bokeo", "LAO.2.1_1", "Houayxay", box(3, 0, 4, 1)),
-        ("ZMB", "ZMB.1_1", "Central", "ZMB.1.1_1", "Kabwe", box(6, 0, 7, 1)),
-        ("GHA", "GHA11_2", "Savannah", "GHA7.13_2", "Ga Central", box(8, 0, 9, 1)),
+        ("LAO", "LAO.1_1", "Attapu", "Attopeu", "LAO.1.1_1", "Sanamxay", "", "LAO.1.1.1_1", "Ban Mai", box(0, 0, 1, 1)),
+        (
+            "LAO",
+            "LAO.1_1",
+            "Attapu",
+            "Attopeu",
+            "LAO.1.2_1",
+            "Samakhixay",
+            "",
+            "LAO.1.2.1_1",
+            "Samakhixay",
+            box(1, 0, 2, 1),
+        ),
+        (
+            "LAO",
+            "LAO.2_1",
+            "Bokeo",
+            "",
+            "LAO.2.1_1",
+            "Houayxay",
+            "Ban Houayxay|Houei Sai",
+            "LAO.2.1.1_1",
+            "Ban Mai",
+            box(3, 0, 4, 1),
+        ),
+        # A district sharing its name with a province elsewhere, which is the common homonym: 94 of
+        # 111 ambiguous mentions in the workbook are a province and a same-named district.
+        ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", box(4, 0, 5, 1)),
+        ("ZMB", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", box(6, 0, 7, 1)),
+        # GADM writes an unnamed Ukrainian unit as `?` at both levels, so it comes out its own parent.
+        ("UKR", "?", "?", "", "?", "?", "", "", "", box(10, 0, 11, 1)),
+        ("GHA", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", box(8, 0, 9, 1)),
     ]
-    columns = ("GID_0", "GID_1", "NAME_1", "GID_2", "NAME_2", "geometry")
+    columns = (
+        "GID_0",
+        "GID_1",
+        "NAME_1",
+        "VARNAME_1",
+        "GID_2",
+        "NAME_2",
+        "VARNAME_2",
+        "GID_3",
+        "NAME_3",
+        "geometry",
+    )
 
     return gpd.GeoDataFrame(dict(zip(columns, zip(*rows, strict=True), strict=True)), crs="EPSG:4326")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import xarray as xr
 from shapely.geometry import LineString, Point, box
 
 from climate_risk.data.gpcc import GriddedProduct
+from climate_risk.data.osm import LOOKUP_COLUMNS
 from climate_risk.data.source import DataSource
 
 # One event that clears every downstream filter: deaths above 100, affected above 1000, and a start
@@ -758,6 +759,23 @@ def write_geonames_cache(tmp_path):
         )
         with zipfile.ZipFile(directory / f"{alpha2}.zip", "w") as archive:
             archive.writestr(f"{alpha2}.txt", toy_geonames() if rows is None else rows)
+
+        return tmp_path
+
+    return write
+
+
+@pytest.fixture
+def write_osm_cache(tmp_path):
+    """Return a callable writing cached Nominatim answers, and giving back the cache root.
+
+    The layout is stated literally rather than derived from the loader, so a wrong cache path fails
+    instead of agreeing with itself."""
+
+    def write(rows, *, iso="LAO"):
+        directory = tmp_path / "osm"
+        directory.mkdir(exist_ok=True)
+        pl.DataFrame(rows, schema=LOOKUP_COLUMNS, orient="row").write_parquet(directory / f"lookups__iso={iso}.parquet")
 
         return tmp_path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,6 +384,8 @@ def toy_gadm() -> gpd.GeoDataFrame:
     `LAO.1.2.1_1` is the seat named after the district holding it, which is what most ambiguous
     mentions turn out to be: candidates on one nesting chain rather than places in two locations.
 
+    Ethiopia and Eritrea stand in for a country that lost territory and the state that holds it now.
+
     Canada carries a unit whose own name joins two places with `and`, and Czechia and Slovakia
     stand in for the successors of a state GADM no longer models.
 
@@ -515,6 +517,9 @@ def toy_gadm() -> gpd.GeoDataFrame:
             "",
             box(22, 0, 23, 1),
         ),
+        # A country that lost territory, and the state that holds it now.
+        ("ETH", "Ethiopia", "ETH.1_1", "Tigray", "", "ETH.1.1_1", "Mekele", "", "", "", "", "", box(24, 0, 25, 1)),
+        ("ERI", "Eritrea", "ERI.1_1", "Maekel", "", "ERI.1.1_1", "Asmara", "", "", "", "", "", box(26, 0, 27, 1)),
         # GADM writes an unnamed Ukrainian unit as `?` at both levels, so it comes out its own parent.
         ("UKR", "Ukraine", "?", "?", "", "?", "?", "", "", "", "", "", box(10, 0, 11, 1)),
         ("GHA", "Ghana", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", "", "", box(8, 0, 9, 1)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,7 +384,8 @@ def toy_gadm() -> gpd.GeoDataFrame:
     `LAO.1.2.1_1` is the seat named after the district holding it, which is what most ambiguous
     mentions turn out to be: candidates on one nesting chain rather than places in two locations.
 
-    Canada carries a unit whose own name joins two places with `and`.
+    Canada carries a unit whose own name joins two places with `and`, and Czechia and Slovakia
+    stand in for the successors of a state GADM no longer models.
 
     Ukraine carries GADM's placeholder identifier, which is the string `?` at both levels and
     therefore parents itself. Walking a unit's containers without a visited set never terminates.
@@ -457,6 +458,14 @@ def toy_gadm() -> gpd.GeoDataFrame:
             "",
             box(12, 0, 13, 1),
         ),
+        # Two successors of a dissolved state, so a historical event has something to choose between.
+        ("CZE", "CZE.1_1", "Praha", "", "CZE.1.1_1", "Praha 1", "", "", "", "", "", box(14, 0, 15, 1)),
+        ("SVK", "SVK.1_1", "Bratislavsky", "", "SVK.1.1_1", "Bratislava I", "", "", "", "", "", box(16, 0, 17, 1)),
+        # A name both successors publish, which is a tie rather than an answer.
+        ("CZE", "CZE.1_1", "Praha", "", "CZE.1.2_1", "Nove Mesto", "", "", "", "", "", box(14, 1, 15, 2)),
+        ("SVK", "SVK.1_1", "Bratislavsky", "", "SVK.1.2_1", "Nove Mesto", "", "", "", "", "", box(16, 1, 17, 2)),
+        # One successor of a second dissolved state, so a lone candidate placing nothing is still no answer.
+        ("HRV", "HRV.1_1", "Zagreb", "", "HRV.1.1_1", "Zagreb", "", "", "", "", "", box(18, 0, 19, 1)),
         # GADM writes an unnamed Ukrainian unit as `?` at both levels, so it comes out its own parent.
         ("UKR", "?", "?", "", "?", "?", "", "", "", "", "", box(10, 0, 11, 1)),
         ("GHA", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", "", "", box(8, 0, 9, 1)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -391,7 +391,20 @@ def toy_gadm() -> gpd.GeoDataFrame:
     most units. A name lookup that reads only `NAME` misses whichever spelling the mention used.
     """
     rows = [
-        ("LAO", "LAO.1_1", "Attapu", "Attopeu", "LAO.1.1_1", "Sanamxay", "", "LAO.1.1.1_1", "Ban Mai", box(0, 0, 1, 1)),
+        (
+            "LAO",
+            "LAO.1_1",
+            "Attapu",
+            "Attopeu",
+            "LAO.1.1_1",
+            "Sanamxay",
+            "",
+            "LAO.1.1.1_1",
+            "Ban Mai",
+            "",
+            "",
+            box(0, 0, 1, 1),
+        ),
         (
             "LAO",
             "LAO.1_1",
@@ -402,6 +415,8 @@ def toy_gadm() -> gpd.GeoDataFrame:
             "",
             "LAO.1.2.1_1",
             "Samakhixay",
+            "",
+            "",
             box(1, 0, 2, 1),
         ),
         (
@@ -414,15 +429,17 @@ def toy_gadm() -> gpd.GeoDataFrame:
             "Ban Houayxay|Houei Sai",
             "LAO.2.1.1_1",
             "Ban Mai",
+            "",
+            "",
             box(3, 0, 4, 1),
         ),
         # A district sharing its name with a province elsewhere, which is the common homonym: 94 of
         # 111 ambiguous mentions in the workbook are a province and a same-named district.
-        ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", box(4, 0, 5, 1)),
-        ("ZMB", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", box(6, 0, 7, 1)),
+        ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", "", "", box(4, 0, 5, 1)),
+        ("ZMB", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", "", "", box(6, 0, 7, 1)),
         # GADM writes an unnamed Ukrainian unit as `?` at both levels, so it comes out its own parent.
-        ("UKR", "?", "?", "", "?", "?", "", "", "", box(10, 0, 11, 1)),
-        ("GHA", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", box(8, 0, 9, 1)),
+        ("UKR", "?", "?", "", "?", "?", "", "", "", "", "", box(10, 0, 11, 1)),
+        ("GHA", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", "", "", box(8, 0, 9, 1)),
     ]
     columns = (
         "GID_0",
@@ -434,6 +451,8 @@ def toy_gadm() -> gpd.GeoDataFrame:
         "VARNAME_2",
         "GID_3",
         "NAME_3",
+        "GID_4",
+        "NAME_4",
         "geometry",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,7 @@ def toy_gadm() -> gpd.GeoDataFrame:
     rows = [
         (
             "LAO",
+            "Laos",
             "LAO.1_1",
             "Attapu",
             "Attopeu",
@@ -410,6 +411,7 @@ def toy_gadm() -> gpd.GeoDataFrame:
         ),
         (
             "LAO",
+            "Laos",
             "LAO.1_1",
             "Attapu",
             "Attopeu",
@@ -424,6 +426,7 @@ def toy_gadm() -> gpd.GeoDataFrame:
         ),
         (
             "LAO",
+            "Laos",
             "LAO.2_1",
             "Bokeo",
             "",
@@ -438,14 +441,15 @@ def toy_gadm() -> gpd.GeoDataFrame:
         ),
         # A district sharing its name with a province elsewhere, which is the common homonym: 94 of
         # 111 ambiguous mentions in the workbook are a province and a same-named district.
-        ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", "", "", box(4, 0, 5, 1)),
-        ("ZMB", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", "", "", box(6, 0, 7, 1)),
+        ("LAO", "Laos", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", "", "", box(4, 0, 5, 1)),
+        ("ZMB", "Zambia", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", "", "", box(6, 0, 7, 1)),
         # `Nam Bay` is one edit from this district and names a bay, which is the collision an
         # approximate match has to refuse: `Manila Bay` reaches a barangay called Manlabay.
-        ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.3_1", "Nambak", "", "", "", "", "", box(5, 0, 6, 1)),
+        ("LAO", "Laos", "LAO.2_1", "Bokeo", "", "LAO.2.3_1", "Nambak", "", "", "", "", "", box(5, 0, 6, 1)),
         # 75 GADM units carry a conjunction in their own name, which a split on `and` destroys.
         (
             "CAN",
+            "Canada",
             "CAN.5_1",
             "Newfoundland and Labrador",
             "",
@@ -459,19 +463,65 @@ def toy_gadm() -> gpd.GeoDataFrame:
             box(12, 0, 13, 1),
         ),
         # Two successors of a dissolved state, so a historical event has something to choose between.
-        ("CZE", "CZE.1_1", "Praha", "", "CZE.1.1_1", "Praha 1", "", "", "", "", "", box(14, 0, 15, 1)),
-        ("SVK", "SVK.1_1", "Bratislavsky", "", "SVK.1.1_1", "Bratislava I", "", "", "", "", "", box(16, 0, 17, 1)),
+        ("CZE", "Czechia", "CZE.1_1", "Praha", "", "CZE.1.1_1", "Praha 1", "", "", "", "", "", box(14, 0, 15, 1)),
+        (
+            "SVK",
+            "Slovakia",
+            "SVK.1_1",
+            "Bratislavsky",
+            "",
+            "SVK.1.1_1",
+            "Bratislava I",
+            "",
+            "",
+            "",
+            "",
+            "",
+            box(16, 0, 17, 1),
+        ),
         # A name both successors publish, which is a tie rather than an answer.
-        ("CZE", "CZE.1_1", "Praha", "", "CZE.1.2_1", "Nove Mesto", "", "", "", "", "", box(14, 1, 15, 2)),
-        ("SVK", "SVK.1_1", "Bratislavsky", "", "SVK.1.2_1", "Nove Mesto", "", "", "", "", "", box(16, 1, 17, 2)),
+        ("CZE", "Czechia", "CZE.1_1", "Praha", "", "CZE.1.2_1", "Nove Mesto", "", "", "", "", "", box(14, 1, 15, 2)),
+        (
+            "SVK",
+            "Slovakia",
+            "SVK.1_1",
+            "Bratislavsky",
+            "",
+            "SVK.1.2_1",
+            "Nove Mesto",
+            "",
+            "",
+            "",
+            "",
+            "",
+            box(16, 1, 17, 2),
+        ),
         # One successor of a second dissolved state, so a lone candidate placing nothing is still no answer.
-        ("HRV", "HRV.1_1", "Zagreb", "", "HRV.1.1_1", "Zagreb", "", "", "", "", "", box(18, 0, 19, 1)),
+        ("HRV", "Croatia", "HRV.1_1", "Zagreb", "", "HRV.1.1_1", "Zagreb", "", "", "", "", "", box(18, 0, 19, 1)),
+        # Kashmir is filed under a code of its own, with GADM naming the country administering it.
+        ("IND", "India", "IND.1_1", "Kerala", "", "IND.1.1_1", "Kochi", "", "", "", "", "", box(20, 0, 21, 1)),
+        (
+            "Z01",
+            "India",
+            "Z01.1_1",
+            "Jammu and Kashmir",
+            "",
+            "Z01.1.1_1",
+            "Srinagar",
+            "",
+            "",
+            "",
+            "",
+            "",
+            box(22, 0, 23, 1),
+        ),
         # GADM writes an unnamed Ukrainian unit as `?` at both levels, so it comes out its own parent.
-        ("UKR", "?", "?", "", "?", "?", "", "", "", "", "", box(10, 0, 11, 1)),
-        ("GHA", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", "", "", box(8, 0, 9, 1)),
+        ("UKR", "Ukraine", "?", "?", "", "?", "?", "", "", "", "", "", box(10, 0, 11, 1)),
+        ("GHA", "Ghana", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", "", "", box(8, 0, 9, 1)),
     ]
     columns = (
         "GID_0",
+        "COUNTRY",
         "GID_1",
         "NAME_1",
         "VARNAME_1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,6 +386,8 @@ def toy_gadm() -> gpd.GeoDataFrame:
 
     Ethiopia and Eritrea stand in for a country that lost territory and the state that holds it now.
 
+    Poland stands in for a language that writes a unit as an adjective built from its seat's name.
+
     Canada carries a unit whose own name joins two places with `and`, and Czechia and Slovakia
     stand in for the successors of a state GADM no longer models.
 
@@ -526,6 +528,25 @@ def toy_gadm() -> gpd.GeoDataFrame:
         # GADM writes an unnamed Ukrainian unit as `?` at both levels, so it comes out its own parent.
         ("UKR", "Ukraine", "?", "?", "", "?", "?", "", "", "", "", "", box(10, 0, 11, 1)),
         ("GHA", "Ghana", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", "", "", box(8, 0, 9, 1)),
+        # Poland, where a mention is the adjective built from the seat GADM publishes. `Rybnik`
+        # and `Rybno` share the stem the adjective leaves, so one adjective settles nothing.
+        (
+            "POL",
+            "Poland",
+            "POL.1_1",
+            "Podkarpackie",
+            "",
+            "POL.1.1_1",
+            "Tarnobrzeg",
+            "",
+            "",
+            "",
+            "",
+            "",
+            box(28, 0, 29, 1),
+        ),
+        ("POL", "Poland", "POL.2_1", "Slaskie", "", "POL.2.1_1", "Rybnik", "", "", "", "", "", box(30, 0, 31, 1)),
+        ("POL", "Poland", "POL.2_1", "Slaskie", "", "POL.2.2_1", "Rybno", "", "", "", "", "", box(31, 0, 32, 1)),
     ]
     columns = (
         "GID_0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,6 +445,9 @@ def toy_gadm() -> gpd.GeoDataFrame:
         # 111 ambiguous mentions in the workbook are a province and a same-named district.
         ("LAO", "Laos", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", "", "", box(4, 0, 5, 1)),
         ("ZMB", "Zambia", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", "", "", box(6, 0, 7, 1)),
+        # A district whose name is short enough to be a syllable of another, which is what a dash
+        # split has to refuse: `Ali-Shan` is one mountain and both halves are Chinese counties.
+        ("LAO", "Laos", "LAO.2_1", "Bokeo", "", "LAO.2.4_1", "Xay", "", "", "", "", "", box(7, 0, 8, 1)),
         # `Nam Bay` is one edit from this district and names a bay, which is the collision an
         # approximate match has to refuse: `Manila Bay` reaches a barangay called Manlabay.
         ("LAO", "Laos", "LAO.2_1", "Bokeo", "", "LAO.2.3_1", "Nambak", "", "", "", "", "", box(5, 0, 6, 1)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,6 +384,8 @@ def toy_gadm() -> gpd.GeoDataFrame:
     `LAO.1.2.1_1` is the seat named after the district holding it, which is what most ambiguous
     mentions turn out to be: candidates on one nesting chain rather than places in two locations.
 
+    Canada carries a unit whose own name joins two places with `and`.
+
     Ukraine carries GADM's placeholder identifier, which is the string `?` at both levels and
     therefore parents itself. Walking a unit's containers without a visited set never terminates.
 
@@ -437,6 +439,21 @@ def toy_gadm() -> gpd.GeoDataFrame:
         # 111 ambiguous mentions in the workbook are a province and a same-named district.
         ("LAO", "LAO.2_1", "Bokeo", "", "LAO.2.2_1", "Attapu", "", "", "", "", "", box(4, 0, 5, 1)),
         ("ZMB", "ZMB.1_1", "Central", "", "ZMB.1.1_1", "Kabwe", "", "", "", "", "", box(6, 0, 7, 1)),
+        # 75 GADM units carry a conjunction in their own name, which a split on `and` destroys.
+        (
+            "CAN",
+            "CAN.5_1",
+            "Newfoundland and Labrador",
+            "",
+            "CAN.5.1_1",
+            "Division No. 1",
+            "",
+            "",
+            "",
+            "",
+            "",
+            box(12, 0, 13, 1),
+        ),
         # GADM writes an unnamed Ukrainian unit as `?` at both levels, so it comes out its own parent.
         ("UKR", "?", "?", "", "?", "?", "", "", "", "", "", box(10, 0, 11, 1)),
         ("GHA", "GHA11_2", "Savannah", "", "GHA7.13_2", "Ga Central", "", "", "", "", "", box(8, 0, 9, 1)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -617,3 +617,57 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "network" in item.keywords:
             item.add_marker(skip_network)
+
+
+def toy_geonames() -> str:
+    """Rows shaped like a GeoNames country dump: headerless, tab-separated, nineteen fields.
+
+    Bacolod is published under three spellings and shares its name with a far smaller barangay,
+    which is the collision that decides whether a written mention reaches the city or the hamlet.
+    """
+    rows = [
+        (
+            "1",
+            "Bacolod",
+            "Bacolod",
+            "Bacolod City,Bakolod",
+            "10.667",
+            "122.95",
+            "P",
+            "PPL",
+            "PH",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "561875",
+        ),
+        ("2", "Bacolod", "Bacolod", "", "8.5", "124.1", "P", "PPL", "PH", "", "", "", "", "", "0"),
+        ("3", "Iloilo", "Iloilo", "Ilo-ilo", "10.7", "122.567", "P", "PPLA", "PH", "", "", "", "", "", "457626"),
+        ("4", "Sulu Sea", "Sulu Sea", "", "8.0", "120.0", "H", "SEA", "PH", "", "", "", "", "", "0"),
+    ]
+    padding = ("", "", "", "")
+
+    return "\n".join("\t".join(row + padding) for row in rows) + "\n"
+
+
+COUNTRY_INFO_HEADER = "#ISO\tISO3\tISO-Numeric\tfips\tCountry\n"
+
+
+@pytest.fixture
+def write_geonames_cache(tmp_path):
+    """Return a callable writing a GeoNames-shaped dump into the cache, and giving back the root."""
+
+    def write(rows=None, *, alpha2="PH", alpha3="PHL"):
+        directory = tmp_path / "geonames"
+        directory.mkdir(exist_ok=True)
+        (directory / "countryInfo.txt").write_text(
+            COUNTRY_INFO_HEADER + f"{alpha2}\t{alpha3}\t608\tRP\tPhilippines\n", encoding="utf-8"
+        )
+        with zipfile.ZipFile(directory / f"{alpha2}.zip", "w") as archive:
+            archive.writestr(f"{alpha2}.txt", toy_geonames() if rows is None else rows)
+
+        return tmp_path
+
+    return write

--- a/tests/data/test_cache.py
+++ b/tests/data/test_cache.py
@@ -10,7 +10,7 @@ from geopandas.testing import assert_geodataframe_equal
 from polars.testing import assert_frame_equal
 from shapely.geometry import Point
 
-from climate_risk.data.cache import cache_key, cached, geo_parquet, pandas_parquet, polars_parquet
+from climate_risk.data.cache import builder_fingerprint, cache_key, cached, geo_parquet, pandas_parquet, polars_parquet
 
 
 @pytest.fixture
@@ -161,3 +161,55 @@ def test_a_polars_date_column_keeps_its_type(tmp_path):
     cached(tmp_path, "co2", lambda: frame, polars_parquet())
 
     assert cached(tmp_path, "co2", lambda: frame, polars_parquet()).schema["Date"] == pl.Date
+
+
+def test_two_builders_named_alike_but_reading_differently_fingerprint_differently():
+    """Every builder in this package is called `build`, so a fingerprint taken from the name would
+    be one value shared by every cached artefact. What has to reach the key is the rule that
+    changed, which lives only in the body."""
+
+    def builder(keep_every_row: bool):
+        if keep_every_row:
+
+            def build() -> str:
+                return "every row"
+        else:
+
+            def build() -> str:
+                return "only the rows that are named"
+
+        return build
+
+    assert builder_fingerprint(builder(True)) != builder_fingerprint(builder(False))
+
+
+def test_the_same_builder_fingerprints_the_same_every_time():
+    """A digest that moved between runs would rebuild every artefact on every process start."""
+
+    def build() -> str:
+        return "unchanged"
+
+    assert builder_fingerprint(build) == builder_fingerprint(build)
+
+
+def test_a_builder_closing_over_different_values_fingerprints_the_same():
+    """The closure's values are what `params` is for. Folding them in here would key one entry per
+    country twice over, and every cached artefact would miss."""
+
+    def builder_for(iso: str):
+        def build() -> str:
+            return iso
+
+        return build
+
+    assert builder_fingerprint(builder_for("LAO")) == builder_fingerprint(builder_for("ZMB"))
+
+
+def test_a_builder_reading_a_different_table_fingerprints_differently():
+    """A builder's source does not show the module tables it consults, so changing one changes the
+    artefact with nothing in the key to say so."""
+
+    def build() -> str:
+        return "unchanged"
+
+    assert builder_fingerprint(build, {"ETH": ("ERI",)}) != builder_fingerprint(build, {})

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -77,7 +77,7 @@ def test_an_id_gadm_does_not_hold_is_an_error_not_a_dropped_row(write_gadm_cache
 
 
 def test_a_level_gadm_is_not_read_at_is_rejected(write_gadm_cache):
-    """Units are read at level 1 and 2; anything else would silently match nothing."""
+    """Units are read at levels 1 through 4; anything else would silently match nothing."""
     cache_dir = write_gadm_cache()
 
     with pytest.raises(DataValidationError, match="read at levels"):
@@ -100,6 +100,32 @@ def test_a_country_reads_back_every_unit_it_holds_at_a_level(write_gadm_cache):
 
     assert sorted(provinces["gid"]) == ["LAO.1_1", "LAO.2_1"]
     assert set(provinces["admin_level"]) == {1}
+
+
+def test_a_country_reads_back_the_villages_below_its_districts(write_gadm_cache):
+    """Written locations name units below adm2 — 18% of the places that resolve are adm3 or adm4 —
+    and scoring a point against one needs its polygon."""
+    cache_dir = write_gadm_cache()
+
+    villages = load_units_in_country("LAO", 3, cache_dir)
+
+    assert sorted(villages["gid"]) == ["LAO.1.1.1_1", "LAO.1.2.1_1", "LAO.2.1.1_1"]
+
+
+def test_a_country_not_divided_at_a_level_reads_back_empty(write_gadm_cache):
+    """GADM stores a blank identifier rather than omitting the row, so dissolving without dropping
+    those yields one phantom unit whose id is the empty string and whose polygon is the country."""
+    cache_dir = write_gadm_cache()
+
+    assert load_units_in_country("LAO", 4, cache_dir).empty
+
+
+def test_a_unit_below_adm2_resolves_to_its_polygon(write_gadm_cache):
+    cache_dir = write_gadm_cache()
+
+    units = load_admin_units([("LAO.1.1.1_1", 3)], cache_dir)
+
+    assert list(units["name"]) == ["Ban Mai"]
 
 
 def test_a_country_reads_back_its_districts(write_gadm_cache):

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -134,7 +134,7 @@ def test_a_country_reads_back_its_districts(write_gadm_cache):
 
     districts = load_units_in_country("LAO", 2, cache_dir)
 
-    assert sorted(districts["name"]) == ["Attapu", "Houayxay", "Samakhixay", "Sanamxay"]
+    assert sorted(districts["name"]) == ["Attapu", "Houayxay", "Nambak", "Samakhixay", "Sanamxay"]
 
 
 def test_a_province_spanning_several_districts_is_one_row(write_gadm_cache):

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -108,7 +108,7 @@ def test_a_country_reads_back_its_districts(write_gadm_cache):
 
     districts = load_units_in_country("LAO", 2, cache_dir)
 
-    assert sorted(districts["name"]) == ["Houayxay", "Samakhixay", "Sanamxay"]
+    assert sorted(districts["name"]) == ["Attapu", "Houayxay", "Samakhixay", "Sanamxay"]
 
 
 def test_a_province_spanning_several_districts_is_one_row(write_gadm_cache):

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -7,7 +7,14 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from climate_risk.data.gadm import GADM, gadm_dir, gadm_path, load_admin_units, load_units_in_country
+from climate_risk.data.gadm import (
+    GADM,
+    administered_territories,
+    gadm_dir,
+    gadm_path,
+    load_admin_units,
+    load_units_in_country,
+)
 from climate_risk.data_functions.emdat_processing import load_emdat_events
 from climate_risk.exceptions import DataValidationError
 
@@ -249,3 +256,13 @@ def test_an_empty_request_still_carries_the_crs(write_gadm_cache):
     assert units.empty
     assert units.crs == "EPSG:4326"
     assert list(units.columns) == ["gid", "name", "admin_level", "geometry"]
+
+
+def test_a_country_names_the_disputed_territory_it_administers(write_gadm_cache):
+    """Kashmir is filed under a code of its own, so an Indian event named there reaches nothing
+    unless the country's own code is read together with what it administers."""
+    assert administered_territories("IND", write_gadm_cache()) == ("Z01",)
+
+
+def test_a_country_administering_nothing_names_nothing(write_gadm_cache):
+    assert administered_territories("LAO", write_gadm_cache()) == ()

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -141,7 +141,7 @@ def test_a_country_reads_back_its_districts(write_gadm_cache):
 
     districts = load_units_in_country("LAO", 2, cache_dir)
 
-    assert sorted(districts["name"]) == ["Attapu", "Houayxay", "Nambak", "Samakhixay", "Sanamxay"]
+    assert sorted(districts["name"]) == ["Attapu", "Houayxay", "Nambak", "Samakhixay", "Sanamxay", "Xay"]
 
 
 def test_a_province_spanning_several_districts_is_one_row(write_gadm_cache):

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -4,9 +4,11 @@ import sqlite3
 
 from pathlib import Path
 
+import geopandas as gpd
 import polars as pl
 import pytest
 
+from climate_risk.data import gadm
 from climate_risk.data.gadm import (
     GADM,
     administered_territories,
@@ -279,3 +281,31 @@ def test_a_country_read_twice_reads_the_same_units(write_gadm_cache):
     assert list(from_cache["gid"]) == list(built["gid"])
     assert from_cache.geometry.equals(built.geometry)
     assert from_cache.crs == built.crs
+
+
+def test_one_layer_does_not_answer_for_another(write_gadm_cache):
+    """`layer` chooses which table is read, so two layers are two different questions. Keyed alike
+    they collide, and the second caller is handed the first one's geometry."""
+    cache_dir = write_gadm_cache()
+    archive = cache_dir / "gadm" / "gadm_410.gpkg"
+    everything = gpd.read_file(archive, layer="gadm_410")
+    everything[everything["GID_0"] == "ZMB"].to_file(archive, layer="zambia_only")
+
+    from_the_whole_world = load_units_in_country("LAO", 2, cache_dir)
+    from_zambia_only = load_units_in_country("LAO", 2, cache_dir, layer="zambia_only")
+
+    assert not from_the_whole_world.empty
+    assert from_zambia_only.empty, "a layer holding no Laos must not answer with another layer's units"
+
+
+def test_changing_which_columns_a_level_reads_turns_the_cached_geometry_over(write_gadm_cache, monkeypatch):
+    """The columns each level is read from live in a table the builder consults, which its own source
+    does not show. Pointing level 2 at level 1's columns returns provinces where districts were
+    cached, and nothing else in the key would say so."""
+    cache_dir = write_gadm_cache()
+    districts = load_units_in_country("LAO", 2, cache_dir)
+
+    monkeypatch.setattr(gadm, "GID_COLUMNS", {**gadm.GID_COLUMNS, 2: ("GID_1", "NAME_1")})
+    reread = load_units_in_country("LAO", 2, cache_dir)
+
+    assert sorted(reread["gid"]) != sorted(districts["gid"])

--- a/tests/data/test_gadm.py
+++ b/tests/data/test_gadm.py
@@ -266,3 +266,16 @@ def test_a_country_names_the_disputed_territory_it_administers(write_gadm_cache)
 
 def test_a_country_administering_nothing_names_nothing(write_gadm_cache):
     assert administered_territories("LAO", write_gadm_cache()) == ()
+
+
+def test_a_country_read_twice_reads_the_same_units(write_gadm_cache):
+    """Reading a country's polygons out of the GeoPackage takes seconds, so the result is cached;
+    a cache hit has to carry the same units and the same geometry as the build."""
+    cache_dir = write_gadm_cache()
+
+    built = load_units_in_country("LAO", 2, cache_dir, force_reload=True)
+    from_cache = load_units_in_country("LAO", 2, cache_dir)
+
+    assert list(from_cache["gid"]) == list(built["gid"])
+    assert from_cache.geometry.equals(built.geometry)
+    assert from_cache.crs == built.crs

--- a/tests/data/test_geo_disasters.py
+++ b/tests/data/test_geo_disasters.py
@@ -373,7 +373,7 @@ def test_an_event_geocoded_at_both_levels_keeps_both(write_gadm_cache):
     """Footprints are dissolved per level, not per event. Dissolving across levels would union a
     province with a district somewhere else and place the pair against whichever level ran first."""
     cache_dir = write_gadm_cache()
-    at_both = pd.concat([footprints_over((3, 0, 4, 1), level=1), footprints_over((0, 0, 1, 1), level=2)])
+    at_both = pd.concat([footprints_over((3, 0, 5, 1), level=1), footprints_over((0, 0, 1, 1), level=2)])
 
     resolved = resolve_to_gadm(gpd.GeoDataFrame(at_both, crs="EPSG:4326"), cache_dir)
 

--- a/tests/data/test_geocoding.py
+++ b/tests/data/test_geocoding.py
@@ -1,0 +1,89 @@
+from climate_risk.data.geocoding import (
+    ELSEWHERE,
+    IN_ITS_PROVINCE,
+    IN_THE_UNIT,
+    NO_POINT,
+    score_geocoder,
+    unambiguous_units,
+)
+from climate_risk.data.place_names import read_gazetteer
+
+
+def test_only_names_reaching_one_unit_become_an_answer_key(write_gadm_cache):
+    """A name reaching two units cannot judge a point: whichever the geocoder picked, the other was
+    available. A third of the places that resolve are ambiguous, so this is most of the workbook."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    settled = unambiguous_units([("Sanamxay", None), ("Attapu", None), ("Bokeo", None)], gazetteer)
+
+    assert settled == {"Sanamxay": "LAO.1.1_1", "Bokeo": "LAO.2_1"}
+
+
+def test_a_point_inside_the_named_unit_scores_as_placed(write_gadm_cache):
+    cache_dir = write_gadm_cache()
+    gazetteer = read_gazetteer("LAO", cache_dir)
+
+    scored = score_geocoder(lambda _, __: (0.5, 0.5), "LAO", [("Sanamxay", None)], gazetteer, cache_dir)
+
+    assert scored == [("Sanamxay", "LAO.1.1_1", IN_THE_UNIT)]
+
+
+def test_a_point_in_the_right_province_but_the_wrong_district_is_told_apart(write_gadm_cache):
+    """Whether a source is usable turns on this outcome. A geocoder landing in the province is
+    worth aggregating upwards; one landing in the wrong province is worth nothing."""
+    cache_dir = write_gadm_cache()
+    gazetteer = read_gazetteer("LAO", cache_dir)
+
+    scored = score_geocoder(lambda _, __: (1.5, 0.5), "LAO", [("Sanamxay", None)], gazetteer, cache_dir)
+
+    assert scored == [("Sanamxay", "LAO.1.1_1", IN_ITS_PROVINCE)]
+
+
+def test_a_point_in_another_province_scores_as_misplaced(write_gadm_cache):
+    cache_dir = write_gadm_cache()
+    gazetteer = read_gazetteer("LAO", cache_dir)
+
+    scored = score_geocoder(lambda _, __: (3.5, 0.5), "LAO", [("Sanamxay", None)], gazetteer, cache_dir)
+
+    assert scored == [("Sanamxay", "LAO.1.1_1", ELSEWHERE)]
+
+
+def test_a_place_the_geocoder_does_not_know_is_not_counted_as_wrong(write_gadm_cache):
+    """Coverage and accuracy are separate decisions — a source that answers rarely and correctly is
+    worth combining with another, and folding the silences into the error rate hides that."""
+    cache_dir = write_gadm_cache()
+    gazetteer = read_gazetteer("LAO", cache_dir)
+
+    scored = score_geocoder(lambda _, __: None, "LAO", [("Sanamxay", None)], gazetteer, cache_dir)
+
+    assert scored == [("Sanamxay", "LAO.1.1_1", NO_POINT)]
+
+
+def test_a_unit_that_is_already_a_province_is_judged_against_itself(write_gadm_cache):
+    """Half the countries in the archive stop at adm1 or adm2, so the named unit is often the
+    level-1 one and there is no coarser answer to fall back to."""
+    cache_dir = write_gadm_cache()
+    gazetteer = read_gazetteer("LAO", cache_dir)
+
+    scored = score_geocoder(lambda _, __: (4.5, 0.5), "LAO", [("Bokeo", None)], gazetteer, cache_dir)
+
+    assert scored == [("Bokeo", "LAO.2_1", IN_THE_UNIT)]
+
+
+def test_a_village_is_scored_against_its_own_polygon_not_its_district(write_gadm_cache):
+    """The resolver reaches adm3 and adm4, and scoring those against the district holding them
+    would pass a geocoder that never resolves finer than adm2."""
+    cache_dir = write_gadm_cache()
+    gazetteer = read_gazetteer("LAO", cache_dir)
+
+    scored = score_geocoder(lambda _, __: (1.5, 0.5), "LAO", [("Samakhixay", None)], gazetteer, cache_dir)
+
+    assert scored == [("Samakhixay", "LAO.1.2_1", IN_THE_UNIT)]
+
+
+def test_nothing_to_check_against_reads_back_empty(write_gadm_cache):
+    """Two fifths of written places name no GADM unit, and a country can supply none at all."""
+    cache_dir = write_gadm_cache()
+    gazetteer = read_gazetteer("LAO", cache_dir)
+
+    assert score_geocoder(lambda _, __: (0.5, 0.5), "LAO", [("Calabarzon", None)], gazetteer, cache_dir) == []

--- a/tests/data/test_geocoding.py
+++ b/tests/data/test_geocoding.py
@@ -122,3 +122,13 @@ def test_nothing_to_place_reads_the_archive_not_at_all(write_gadm_cache):
     """Most countries have no unresolved names left by the time a point is wanted, and reading a
     country's polygons to place nothing is the expensive half of the run."""
     assert units_containing_points({}, "LAO", write_gadm_cache()) == {}
+
+
+def test_a_point_in_a_disputed_territory_is_placed_for_the_country_administering_it(write_gadm_cache):
+    """GADM files Kashmir under codes of its own, so a point there falls in no Indian unit and is
+    discarded — eighty-four rows, on coordinates that were right all along."""
+    cache_dir = write_gadm_cache()
+
+    placed = units_containing_points({"somewhere": (22.5, 0.5)}, "IND", cache_dir)
+
+    assert placed == {"somewhere": "Z01.1.1_1"}

--- a/tests/data/test_geocoding.py
+++ b/tests/data/test_geocoding.py
@@ -5,6 +5,7 @@ from climate_risk.data.geocoding import (
     NO_POINT,
     score_geocoder,
     unambiguous_units,
+    units_containing_points,
 )
 from climate_risk.data.place_names import read_gazetteer
 
@@ -87,3 +88,37 @@ def test_nothing_to_check_against_reads_back_empty(write_gadm_cache):
     gazetteer = read_gazetteer("LAO", cache_dir)
 
     assert score_geocoder(lambda _, __: (0.5, 0.5), "LAO", [("Calabarzon", None)], gazetteer, cache_dir) == []
+
+
+def test_a_point_is_placed_in_the_finest_unit_holding_it(write_gadm_cache):
+    """A province spans fourteen districts at the median, so taking the first level that matches
+    would throw away most of what the point knows."""
+    cache_dir = write_gadm_cache()
+
+    placed = units_containing_points({"somewhere": (0.5, 0.5)}, "LAO", cache_dir)
+
+    assert placed == {"somewhere": "LAO.1.1.1_1"}, "the village, not the district or the province"
+
+
+def test_a_point_outside_the_finest_level_still_reaches_a_coarser_unit(write_gadm_cache):
+    """Most countries are not divided all the way down, and a point in one of them is still worth
+    the unit that does hold it."""
+    cache_dir = write_gadm_cache()
+
+    placed = units_containing_points({"somewhere": (4.5, 0.5)}, "LAO", cache_dir)
+
+    assert placed == {"somewhere": "LAO.2.2_1"}, "no village covers this, the district does"
+
+
+def test_a_point_outside_the_country_is_placed_nowhere(write_gadm_cache):
+    """EM-DAT names places in neighbouring countries and at sea, and a point nothing holds is not
+    an answer."""
+    cache_dir = write_gadm_cache()
+
+    assert units_containing_points({"somewhere": (99.0, 99.0)}, "LAO", cache_dir) == {}
+
+
+def test_nothing_to_place_reads_the_archive_not_at_all(write_gadm_cache):
+    """Most countries have no unresolved names left by the time a point is wanted, and reading a
+    country's polygons to place nothing is the expensive half of the run."""
+    assert units_containing_points({}, "LAO", write_gadm_cache()) == {}

--- a/tests/data/test_geocoding.py
+++ b/tests/data/test_geocoding.py
@@ -6,6 +6,7 @@ from climate_risk.data.geocoding import (
     score_geocoder,
     unambiguous_units,
     units_containing_points,
+    units_from_geocoders,
 )
 from climate_risk.data.place_names import read_gazetteer
 
@@ -132,3 +133,35 @@ def test_a_point_in_a_disputed_territory_is_placed_for_the_country_administering
     placed = units_containing_points({"somewhere": (22.5, 0.5)}, "IND", cache_dir)
 
     assert placed == {"somewhere": "Z01.1.1_1"}
+
+
+def test_the_first_source_to_place_a_name_keeps_it(write_gadm_cache):
+    """Sources are asked in order of how much they are trusted, so a later one must not overwrite an
+    answer an earlier one already gave."""
+    cache_dir = write_gadm_cache()
+    trusted = lambda _, name: (0.5, 0.5) if name == "Somewhere" else None  # noqa: E731 - a stub, not a definition
+    other = lambda _, name: (3.5, 0.5) if name == "Somewhere" else None  # noqa: E731 - a stub, not a definition
+
+    placed = units_from_geocoders(["Somewhere"], "LAO", cache_dir, (trusted, other))
+
+    assert placed == {"Somewhere": "LAO.1.1.1_1"}
+
+
+def test_a_later_source_answers_for_what_the_first_could_not_place(write_gadm_cache):
+    """Adding a source is only worth doing if it reaches names the ones before it missed."""
+    cache_dir = write_gadm_cache()
+    sparse = lambda _, name: None  # noqa: E731 - a stub, not a definition
+    dense = lambda _, name: (0.5, 0.5)  # noqa: E731 - a stub, not a definition
+
+    placed = units_from_geocoders(["Somewhere"], "LAO", cache_dir, (sparse, dense))
+
+    assert placed == {"Somewhere": "LAO.1.1.1_1"}
+
+
+def test_a_point_outside_every_unit_is_not_passed_on_as_a_placement(write_gadm_cache):
+    """A geocoder answering with a point in the sea, or in the country next door, has not placed the
+    name — and a wrong unit is worse than none, because nothing downstream can tell."""
+    cache_dir = write_gadm_cache()
+    offshore = lambda _, name: (-40.0, -40.0)  # noqa: E731 - a stub, not a definition
+
+    assert units_from_geocoders(["Somewhere"], "LAO", cache_dir, (offshore,)) == {}

--- a/tests/data/test_geonames.py
+++ b/tests/data/test_geonames.py
@@ -1,0 +1,66 @@
+from climate_risk.data.geonames import (
+    GEONAMES_LICENCE,
+    country_dump,
+    geonames_geocoder,
+    load_place_points,
+    read_country_codes,
+)
+
+
+def test_a_country_is_looked_up_by_the_code_geonames_files_it_under(write_geonames_cache):
+    """EM-DAT keys on alpha-3 and GeoNames publishes on alpha-2, so every lookup crosses that gap."""
+    codes = read_country_codes(write_geonames_cache())
+
+    assert codes["PHL"] == "PH"
+
+
+def test_a_dump_is_declared_under_the_licence_it_is_published_with():
+    """The archive is redistributable only with attribution, and the declaration is what carries it."""
+    assert country_dump("PH").licence == GEONAMES_LICENCE
+
+
+def test_every_spelling_a_place_is_published_under_reaches_it(write_geonames_cache):
+    """Written mentions use whichever spelling the reporter had; a lookup on the primary name alone
+    misses the alternates, which is where exonyms and older names live."""
+    locate = geonames_geocoder("PHL", write_geonames_cache())
+
+    assert locate("PHL", "Bacolod") == locate("PHL", "Bakolod") == (122.95, 10.667)
+
+
+def test_the_most_populous_place_keeps_a_shared_name(write_geonames_cache):
+    """A city and a hamlet share a name far more often than not. Taking whichever was read first
+    puts a national-scale disaster in a village."""
+    locate = geonames_geocoder("PHL", write_geonames_cache())
+
+    assert locate("PHL", "Bacolod") == (122.95, 10.667), "the city, not the barangay at 8.5N"
+
+
+def test_a_place_the_dump_does_not_carry_answers_with_nothing(write_geonames_cache):
+    """Two fifths of written places are misspelled, relational or not places at all, and the
+    scoring rig counts a silence apart from a wrong answer."""
+    locate = geonames_geocoder("PHL", write_geonames_cache())
+
+    assert locate("PHL", "Bocolod") is None
+
+
+def test_a_mention_carrying_a_unit_noun_still_reaches_the_place(write_geonames_cache):
+    """EM-DAT writes `Iloilo city` where GeoNames writes `Iloilo`, so both sides have to be keyed
+    the same way for the two to meet."""
+    locate = geonames_geocoder("PHL", write_geonames_cache())
+
+    assert locate("PHL", "Iloilo city") == (122.567, 10.7)
+
+
+def test_a_dump_row_that_is_not_a_settlement_is_still_indexed(write_geonames_cache):
+    """Seas and straits are 8% of what fails to resolve. They belong to no administrative unit, but
+    a point in one still says where an event was."""
+    locate = geonames_geocoder("PHL", write_geonames_cache())
+
+    assert locate("PHL", "Sulu Sea") == (120.0, 8.0)
+
+
+def test_the_places_table_carries_one_row_for_each_distinct_name(write_geonames_cache):
+    """Two spellings of one place are two ways in; two places sharing a spelling are one row."""
+    points = load_place_points("PHL", write_geonames_cache())
+
+    assert sorted(points["key"]) == ["bacolod", "bakolod", "iloilo", "sulusea"]

--- a/tests/data/test_geonames.py
+++ b/tests/data/test_geonames.py
@@ -1,3 +1,6 @@
+import re
+
+from climate_risk.data import geonames, place_names
 from climate_risk.data.geonames import (
     GEONAMES_LICENCE,
     country_dump,
@@ -64,3 +67,29 @@ def test_the_places_table_carries_one_row_for_each_distinct_name(write_geonames_
     points = load_place_points("PHL", write_geonames_cache())
 
     assert sorted(points["key"]) == ["bacolod", "bakolod", "iloilo", "sulusea"]
+
+
+def test_changing_how_a_name_is_keyed_turns_the_cached_places_over(write_geonames_cache, monkeypatch):
+    """The places table is keyed by `match_key`, the same as the gazetteer it is matched against.
+    Cached on the country alone it serves keys built under rules that no longer apply, and every
+    mention whose key moved stops reaching its point."""
+    cache_dir = write_geonames_cache()
+    load_place_points("PHL", cache_dir)
+
+    monkeypatch.setattr(place_names, "UNIT_NOUNS", re.compile(r"\b(bacolod)\b", re.IGNORECASE))
+    rekeyed = load_place_points("PHL", cache_dir)
+
+    assert "bacolod" not in rekeyed["key"].to_list(), "the stripped word cannot survive as a key"
+
+
+def test_changing_which_columns_the_dump_is_read_from_turns_the_cached_places_over(write_geonames_cache, monkeypatch):
+    """The dump is headerless, so which field is latitude lives in a table the builder consults and
+    its own source never shows. Reading them the other way round puts every place in the wrong
+    hemisphere, and a cache that cannot see that table change keeps serving the old points."""
+    cache_dir = write_geonames_cache()
+    upright = load_place_points("PHL", cache_dir)
+
+    monkeypatch.setattr(geonames, "DUMP_FIELDS", {**geonames.DUMP_FIELDS, 4: "lon", 5: "lat"})
+    swapped = load_place_points("PHL", cache_dir)
+
+    assert swapped.sort("key")["lat"].to_list() != upright.sort("key")["lat"].to_list()

--- a/tests/data/test_osm.py
+++ b/tests/data/test_osm.py
@@ -1,0 +1,161 @@
+import contextlib
+
+import polars as pl
+import pytest
+import requests
+
+from climate_risk.data import osm
+from climate_risk.data.osm import (
+    OSM_LICENCE,
+    PLACE_CATEGORIES,
+    NominatimAnswer,
+    osm_geocoder,
+    read_osm_places,
+    record_lookups,
+)
+from climate_risk.exceptions import UpstreamUnavailableError
+
+# Nominatim answers over the wire, where every field is a string.
+A_VILLAGE = {"lon": "1.23", "lat": "6.16", "category": "place", "type": "village"}
+
+
+class _FakeResponse:
+    """Stands in for what `requests` hands back, so no socket is opened."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_a_place_reaches_the_point_osm_gave_it(write_osm_cache):
+    """The whole point of the cache: a name GADM never published still reaches a coordinate."""
+    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")])
+
+    assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole") == (1.23, 6.16)
+
+
+def test_a_pharmacy_named_after_a_village_is_not_offered_as_the_village(write_osm_cache):
+    """Nominatim answers with whatever carries the name. Of 30 hits on the residual, over half were
+    a building, a road or an amenity — each of which lands a point somewhere plausible and wrong."""
+    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 9.99, 9.99, "amenity", "pharmacy")])
+
+    assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole") is None
+
+
+def test_a_name_osm_could_not_find_is_remembered_as_unfound(write_osm_cache):
+    """A miss is a result. Without keeping it, every rebuild asks Nominatim the whole question again,
+    which is the one thing its usage policy forbids."""
+    cache_dir = write_osm_cache([("nowhere", "Nowhere At All", None, None, None, None)])
+
+    assert osm_geocoder("LAO", cache_dir)("LAO", "Nowhere At All") is None
+    assert read_osm_places("LAO", cache_dir)["written"].to_list() == ["Nowhere At All"]
+
+
+def test_a_mention_carrying_a_unit_noun_still_reaches_the_point(write_osm_cache):
+    """EM-DAT says what kind of unit it means; the crawl asked under the name alone."""
+    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")])
+
+    assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole village") == (1.23, 6.16)
+
+
+def test_a_country_nobody_has_crawled_answers_with_nothing(tmp_path):
+    """A cold cache is a country not yet asked about, not an error: the resolver falls through to
+    every other reading exactly as it does when GeoNames has no dump."""
+    assert osm_geocoder("LAO", tmp_path)("LAO", "Dzidzole") is None
+
+
+def test_answers_recorded_twice_keep_the_later_one(write_osm_cache):
+    """A recrawl after Nominatim improves its data must not leave two rows for one name, which
+    would resolve on file order."""
+    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 0.0, 0.0, "amenity", "pharmacy")])
+
+    record_lookups("LAO", cache_dir, {"Dzidzole": NominatimAnswer(1.23, 6.16, "place", "village")})
+
+    assert read_osm_places("LAO", cache_dir).height == 1
+    assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole") == (1.23, 6.16)
+
+
+def test_recording_an_answer_leaves_the_names_already_asked_about_alone(write_osm_cache):
+    """The crawl runs country by country over many sittings, and each one has to add to the cache
+    rather than replace it."""
+    cache_dir = write_osm_cache([("kegue", "Kegue", 1.22, 6.19, "place", "quarter")])
+
+    record_lookups(
+        "LAO", cache_dir, {"Dzidzole": NominatimAnswer(1.23, 6.16, "place", "village"), "Nowhere At All": None}
+    )
+
+    assert sorted(read_osm_places("LAO", cache_dir)["written"].to_list()) == ["Dzidzole", "Kegue", "Nowhere At All"]
+
+
+def test_a_miss_is_recorded_with_no_coordinates(write_osm_cache):
+    cache_dir = write_osm_cache([])
+
+    recorded = record_lookups("LAO", cache_dir, {"Nowhere At All": None})
+
+    assert recorded.filter(pl.col("written") == "Nowhere At All")["lon"].to_list() == [None]
+
+
+def test_one_country_does_not_answer_for_another(write_osm_cache):
+    """Nominatim was asked with the country fixed, so an answer is only good for that country."""
+    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")], iso="TGO")
+
+    assert osm_geocoder("TGO", cache_dir)("TGO", "Dzidzole") == (1.23, 6.16)
+    assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole") is None
+
+
+def test_openstreetmap_is_declared_under_the_licence_it_is_published_with():
+    """ODbL carries attribution and share-alike obligations that the other sources here do not, so
+    the terms travel with the data rather than living in a README."""
+    assert OSM_LICENCE == "ODbL 1.0"
+
+
+@pytest.mark.parametrize("category", PLACE_CATEGORIES)
+def test_every_trusted_category_is_actually_offered(write_osm_cache, category):
+    """The filter is the only thing standing between a point and a wrong province, so a category
+    named in it that the geocoder then drops would be silently useless."""
+    cache_dir = write_osm_cache([("somewhere", "Somewhere", 1.0, 2.0, category, "whatever")])
+
+    assert osm_geocoder("LAO", cache_dir)("LAO", "Somewhere") == (1.0, 2.0)
+
+
+def test_a_request_that_never_reached_nominatim_is_not_an_answer(monkeypatch):
+    """A failed request and a name Nominatim has no place for are different facts. Conflating them
+    caches a permanent absence for a name nobody ever managed to ask about, and nothing afterwards
+    can tell it from a real one — which is the whole value of caching the misses."""
+    monkeypatch.setattr(osm.requests, "get", lambda *_, **__: (_ for _ in ()).throw(requests.ConnectionError()))
+    monkeypatch.setattr(osm.time, "sleep", lambda _: None)
+
+    with pytest.raises(UpstreamUnavailableError, match="Dzidzole"):
+        osm.search_nominatim("Dzidzole", "tg")
+
+
+def test_a_name_nominatim_has_no_place_for_is_an_answer(monkeypatch):
+    """The other half of the same contract: an empty result is a fact worth caching, not a failure."""
+    monkeypatch.setattr(osm.requests, "get", lambda *_, **__: _FakeResponse([]))
+    monkeypatch.setattr(osm.time, "sleep", lambda _: None)
+
+    assert osm.search_nominatim("Nowhere At All", "tg") is None
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [lambda *a, **k: _FakeResponse([A_VILLAGE]), lambda *a, **k: (_ for _ in ()).throw(requests.ConnectionError())],
+    ids=["an answer", "a failure"],
+)
+def test_every_request_waits_out_the_rate_limit(monkeypatch, answer):
+    """One request a second is a condition of using the public instance, not a tuning knob. A crawl
+    that skips the wait after a failed request gets the project blocked, so the wait is in the
+    `finally` and both paths are held to it."""
+    waited: list[float] = []
+    monkeypatch.setattr(osm.requests, "get", answer)
+    monkeypatch.setattr(osm.time, "sleep", waited.append)
+
+    with contextlib.suppress(UpstreamUnavailableError):
+        osm.search_nominatim("Dzidzole", "tg")
+
+    assert waited == [osm.RATE_LIMIT_SECONDS]

--- a/tests/data/test_osm.py
+++ b/tests/data/test_osm.py
@@ -34,7 +34,7 @@ class _FakeResponse:
 
 def test_a_place_reaches_the_point_osm_gave_it(write_osm_cache):
     """The whole point of the cache: a name GADM never published still reaches a coordinate."""
-    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")])
+    cache_dir = write_osm_cache([("Dzidzole", 1.23, 6.16, "place", "village")])
 
     assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole") == (1.23, 6.16)
 
@@ -42,7 +42,7 @@ def test_a_place_reaches_the_point_osm_gave_it(write_osm_cache):
 def test_a_pharmacy_named_after_a_village_is_not_offered_as_the_village(write_osm_cache):
     """Nominatim answers with whatever carries the name. Of 30 hits on the residual, over half were
     a building, a road or an amenity — each of which lands a point somewhere plausible and wrong."""
-    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 9.99, 9.99, "amenity", "pharmacy")])
+    cache_dir = write_osm_cache([("Dzidzole", 9.99, 9.99, "amenity", "pharmacy")])
 
     assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole") is None
 
@@ -50,7 +50,7 @@ def test_a_pharmacy_named_after_a_village_is_not_offered_as_the_village(write_os
 def test_a_name_osm_could_not_find_is_remembered_as_unfound(write_osm_cache):
     """A miss is a result. Without keeping it, every rebuild asks Nominatim the whole question again,
     which is the one thing its usage policy forbids."""
-    cache_dir = write_osm_cache([("nowhere", "Nowhere At All", None, None, None, None)])
+    cache_dir = write_osm_cache([("Nowhere At All", None, None, None, None)])
 
     assert osm_geocoder("LAO", cache_dir)("LAO", "Nowhere At All") is None
     assert read_osm_places("LAO", cache_dir)["written"].to_list() == ["Nowhere At All"]
@@ -58,7 +58,7 @@ def test_a_name_osm_could_not_find_is_remembered_as_unfound(write_osm_cache):
 
 def test_a_mention_carrying_a_unit_noun_still_reaches_the_point(write_osm_cache):
     """EM-DAT says what kind of unit it means; the crawl asked under the name alone."""
-    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")])
+    cache_dir = write_osm_cache([("Dzidzole", 1.23, 6.16, "place", "village")])
 
     assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole village") == (1.23, 6.16)
 
@@ -72,7 +72,7 @@ def test_a_country_nobody_has_crawled_answers_with_nothing(tmp_path):
 def test_answers_recorded_twice_keep_the_later_one(write_osm_cache):
     """A recrawl after Nominatim improves its data must not leave two rows for one name, which
     would resolve on file order."""
-    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 0.0, 0.0, "amenity", "pharmacy")])
+    cache_dir = write_osm_cache([("Dzidzole", 0.0, 0.0, "amenity", "pharmacy")])
 
     record_lookups("LAO", cache_dir, {"Dzidzole": NominatimAnswer(1.23, 6.16, "place", "village")})
 
@@ -83,7 +83,7 @@ def test_answers_recorded_twice_keep_the_later_one(write_osm_cache):
 def test_recording_an_answer_leaves_the_names_already_asked_about_alone(write_osm_cache):
     """The crawl runs country by country over many sittings, and each one has to add to the cache
     rather than replace it."""
-    cache_dir = write_osm_cache([("kegue", "Kegue", 1.22, 6.19, "place", "quarter")])
+    cache_dir = write_osm_cache([("Kegue", 1.22, 6.19, "place", "quarter")])
 
     record_lookups(
         "LAO", cache_dir, {"Dzidzole": NominatimAnswer(1.23, 6.16, "place", "village"), "Nowhere At All": None}
@@ -102,7 +102,7 @@ def test_a_miss_is_recorded_with_no_coordinates(write_osm_cache):
 
 def test_one_country_does_not_answer_for_another(write_osm_cache):
     """Nominatim was asked with the country fixed, so an answer is only good for that country."""
-    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")], iso="TGO")
+    cache_dir = write_osm_cache([("Dzidzole", 1.23, 6.16, "place", "village")], iso="TGO")
 
     assert osm_geocoder("TGO", cache_dir)("TGO", "Dzidzole") == (1.23, 6.16)
     assert osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole") is None
@@ -118,7 +118,7 @@ def test_openstreetmap_is_declared_under_the_licence_it_is_published_with():
 def test_every_trusted_category_is_actually_offered(write_osm_cache, category):
     """The filter is the only thing standing between a point and a wrong province, so a category
     named in it that the geocoder then drops would be silently useless."""
-    cache_dir = write_osm_cache([("somewhere", "Somewhere", 1.0, 2.0, category, "whatever")])
+    cache_dir = write_osm_cache([("Somewhere", 1.0, 2.0, category, "whatever")])
 
     assert osm_geocoder("LAO", cache_dir)("LAO", "Somewhere") == (1.0, 2.0)
 
@@ -159,3 +159,13 @@ def test_every_request_waits_out_the_rate_limit(monkeypatch, answer):
         osm.search_nominatim("Dzidzole", "tg")
 
     assert waited == [osm.RATE_LIMIT_SECONDS]
+
+
+def test_a_change_to_the_keying_rules_does_not_orphan_a_crawl(write_osm_cache, monkeypatch):
+    """The written name is what Nominatim was asked about, and the key is derived from it. Storing
+    the key instead would strand every answer the moment the keying rules moved — and a re-crawl
+    could not repair it, because the crawl skips names it has already asked about."""
+    cache_dir = write_osm_cache([("Dzidzole town", 1.23, 6.16, "place", "village")])
+    monkeypatch.setattr(osm, "match_key", lambda name: name.replace(" ", "").upper())
+
+    assert osm.osm_geocoder("LAO", cache_dir)("LAO", "Dzidzole town") == (1.23, 6.16)

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -474,3 +474,14 @@ def test_a_stretch_of_water_written_inside_a_province_still_reaches_the_province
     (placed,) = resolve_event_places([("Java Sea", "Bokeo")], gazetteer)
 
     assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)
+
+
+def test_a_gazetteer_read_twice_reads_the_same_units(write_gadm_cache):
+    """The index is cached to disk between calls, so a rebuild and a cache hit have to agree — the
+    cached form is a flat table and the units are rebuilt from it."""
+    cache_dir = write_gadm_cache()
+
+    built = read_gazetteer("LAO", cache_dir, force_reload=True)
+    from_cache = read_gazetteer("LAO", cache_dir)
+
+    assert (from_cache.names, from_cache.parent_of) == (built.names, built.parent_of)

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -2,6 +2,7 @@ import pytest
 
 from climate_risk.data.place_names import (
     CONTAINED_BY,
+    LOCATED,
     NAMED,
     Placement,
     Unit,
@@ -242,3 +243,22 @@ def test_the_outermost_container_of_the_placeholder_unit_is_itself(write_gadm_ca
     gazetteer = read_gazetteer("UKR", write_gadm_cache())
 
     assert gazetteer.top_container("?") == "?"
+
+
+def test_a_point_is_preferred_to_the_container_a_place_was_written_in(write_gadm_cache):
+    """The container claims every unit inside it. A point names one, so it wins wherever it exists:
+    over half the places that fall back to a container have one."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Nowhere At All", "Bokeo")], gazetteer, located={"Nowhere At All": "LAO.2.1_1"})
+
+    assert placed == Placement({"LAO.2.1_1"}, LOCATED), "the district, not the whole of Bokeo"
+
+
+def test_a_place_its_own_name_reaches_ignores_the_point_offered_for_it(write_gadm_cache):
+    """A name GADM publishes is better evidence than a coordinate somebody geocoded from it."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Sanamxay", None)], gazetteer, located={"Sanamxay": "LAO.2.1_1"})
+
+    assert placed == Placement({"LAO.1.1_1"}, NAMED)

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -823,6 +823,47 @@ def test_a_name_that_was_never_mangled_survives_the_repair(written):
     assert repair_mojibake(written) == written
 
 
+def test_a_dash_joining_two_places_reaches_both(write_gadm_cache):
+    """EM-DAT joins a pair of districts with a dash as readily as with `and`, and refusing to split
+    leaves both unplaced."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Sanamxay-Samakhixay", None, gazetteer) == {"LAO.1.1_1", "LAO.1.2_1"}
+
+
+def test_a_dash_only_half_of_which_names_a_place_is_left_whole(write_gadm_cache):
+    """A dash sits inside a single name — `Nord-Ubangi`, `Alpes-Maritimes` — more often than it
+    joins two. Only unanimity tells a pair from one name the gazetteer spells differently, so a
+    half-match is read as a misspelling rather than split."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Sanamxay-Nowhere", None, gazetteer) == set()
+
+
+def test_a_dash_split_refuses_a_part_too_short_to_be_a_place(write_gadm_cache):
+    """`Ali-Shan` is one Taiwanese mountain whose halves are both Chinese counties. A syllable is
+    not a place, whatever it happens to spell."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Xay-Sanamxay", None, gazetteer) == set(), "Xay names a district and is still too short"
+
+
+def test_a_route_running_between_two_places_is_not_split_across_them(write_gadm_cache):
+    """`Qom-Teheran highway` names the road, not the provinces at its ends. Splitting it claims a
+    footprint the event never had."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Sanamxay-Samakhixay road", None, gazetteer) == set()
+
+
+def test_a_place_beside_a_road_reaches_the_place(write_gadm_cache):
+    """A route noun attaches to one place as often as it spans two, and `Bankass road` is a cercle
+    of Mali with a word after it."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Sanamxay road", None, gazetteer) == {"LAO.1.1_1"}
+
+
 def test_a_keying_rule_with_no_pattern_of_its_own_still_turns_the_cache_over(write_gadm_cache, monkeypatch):
     """Fingerprinting the unit-noun pattern covers only the rules that are patterns. Repairing a
     mis-decoded name is a codec round trip, and a cache that cannot see it changing serves an index

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -1,0 +1,146 @@
+import pytest
+
+from climate_risk.data.place_names import Unit, match_key, read_gazetteer, resolve_event_places, resolve_place
+
+
+@pytest.mark.parametrize(
+    ("written", "published"),
+    [
+        ("Kalin-Aapayo province", "Kalin Aapayo"),
+        ("Ron Phibun districts", "Ron Phibun"),
+        ("Luzon Isl.", "Luzon"),
+        ("Đà Nẵng city", "Da Nang"),
+    ],
+    ids=["province", "plural district", "abbreviated island", "transliterated"],
+)
+def test_a_written_mention_and_a_published_name_reach_the_same_key(written, published):
+    """EM-DAT says what kind of unit it means and GADM does not, so the noun has to come off before
+    the two can meet."""
+    assert match_key(written) == match_key(published)
+
+
+def test_a_name_that_is_only_a_unit_noun_reaches_nothing():
+    """`districts` on its own is what a trailing separator leaves behind. Keyed on the empty string
+    it would collide with every other such fragment and match whatever came first."""
+    assert match_key("districts") == ""
+
+
+def test_units_are_indexed_under_every_name_they_are_published_under(write_gadm_cache):
+    """GADM carries a variant name for many units, and EM-DAT writes whichever it has."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert Unit("LAO.1_1", 1, None) in gazetteer.names[match_key("Attapu")]
+    assert gazetteer.names[match_key("Attopeu")] == {Unit("LAO.1_1", 1, None)}, "the variant name reaches the same unit"
+    assert gazetteer.names[match_key("Houei Sai")] == {Unit("LAO.2.1_1", 2, "LAO.2_1")}, "one of two piped variants"
+
+
+def test_every_level_the_archive_publishes_is_indexed(write_gadm_cache):
+    """A location string names provinces, districts and villages in one breath, and stopping at
+    adm2 loses the finest of them: adm3 and adm4 carry a fifth of everything that resolves."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert Unit("LAO.1.1.1_1", 3, "LAO.1.1_1") in gazetteer.names[match_key("Ban Mai")]
+
+
+def test_a_district_knows_the_province_holding_it(write_gadm_cache):
+    """Parentage decides which of two same-named units a container selects, so it has to come from
+    the row rather than from the shape of the identifier: 37 GADM rows do not nest."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert {unit.parent for unit in gazetteer.names[match_key("Houayxay")]} == {"LAO.2_1"}
+
+
+def test_a_repeated_name_reaches_every_unit_that_carries_it(write_gadm_cache):
+    """A name is not an identifier: Attapu is a province and, elsewhere, a district of Bokeo.
+    Keeping whichever unit was read first would silently pick one and look decisive about it."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Attapu", None, gazetteer) == {"LAO.1_1", "LAO.2.2_1"}
+
+
+def test_a_container_chooses_between_units_sharing_a_name(write_gadm_cache):
+    """The container is what the location prose buys over a bare name match. Without it the choice
+    between same-named units is a similarity threshold, which is the approach this project rejected."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Attapu", "Bokeo", gazetteer) == {"LAO.2.2_1"}, "the district inside Bokeo"
+
+
+def test_a_container_naming_nothing_leaves_the_candidates_alone(write_gadm_cache):
+    """The prose routinely names a region GADM does not model — `Calabarzon`, `Bicol` — and an
+    unrecognised container is missing information, not evidence against the candidates."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Sanamxay", "Some Region GADM Never Heard Of", gazetteer) == {"LAO.1.1_1"}
+
+
+def test_a_container_holding_none_of_the_candidates_leaves_them_alone(write_gadm_cache):
+    """EM-DAT's containers are sometimes wrong or coarser than GADM's hierarchy. Dropping every
+    candidate would turn a mistaken container into a lost place."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Sanamxay", "Bokeo", gazetteer) == {"LAO.1.1_1"}
+
+
+def test_a_name_no_unit_carries_reaches_nothing(write_gadm_cache):
+    """Two fifths of written places name no GADM unit at all, and the caller has to tell that from
+    a match."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Calabarzon", None, gazetteer) == set()
+
+
+def test_a_seat_named_after_its_district_resolves_to_the_district(write_gadm_cache):
+    """Two thirds of ambiguous mentions are one nesting chain, not two places. The district is the
+    whole of what the mention can mean, and returning the seat beside it invents a choice."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Samakhixay", None, gazetteer) == {"LAO.1.2_1"}
+
+
+def test_a_container_reaches_past_the_level_directly_below_it(write_gadm_cache):
+    """Prose names the province and then a village, skipping the district between them, so a
+    container matched against the immediate parent alone would discard the village."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Ban Mai", "Attapu", gazetteer) == {"LAO.1.1.1_1"}
+
+
+def test_an_unambiguous_place_narrows_the_ambiguous_ones_beside_it(write_gadm_cache):
+    """An event's places share a footprint. Resolving each alone throws that away and leaves
+    Attapu split between a province and a district in the province the event is plainly in."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_event_places([("Houayxay", None), ("Attapu", None)], gazetteer) == [
+        {"LAO.2.1_1"},
+        {"LAO.2.2_1"},
+    ]
+
+
+def test_an_event_pinning_nothing_leaves_its_places_alone(write_gadm_cache):
+    """Half the ambiguous mentions sit in events where nothing resolves uniquely, and narrowing
+    against an empty envelope would drop every candidate."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_event_places([("Attapu", None), ("Calabarzon", None)], gazetteer) == [
+        {"LAO.1_1", "LAO.2.2_1"},
+        set(),
+    ]
+
+
+def test_a_country_the_archive_does_not_cover_reads_back_empty(write_gadm_cache):
+    """EM-DAT codes states GADM never modeled — Serbia and Montenegro, the USSR — and a caller
+    walking every ISO in the workbook reaches them."""
+    gazetteer = read_gazetteer("SCG", write_gadm_cache())
+
+    assert gazetteer.names == {}
+    assert resolve_place("Beograd", None, gazetteer) == set()
+
+
+def test_a_unit_that_parents_itself_still_terminates(write_gadm_cache):
+    """GADM writes an unnamed Ukrainian unit as `?` at two levels, making it its own container.
+    Walking upwards without a visited set never returns, and nothing upstream rejects the row."""
+    gazetteer = read_gazetteer("UKR", write_gadm_cache())
+
+    assert gazetteer.parent_of["?"] == "?", "the archive really does produce this"
+    assert gazetteer.ancestry("?") == {"?"}

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -10,10 +10,12 @@ from climate_risk.data.place_names import (
     LOCATED,
     NAME_CORRECTIONS,
     NAMED,
+    NAMES_NO_UNIT,
     Placement,
     Unit,
     match_key,
     name_shapes,
+    names_no_unit,
     nearest_name,
     read_gazetteer,
     read_name_corrections,
@@ -255,25 +257,6 @@ def test_the_outermost_container_of_the_placeholder_unit_is_itself(write_gadm_ca
     assert gazetteer.top_container("?") == "?"
 
 
-def test_a_point_is_preferred_to_the_container_a_place_was_written_in(write_gadm_cache):
-    """The container claims every unit inside it. A point names one, so it wins wherever it exists:
-    over half the places that fall back to a container have one."""
-    gazetteer = read_gazetteer("LAO", write_gadm_cache())
-
-    (placed,) = resolve_event_places([("Nowhere At All", "Bokeo")], gazetteer, located={"Nowhere At All": "LAO.2.1_1"})
-
-    assert placed == Placement({"LAO.2.1_1"}, LOCATED), "the district, not the whole of Bokeo"
-
-
-def test_a_place_its_own_name_reaches_ignores_the_point_offered_for_it(write_gadm_cache):
-    """A name GADM publishes is better evidence than a coordinate somebody geocoded from it."""
-    gazetteer = read_gazetteer("LAO", write_gadm_cache())
-
-    (placed,) = resolve_event_places([("Sanamxay", None)], gazetteer, located={"Sanamxay": "LAO.2.1_1"})
-
-    assert placed == Placement({"LAO.1.1_1"}, NAMED)
-
-
 def test_a_misspelling_reaches_the_name_it_misspells(write_gadm_cache):
     """Misspellings are the largest thing left that no gazetteer places: `Barrranquilla`,
     `Marizales`, `Santa Rose de Cabal`."""
@@ -316,14 +299,6 @@ def test_a_name_that_already_matches_is_not_approximated(write_gadm_cache):
     assert nearest_name("Sanamxay", gazetteer, name_shapes(gazetteer)) is None
 
 
-def test_a_name_two_edits_away_is_not_a_misspelling_of_it(write_gadm_cache):
-    """One slip is a misspelling. At two, `Sanamxay` and a different district are equally far, and
-    the match is a guess dressed as a correction."""
-    gazetteer = read_gazetteer("LAO", write_gadm_cache())
-
-    assert nearest_name("Sanamxii", gazetteer, name_shapes(gazetteer)) is None
-
-
 def test_a_checked_misspelling_reaches_the_unit_it_stands_for(write_gadm_cache):
     """Approximate matching proposes corrections; only the ones written into the table are applied."""
     gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": "sanamxay"})
@@ -347,6 +322,33 @@ def test_a_container_is_preferred_to_a_checked_misspelling(write_gadm_cache):
     (placed,) = resolve_event_places([("Sanamxai", "Bokeo")], gazetteer)
 
     assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)
+
+
+def test_a_name_two_edits_away_is_not_a_misspelling_of_it(write_gadm_cache):
+    """One slip is a misspelling. At two, `Sanamxay` and a different district are equally far, and
+    the match is a guess dressed as a correction."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Sanamxii", gazetteer, name_shapes(gazetteer)) is None
+
+
+def test_a_point_is_preferred_to_the_container_a_place_was_written_in(write_gadm_cache):
+    """The container claims every unit inside it. A point names one, so it wins wherever it exists:
+    over half the places that fall back to a container have one."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Nowhere At All", "Bokeo")], gazetteer, located={"Nowhere At All": "LAO.2.1_1"})
+
+    assert placed == Placement({"LAO.2.1_1"}, LOCATED), "the district, not the whole of Bokeo"
+
+
+def test_a_place_its_own_name_reaches_ignores_the_point_offered_for_it(write_gadm_cache):
+    """A name GADM publishes is better evidence than a coordinate somebody geocoded from it."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Sanamxay", None)], gazetteer, located={"Sanamxay": "LAO.2.1_1"})
+
+    assert placed == Placement({"LAO.1.1_1"}, NAMED)
 
 
 def test_a_correction_is_read_only_for_the_country_that_declares_it(write_gadm_cache, tmp_path):
@@ -421,3 +423,54 @@ def test_a_gazetteer_covers_the_territory_its_country_administers(write_gadm_cac
 
     assert resolve_place("Srinagar", None, gazetteer) == {"Z01.1.1_1"}
     assert resolve_place("Kochi", None, gazetteer) == {"IND.1.1_1"}
+
+
+@pytest.mark.parametrize(
+    "written",
+    [
+        "North",
+        "Countrywide",
+        "N.A. on the source",
+        "Between Java and Bali",
+        "Off the coast of Luzon",
+        "Java Sea",
+        "Congo river",
+        ".",
+    ],
+    ids=["direction", "countrywide", "not available", "between", "offshore", "sea", "river", "punctuation"],
+)
+def test_a_place_that_names_no_unit_is_told_apart(written):
+    """A fifth of what stays unplaced is like this. Counting it as a coverage failure understates
+    what the resolver reaches, because no gazetteer could ever hold it."""
+    assert names_no_unit(written)
+
+
+@pytest.mark.parametrize(
+    "written",
+    ["Sanamxay", "Attapu", "Bokeo", "Central Java"],
+    ids=["district", "province", "short province", "a direction inside a real name"],
+)
+def test_a_real_place_is_not_mistaken_for_noise(written):
+    """`Central` is a Zambian province and `Coast` a Kenyan one, so the test is on the whole string
+    rather than on any word appearing in it."""
+    assert not names_no_unit(written)
+
+
+def test_an_unplaceable_place_is_recorded_as_naming_no_unit(write_gadm_cache):
+    """A caller measuring coverage has to be able to leave these out of the denominator without
+    guessing which of the unplaced rows were ever placeable."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    unplaceable, missing = resolve_event_places([("Java Sea", None), ("Nowhere At All", None)], gazetteer)
+
+    assert (unplaceable.how, missing.how) == (NAMES_NO_UNIT, NAMED)
+
+
+def test_a_stretch_of_water_written_inside_a_province_still_reaches_the_province(write_gadm_cache):
+    """`Java Sea (West Java province)` names no unit and a container that does. The container is
+    what the prose gives, so the event is placed there rather than discarded as noise."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Java Sea", "Bokeo")], gazetteer)
+
+    assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -229,3 +229,16 @@ def test_a_container_standing_in_for_a_place_is_narrowed_like_any_other(write_ga
     _, fallen_back = resolve_event_places([("Houayxay", None), ("Nowhere At All", "Attapu")], gazetteer)
 
     assert fallen_back == Placement({"LAO.2.2_1"}, CONTAINED_BY), "the district inside the pinned province"
+
+
+def test_a_unit_below_a_province_names_the_province_as_its_outermost(write_gadm_cache):
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert gazetteer.top_container("LAO.1.1.1_1") == "LAO.1_1"
+
+
+def test_the_outermost_container_of_the_placeholder_unit_is_itself(write_gadm_cache):
+    """Walking outwards from a unit the archive nests inside itself must still reach a top."""
+    gazetteer = read_gazetteer("UKR", write_gadm_cache())
+
+    assert gazetteer.top_container("?") == "?"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -527,3 +527,16 @@ def test_a_container_whose_first_place_is_unknown_falls_through_to_the_next(writ
     (placed,) = resolve_event_places([("Nowhere At All", "Nowhere district, Bokeo province")], gazetteer)
 
     assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)
+
+
+@pytest.mark.parametrize(
+    ("written", "published"),
+    [("Damavand/Rou Dehan", "Damavand"), ("Kwilu et Tshuapa", "Kwilu"), ("Seoul + Chungchong", "Seoul")],
+    ids=["slash", "french and", "plus"],
+)
+def test_a_place_joined_by_any_of_the_written_separators_is_split(written, published, write_gadm_cache):
+    """EM-DAT joins places with `/`, `+`, `&` and the French `et` as readily as with `and`."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+    joined = written.replace("Damavand", "Sanamxay").replace("Kwilu", "Sanamxay").replace("Seoul", "Sanamxay")
+
+    assert resolve_place(joined, None, gazetteer) == {"LAO.1.1_1"}

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -641,3 +641,16 @@ def test_a_transposition_is_one_slip_from_the_name_it_garbles(write_gadm_cache):
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert nearest_name("Snaamxay", gazetteer, name_shapes(gazetteer)) == "sanamxay"
+
+
+@pytest.mark.parametrize(
+    "written",
+    ["anamxay", "Zanamxay", "Sanamxai", "Snaamxay"],
+    ids=["first letter lost", "first letter wrong", "last letter wrong", "transposed"],
+)
+def test_a_slip_in_the_first_letter_still_finds_the_name(written, write_gadm_cache):
+    """Names are filed for lookup under their opening letters, so a name that lost or changed its
+    first one is otherwise unreachable however close it is: `llinois` is one letter from Illinois."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name(written, gazetteer, name_shapes(gazetteer)) == "sanamxay"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -144,3 +144,19 @@ def test_a_unit_that_parents_itself_still_terminates(write_gadm_cache):
 
     assert gazetteer.parent_of["?"] == "?", "the archive really does produce this"
     assert gazetteer.ancestry("?") == {"?"}
+
+
+@pytest.mark.parametrize(
+    ("written", "published"),
+    [
+        ("Bengkulu area", "Bengkulu"),
+        ("Cagayan Prov.", "Cagayan"),
+        ("City of Bandung", "Bandung"),
+        ("Near Villavicencio", "Villavicencio"),
+        ("Coast of Zamboanga", "Zamboanga"),
+    ],
+    ids=["area", "abbreviated province", "city of", "near", "coast of"],
+)
+def test_a_decorated_mention_reaches_the_published_name(written, published):
+    """A fifth of the names nothing matches are a published name with a word like this attached."""
+    assert match_key(written) == match_key(published)

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -412,3 +412,12 @@ def test_a_state_whose_successors_place_nothing_stays_unplaced(write_gadm_cache)
 def test_a_country_that_still_exists_has_no_successor(write_gadm_cache):
     """The mapping covers dissolved states only; anything else is read from its own gazetteer."""
     assert successor_state([("Sanamxay", None)], "LAO", write_gadm_cache()) is None
+
+
+def test_a_gazetteer_covers_the_territory_its_country_administers(write_gadm_cache):
+    """Fifty-five Indian and twenty-nine Pakistani events name places in Kashmir, which GADM holds
+    at the right coordinates under a code neither country's own gazetteer reads."""
+    gazetteer = read_gazetteer("IND", write_gadm_cache())
+
+    assert resolve_place("Srinagar", None, gazetteer) == {"Z01.1.1_1"}
+    assert resolve_place("Kochi", None, gazetteer) == {"IND.1.1_1"}

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -437,9 +437,34 @@ def test_a_gazetteer_covers_the_territory_its_country_administers(write_gadm_cac
         "Off the coast of Luzon",
         "Java Sea",
         "Congo river",
+        "Mer d'Adaman",
+        "Golfe du Lion",
+        "Northeastern",
+        "Northwestern provinces",
+        "East Coast",
+        "Alps",
+        "Atlantique",
+        "Bight of Bangkok",
         ".",
     ],
-    ids=["direction", "countrywide", "not available", "between", "offshore", "sea", "river", "punctuation"],
+    ids=[
+        "direction",
+        "countrywide",
+        "not available",
+        "between",
+        "offshore",
+        "sea",
+        "river",
+        "french sea",
+        "french gulf",
+        "adjectival direction",
+        "adjectival direction with a unit word",
+        "direction and a coast",
+        "mountain range",
+        "french ocean",
+        "bight",
+        "punctuation",
+    ],
 )
 def test_a_place_that_names_no_unit_is_told_apart(written):
     """A fifth of what stays unplaced is like this. Counting it as a coverage failure understates
@@ -449,12 +474,37 @@ def test_a_place_that_names_no_unit_is_told_apart(written):
 
 @pytest.mark.parametrize(
     "written",
-    ["Sanamxay", "Attapu", "Bokeo", "Central Java"],
-    ids=["district", "province", "short province", "a direction inside a real name"],
+    [
+        "Sanamxay",
+        "Attapu",
+        "Bokeo",
+        "Central Java",
+        "Rio de Janeiro",
+        "Valle del Cauca",
+        "Mar del Plata",
+        "Sierra Leone",
+        "Alpes-Maritimes",
+        "Cerro Largo",
+        "Northern Territory",
+    ],
+    ids=[
+        "district",
+        "province",
+        "short province",
+        "a direction inside a real name",
+        "a river word heading a city",
+        "a valley word heading a department",
+        "a sea word heading a city",
+        "a range word heading a country",
+        "the french range word heading a department",
+        "a hill word heading a department",
+        "a direction heading a real territory",
+    ],
 )
 def test_a_real_place_is_not_mistaken_for_noise(written):
-    """`Central` is a Zambian province and `Coast` a Kenyan one, so the test is on the whole string
-    rather than on any word appearing in it."""
+    """`Central` is a Zambian province and `Coast` a Kenyan one, so the direction test is on the
+    whole string. The feature words are searched anywhere, so the ones heading real units — `Rio`,
+    `Valle`, `Mar`, `Costa`, `Sierra`, `Lago` — are left out of that list entirely."""
     assert not names_no_unit(written)
 
 

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -19,6 +19,7 @@ from climate_risk.data.place_names import (
     read_name_corrections,
     resolve_event_places,
     resolve_place,
+    successor_state,
 )
 
 
@@ -376,3 +377,38 @@ def test_no_country_corrects_one_name_to_two_different_units(write_gadm_cache):
     conflicting = {key: sorted(published) for key, published in targets.items() if len(published) > 1}
 
     assert not conflicting, f"one name corrected two ways: {sorted(conflicting.items())[:5]}"
+
+
+def test_a_state_with_one_successor_needs_no_evidence(write_gadm_cache):
+    """East and West Germany both became Germany, so their events need no disambiguating at all."""
+    assert successor_state([], "DFR", write_gadm_cache()) == "DEU"
+
+
+def test_the_successor_holding_the_places_takes_the_event(write_gadm_cache):
+    """A Czechoslovak flood naming Prague is Czech. EM-DAT files 417 events under states GADM no
+    longer models, and the location text is the only thing that says where they happened."""
+    cache_dir = write_gadm_cache()
+
+    assert successor_state([("Praha", None)], "CSK", cache_dir) == "CZE"
+    assert successor_state([("Bratislavsky", None)], "CSK", cache_dir) == "SVK"
+
+
+def test_a_name_both_successors_publish_settles_nothing(write_gadm_cache):
+    """Czechia and Slovakia both have a Nové Město. Taking whichever was read first would put the
+    event in a country on alphabetical order alone."""
+    assert successor_state([("Nove Mesto", None)], "CSK", write_gadm_cache()) is None
+
+
+def test_the_only_successor_in_the_archive_still_has_to_place_something(write_gadm_cache):
+    """Being the sole candidate is not evidence. Assigning the event to the largest successor would
+    put every Soviet flood in Russia by default."""
+    assert successor_state([("Nowhere At All", None)], "YUG", write_gadm_cache()) is None
+
+
+def test_a_state_whose_successors_place_nothing_stays_unplaced(write_gadm_cache):
+    assert successor_state([("Nowhere At All", None)], "CSK", write_gadm_cache()) is None
+
+
+def test_a_country_that_still_exists_has_no_successor(write_gadm_cache):
+    """The mapping covers dissolved states only; anything else is read from its own gazetteer."""
+    assert successor_state([("Sanamxay", None)], "LAO", write_gadm_cache()) is None

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -540,3 +540,46 @@ def test_a_place_joined_by_any_of_the_written_separators_is_split(written, publi
     joined = written.replace("Damavand", "Sanamxay").replace("Kwilu", "Sanamxay").replace("Seoul", "Sanamxay")
 
     assert resolve_place(joined, None, gazetteer) == {"LAO.1.1_1"}
+
+
+@pytest.mark.parametrize(
+    ("written", "published"),
+    [
+        ("Arr. Mechelen", "Mechelen"),
+        ("Barangay Rizal", "Rizal"),
+        ("towns of Kauswagan", "Kauswagan"),
+        ("woredas of Dale", "Dale"),
+        ("Oshai Darray village", "Oshai Darray"),
+        ("Lamu archipel", "Lamu"),
+        ("Kalehe territory", "Kalehe"),
+        ("Ayeyarwady divisions", "Ayeyarwady"),
+        ("Lancashire CC", "Lancashire"),
+        ("Tafawa alewa Local Government Area", "Tafawa alewa"),
+        ("Keumbu market", "Keumbu"),
+        ("Goalanda Upazilla", "Goalanda"),
+    ],
+    ids=[
+        "abbreviated prefix",
+        "barangay",
+        "town of",
+        "woreda of",
+        "village",
+        "archipel",
+        "territory",
+        "division",
+        "county council",
+        "local government area",
+        "market",
+        "upazila",
+    ],
+)
+def test_a_unit_word_before_the_name_is_stripped_like_one_after(written, published):
+    """EM-DAT writes the unit word on whichever side the local convention puts it, and a whole
+    Belgian event can carry `Arr.` on every name."""
+    assert match_key(written) == match_key(published)
+
+
+def test_a_unit_word_that_names_a_real_place_is_left_alone():
+    """GADM carries units called Canton, so stripping the word would reduce them to nothing and
+    drop them out of the index entirely."""
+    assert match_key("Canton") == "canton"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -160,3 +160,35 @@ def test_a_unit_that_parents_itself_still_terminates(write_gadm_cache):
 def test_a_decorated_mention_reaches_the_published_name(written, published):
     """A fifth of the names nothing matches are a published name with a word like this attached."""
     assert match_key(written) == match_key(published)
+
+
+def test_a_conjunction_reaches_both_places_it_joins(write_gadm_cache):
+    """EM-DAT writes a run of provinces joined by `and`, and refusing to split leaves every one of
+    them unplaced."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Sanamxay and Samakhixay", None, gazetteer) == {"LAO.1.1_1", "LAO.1.2_1"}
+
+
+def test_a_unit_whose_own_name_carries_a_conjunction_survives(write_gadm_cache):
+    """Splitting `Newfoundland and Labrador` destroys the province it names, so the whole string
+    has to be tried before its parts."""
+    gazetteer = read_gazetteer("CAN", write_gadm_cache())
+
+    assert resolve_place("Newfoundland and Labrador", None, gazetteer) == {"CAN.5_1"}
+
+
+def test_a_conjunction_keeps_whichever_parts_name_something(write_gadm_cache):
+    """EM-DAT joins a place it spelled well to one it spelled badly. Discarding both because one
+    failed throws away geography the prose plainly gives."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Nowhere At All and Sanamxay", None, gazetteer) == {"LAO.1.1_1"}
+
+
+def test_a_place_named_between_two_others_is_in_neither(write_gadm_cache):
+    """`Between Java and Bali` is a stretch of sea named by its shores. Splitting it puts the event
+    on whichever shore resolves, which is a coastline away from where it happened."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Between Bokeo and Sanamxay", None, gazetteer) == set()

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -499,3 +499,31 @@ def test_changing_how_a_name_is_keyed_turns_the_cached_index_over(write_gadm_cac
     rekeyed = read_gazetteer("LAO", cache_dir)
 
     assert "sanamxay" not in rekeyed.names, "the stripped word cannot survive as a key"
+
+
+def test_a_container_naming_several_places_gives_the_finest_that_resolves(write_gadm_cache):
+    """EM-DAT writes `Wayanad district, Kerala state` finest first. Read whole it matches nothing,
+    and the village inside it goes unplaced — 1,173 places carry a container like this."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Nowhere At All", "Sanamxay district, Attapu province")], gazetteer)
+
+    assert placed == Placement({"LAO.1.1_1"}, CONTAINED_BY), "the district, not the province beside it"
+
+
+def test_a_compound_container_narrows_an_ambiguous_name(write_gadm_cache):
+    """The container is used to choose between same-named units as well as to stand in for them, and
+    both readings have to see every place it names."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_place("Attapu", "Houayxay district, Bokeo province", gazetteer) == {"LAO.2.2_1"}
+
+
+def test_a_container_whose_first_place_is_unknown_falls_through_to_the_next(write_gadm_cache):
+    """The finest place named is often a village GADM does not carry, and the state beside it is
+    the whole reason the container is worth reading."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Nowhere At All", "Nowhere district, Bokeo province")], gazetteer)
+
+    assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -146,12 +146,12 @@ def test_a_country_the_archive_does_not_cover_reads_back_empty(write_gadm_cache)
     assert resolve_place("Beograd", None, gazetteer) == set()
 
 
-def test_a_unit_that_parents_itself_still_terminates(write_gadm_cache):
-    """GADM writes an unnamed Ukrainian unit as `?` at two levels, making it its own container.
-    Walking upwards without a visited set never returns, and nothing upstream rejects the row."""
+def test_a_unit_the_archive_nests_inside_itself_is_read_as_containing_nothing(write_gadm_cache):
+    """GADM writes an unnamed Ukrainian unit as `?` at two levels, which reads as its own container
+    and makes every walk over parentage non-terminating. The reader is where that has to stop."""
     gazetteer = read_gazetteer("UKR", write_gadm_cache())
 
-    assert gazetteer.parent_of["?"] == "?", "the archive really does produce this"
+    assert gazetteer.parent_of["?"] is None
     assert gazetteer.ancestry("?") == {"?"}
 
 

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -767,3 +767,33 @@ def test_a_place_whose_name_ends_in_a_unit_word_survives():
     the published name, so the two still meet — but a name reduced to nothing would be lost."""
     assert match_key("Rhode Island") == match_key("Rhode Island")
     assert match_key("Kelantan") == "kelantan"
+
+
+def test_a_container_with_a_direction_on_it_reaches_the_unit(write_gadm_cache):
+    """`northern Queensland` names a container the prose plainly gives, and Queensland is a unit.
+    Everything built for reading a place name has to reach the container too."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Nowhere At All", "Northern Bokeo")], gazetteer)
+
+    assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)
+
+
+def test_a_misspelled_container_the_event_vouches_for_reaches_the_unit(write_gadm_cache):
+    """GADM spells it Hirat and EM-DAT writes Herat. The container carries the same slips a name
+    does, and the event's other places vouch for it the same way."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    _, fallen_back = resolve_event_places([("Sanamxay", None), ("Nowhere At All", "Samakhixai")], gazetteer)
+
+    assert fallen_back == Placement({"LAO.1.2_1"}, CONTAINED_BY)
+
+
+def test_an_exact_container_beats_a_misspelling_of_a_finer_one(write_gadm_cache):
+    """The prose writes a container finest first, but an exact match on the coarser part is better
+    evidence than a slip on the finer one — even when the event vouches for the slip."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    _, fallen_back = resolve_event_places([("Sanamxay", None), ("Nowhere At All", "Samakhixai, Bokeo")], gazetteer)
+
+    assert fallen_back == Placement({"LAO.2_1"}, CONTAINED_BY), "Bokeo exactly, not a slip for Samakhixay"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -1,6 +1,15 @@
 import pytest
 
-from climate_risk.data.place_names import Unit, match_key, read_gazetteer, resolve_event_places, resolve_place
+from climate_risk.data.place_names import (
+    CONTAINED_BY,
+    NAMED,
+    Placement,
+    Unit,
+    match_key,
+    read_gazetteer,
+    resolve_event_places,
+    resolve_place,
+)
 
 
 @pytest.mark.parametrize(
@@ -112,8 +121,8 @@ def test_an_unambiguous_place_narrows_the_ambiguous_ones_beside_it(write_gadm_ca
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert resolve_event_places([("Houayxay", None), ("Attapu", None)], gazetteer) == [
-        {"LAO.2.1_1"},
-        {"LAO.2.2_1"},
+        Placement({"LAO.2.1_1"}, NAMED),
+        Placement({"LAO.2.2_1"}, NAMED),
     ]
 
 
@@ -123,8 +132,8 @@ def test_an_event_pinning_nothing_leaves_its_places_alone(write_gadm_cache):
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert resolve_event_places([("Attapu", None), ("Calabarzon", None)], gazetteer) == [
-        {"LAO.1_1", "LAO.2.2_1"},
-        set(),
+        Placement({"LAO.1_1", "LAO.2.2_1"}, NAMED),
+        Placement(set(), NAMED),
     ]
 
 
@@ -192,3 +201,31 @@ def test_a_place_named_between_two_others_is_in_neither(write_gadm_cache):
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert resolve_place("Between Bokeo and Sanamxay", None, gazetteer) == set()
+
+
+def test_a_place_naming_nothing_falls_back_to_the_container_it_was_written_in(write_gadm_cache):
+    """A third of the events still unplaced name a container that resolves — `Pesisir Selaten (West
+    Sumatra province)` gives the province even where the district is unrecognisable."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_event_places([("Nowhere At All", "Bokeo")], gazetteer) == [Placement({"LAO.2_1"}, CONTAINED_BY)]
+
+
+def test_a_container_standing_in_for_a_place_is_marked_as_coarser(write_gadm_cache):
+    """The province is not what the prose named, and a caller aggregating footprints has to be able
+    to tell a district it asked for from the province it settled for."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    named, fallen_back = resolve_event_places([("Sanamxay", None), ("Nowhere At All", "Bokeo")], gazetteer)
+
+    assert (named.how, fallen_back.how) == (NAMED, CONTAINED_BY)
+
+
+def test_a_container_standing_in_for_a_place_is_narrowed_like_any_other(write_gadm_cache):
+    """`Attapu` names a province and a district elsewhere. Falling back to it without the narrowing
+    a named place gets would hand back both, when the event has already pinned which one."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    _, fallen_back = resolve_event_places([("Houayxay", None), ("Nowhere At All", "Attapu")], gazetteer)
+
+    assert fallen_back == Placement({"LAO.2.2_1"}, CONTAINED_BY), "the district inside the pinned province"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -760,3 +760,10 @@ def test_a_slip_vouched_for_at_two_places_at_once_is_refused(write_gadm_cache):
     *_, ambiguous = resolve_event_places([("Sanamxay", None), ("Houayxay", None), ("Attapy", None)], gazetteer)
 
     assert ambiguous == Placement(set(), NAMED)
+
+
+def test_a_place_whose_name_ends_in_a_unit_word_survives():
+    """`Rhode Island` and `Coast` are real units. The words are stripped from both the mention and
+    the published name, so the two still meet — but a name reduced to nothing would be lost."""
+    assert match_key("Rhode Island") == match_key("Rhode Island")
+    assert match_key("Kelantan") == "kelantan"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -7,6 +7,8 @@ from climate_risk.data.place_names import (
     Placement,
     Unit,
     match_key,
+    name_shapes,
+    nearest_name,
     read_gazetteer,
     resolve_event_places,
     resolve_place,
@@ -262,3 +264,53 @@ def test_a_place_its_own_name_reaches_ignores_the_point_offered_for_it(write_gad
     (placed,) = resolve_event_places([("Sanamxay", None)], gazetteer, located={"Sanamxay": "LAO.2.1_1"})
 
     assert placed == Placement({"LAO.1.1_1"}, NAMED)
+
+
+def test_a_misspelling_reaches_the_name_it_misspells(write_gadm_cache):
+    """Misspellings are the largest thing left that no gazetteer places: `Barrranquilla`,
+    `Marizales`, `Santa Rose de Cabal`."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Sanamxai", gazetteer, name_shapes(gazetteer)) == "sanamxay"
+
+
+def test_a_name_equally_close_to_two_published_names_reaches_neither(write_gadm_cache):
+    """Two names one edit away is not a near miss, it is a choice. `Bocolod` sits one edit from
+    both Bacolod the city and Boclod the barangay, and picking either looks equally confident."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Attopu", gazetteer, name_shapes(gazetteer)) is None, "one edit from both Attapu and Attopeu"
+
+
+def test_a_name_too_short_to_misspell_is_refused(write_gadm_cache):
+    """One edit in a five-letter name changes too much of it to call the rest a match."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Bokea", gazetteer, name_shapes(gazetteer)) is None
+
+
+def test_a_physical_feature_is_never_taken_for_a_unit_it_resembles(write_gadm_cache):
+    """A bay is not an administrative unit however close its name sits to one. Units named after a
+    feature still match exactly; only the approximate lookup refuses them."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Nambok", gazetteer, name_shapes(gazetteer)) == "nambak", (
+        "the same unit is reachable by a plain misspelling"
+    )
+    assert nearest_name("Nam Bay", gazetteer, name_shapes(gazetteer)) is None
+
+
+def test_a_name_that_already_matches_is_not_approximated(write_gadm_cache):
+    """An exact match is the answer, and offering a near one beside it would let a misspelling of
+    some other place override a name GADM publishes."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Sanamxay", gazetteer, name_shapes(gazetteer)) is None
+
+
+def test_a_name_two_edits_away_is_not_a_misspelling_of_it(write_gadm_cache):
+    """One slip is a misspelling. At two, `Sanamxay` and a different district are equally far, and
+    the match is a guess dressed as a correction."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Sanamxii", gazetteer, name_shapes(gazetteer)) is None

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -697,3 +697,19 @@ def test_an_entry_naming_several_units_is_read_as_several(write_gadm_cache, tmp_
     table.write_text("iso,written,corrected\nVNM,Nghe Tinh,nghean|hatinh\n", encoding="utf-8")
 
     assert read_name_corrections("VNM", path=table) == {"nghetinh": ("nghean", "hatinh")}
+
+
+def test_a_country_reads_the_territory_it_no_longer_contains(write_gadm_cache):
+    """An event recorded before a secession names a place its country then held. `Malakal` under
+    SDN is South Sudanese now, and reaches nothing unless the successor is read alongside."""
+    gazetteer = read_gazetteer("ETH", write_gadm_cache())
+
+    assert resolve_place("Asmara", None, gazetteer) == {"ERI.1.1_1"}
+    assert resolve_place("Mekele", None, gazetteer) == {"ETH.1.1_1"}
+
+
+def test_a_country_that_lost_nothing_reads_only_itself(write_gadm_cache):
+    """The table covers secessions only; every other country is read from its own code alone."""
+    gazetteer = read_gazetteer("ERI", write_gadm_cache())
+
+    assert resolve_place("Mekele", None, gazetteer) == set()

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -22,6 +22,7 @@ from climate_risk.data.place_names import (
     nearest_name,
     read_gazetteer,
     read_name_corrections,
+    repair_mojibake,
     resolve_event_places,
     resolve_place,
     successor_state,
@@ -797,3 +798,39 @@ def test_an_exact_container_beats_a_misspelling_of_a_finer_one(write_gadm_cache)
     _, fallen_back = resolve_event_places([("Sanamxay", None), ("Nowhere At All", "Samakhixai, Bokeo")], gazetteer)
 
     assert fallen_back == Placement({"LAO.2_1"}, CONTAINED_BY), "Bokeo exactly, not a slip for Samakhixay"
+
+
+@pytest.mark.parametrize(
+    ("mangled", "intended"),
+    [("SÃ©dhiou", "Sédhiou"), ("SÃƒÂ©dhiou", "Sédhiou"), ("HanoÃ¯", "Hanoï")],
+    ids=["decoded once through the wrong codec", "decoded twice", "a different accent"],
+)
+def test_a_name_decoded_through_the_wrong_codec_reaches_the_name_it_mangles(mangled, intended):
+    """EM-DAT carries names written as UTF-8 and read back as cp1252, some of them twice over. Until
+    the mangling comes off they key to letters GADM never published."""
+    assert match_key(mangled) == match_key(intended)
+
+
+@pytest.mark.parametrize(
+    "written",
+    ["Sédhiou", "Đà Nẵng", "Attapu", "Kraków", "São Paulo", "Côte-d'Or"],
+    ids=["accented", "vietnamese", "plain", "polish", "portuguese", "french"],
+)
+def test_a_name_that_was_never_mangled_survives_the_repair(written):
+    """The repair is only safe because it is self-guarding: a correctly written name encodes to
+    bytes that are not valid UTF-8, so the round trip fails and leaves it alone. A name that
+    silently changed here would be corrupted for every lookup."""
+    assert repair_mojibake(written) == written
+
+
+def test_a_keying_rule_with_no_pattern_of_its_own_still_turns_the_cache_over(write_gadm_cache, monkeypatch):
+    """Fingerprinting the unit-noun pattern covers only the rules that are patterns. Repairing a
+    mis-decoded name is a codec round trip, and a cache that cannot see it changing serves an index
+    built under rules that no longer apply."""
+    cache_dir = write_gadm_cache()
+    read_gazetteer("LAO", cache_dir)
+
+    monkeypatch.setattr(place_names, "repair_mojibake", lambda text: text.replace("a", "z"))
+    rekeyed = read_gazetteer("LAO", cache_dir)
+
+    assert "sznzmxzy" in rekeyed.names, "the index was rebuilt under the changed rule"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -1,9 +1,11 @@
 import csv
+import re
 
 from collections import defaultdict
 
 import pytest
 
+from climate_risk.data import place_names
 from climate_risk.data.place_names import (
     CONTAINED_BY,
     CORRECTED,
@@ -485,3 +487,15 @@ def test_a_gazetteer_read_twice_reads_the_same_units(write_gadm_cache):
     from_cache = read_gazetteer("LAO", cache_dir)
 
     assert (from_cache.names, from_cache.parent_of) == (built.names, built.parent_of)
+
+
+def test_changing_how_a_name_is_keyed_turns_the_cached_index_over(write_gadm_cache, monkeypatch):
+    """The index is built with `match_key`, so a cache keyed on the country alone serves an index
+    built under rules that no longer apply — every unit word added would be invisible."""
+    cache_dir = write_gadm_cache()
+    read_gazetteer("LAO", cache_dir)
+
+    monkeypatch.setattr(place_names, "UNIT_NOUNS", re.compile(r"\b(sanamxay)\b", re.IGNORECASE))
+    rekeyed = read_gazetteer("LAO", cache_dir)
+
+    assert "sanamxay" not in rekeyed.names, "the stripped word cannot survive as a key"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -303,7 +303,7 @@ def test_a_name_that_already_matches_is_not_approximated(write_gadm_cache):
 
 def test_a_checked_misspelling_reaches_the_unit_it_stands_for(write_gadm_cache):
     """Approximate matching proposes corrections; only the ones written into the table are applied."""
-    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": "sanamxay"})
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": ("sanamxay",)})
 
     assert resolve_event_places([("Sanamxai", None)], gazetteer) == [Placement({"LAO.1.1_1"}, CORRECTED)]
 
@@ -319,7 +319,7 @@ def test_a_misspelling_nobody_checked_is_left_unplaced(write_gadm_cache):
 def test_a_container_is_preferred_to_a_checked_misspelling(write_gadm_cache):
     """The container is coarse but certain. A wrong district is worse for a damage estimate than a
     correct province."""
-    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": "sanamxay"})
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": ("sanamxay",)})
 
     (placed,) = resolve_event_places([("Sanamxai", "Bokeo")], gazetteer)
 
@@ -359,7 +359,7 @@ def test_a_correction_is_read_only_for_the_country_that_declares_it(write_gadm_c
     table = tmp_path / "corrections.csv"
     table.write_text("iso,written,corrected\nLAO,Sanamxai,sanamxay\nZMB,Sanamxai,kabwe\n", encoding="utf-8")
 
-    assert read_name_corrections("LAO", path=table) == {"sanamxai": "sanamxay"}
+    assert read_name_corrections("LAO", path=table) == {"sanamxai": ("sanamxay",)}
 
 
 def test_a_correction_the_table_leaves_blank_is_not_applied(write_gadm_cache, tmp_path):
@@ -654,3 +654,46 @@ def test_a_slip_in_the_first_letter_still_finds_the_name(written, write_gadm_cac
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert nearest_name(written, gazetteer, name_shapes(gazetteer)) == "sanamxay"
+
+
+def test_one_entry_can_stand_for_several_units(write_gadm_cache):
+    """`Nghe Tinh` was a province until 1991 and is now two; `Western Visayas` is a statistical
+    region GADM never carried. Neither is a misspelling of any single unit."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(
+        corrections={"oldattapu": ("sanamxay", "samakhixay")}
+    )
+
+    (placed,) = resolve_event_places([("Old Attapu", None)], gazetteer)
+
+    assert placed == Placement({"LAO.1.1_1", "LAO.1.2_1"}, CORRECTED)
+
+
+def test_an_entry_naming_a_unit_gadm_dropped_reaches_the_rest(write_gadm_cache):
+    """A curated entry is written by hand against a GADM vintage that moves under it, so a name it
+    lists may no longer exist. The units that do still resolve."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(
+        corrections={"oldattapu": ("sanamxay", "gone from the archive")}
+    )
+
+    (placed,) = resolve_event_places([("Old Attapu", None)], gazetteer)
+
+    assert placed == Placement({"LAO.1.1_1"}, CORRECTED)
+
+
+def test_an_entry_naming_nothing_the_archive_holds_is_not_a_correction(write_gadm_cache):
+    """A curated entry outlives the GADM vintage it was written against. One that reaches no unit
+    at all is a miss, and recording it as a correction would claim geography we do not have."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(
+        corrections={"oldattapu": ("gone from the archive",)}
+    )
+
+    assert resolve_event_places([("Old Attapu", None)], gazetteer) == [Placement(set(), NAMED)]
+
+
+def test_an_entry_naming_several_units_is_read_as_several(write_gadm_cache, tmp_path):
+    """`Nghe Tinh` was one province until 1991 and is two now, so the table has to be able to say
+    so — the same shape a statistical region or an island group needs."""
+    table = tmp_path / "corrections.csv"
+    table.write_text("iso,written,corrected\nVNM,Nghe Tinh,nghean|hatinh\n", encoding="utf-8")
+
+    assert read_name_corrections("VNM", path=table) == {"nghetinh": ("nghean", "hatinh")}

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -9,6 +9,7 @@ from climate_risk.data import place_names
 from climate_risk.data.place_names import (
     CONTAINED_BY,
     CORRECTED,
+    DERIVED,
     INFERRED,
     LOCATED,
     NAME_CORRECTIONS,
@@ -862,6 +863,35 @@ def test_a_place_beside_a_road_reaches_the_place(write_gadm_cache):
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert resolve_place("Sanamxay road", None, gazetteer) == {"LAO.1.1_1"}
+
+
+def test_an_adjective_built_from_a_place_reaches_it(write_gadm_cache):
+    """EM-DAT writes a Polish powiat as `Tarnobrzeski` and GADM publishes Tarnobrzeg. Suffixing
+    reshapes the stem, so the match is on what the name opens with rather than what it equals."""
+    gazetteer = read_gazetteer("POL", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Tarnobrzeski", None)], gazetteer)
+
+    assert placed == Placement({"POL.1.1_1"}, DERIVED)
+
+
+def test_an_adjective_whose_stem_opens_two_names_reaches_neither(write_gadm_cache):
+    """`Rybnicki` leaves a stem that opens both Rybnik and Rybno. Two names equally reachable is a
+    choice, and this makes none."""
+    gazetteer = read_gazetteer("POL", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Rybnicki", None)], gazetteer)
+
+    assert placed.gids == set()
+
+
+def test_a_country_that_writes_no_adjectives_leaves_a_name_ending_that_way_alone(write_gadm_cache):
+    """The suffix is Polish morphology, not a general rule: `Nagasaki` and `Helsinki` end the same
+    way and are the names themselves."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert gazetteer.adjective is None
+    assert place_names._derived_unit("Sanamxayski", gazetteer) == set()
 
 
 def test_a_keying_rule_with_no_pattern_of_its_own_still_turns_the_cache_over(write_gadm_cache, monkeypatch):

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -3,6 +3,7 @@ import re
 
 from collections import defaultdict
 
+import geopandas as gpd
 import pytest
 
 from climate_risk.data import place_names
@@ -905,3 +906,30 @@ def test_a_keying_rule_with_no_pattern_of_its_own_still_turns_the_cache_over(wri
     rekeyed = read_gazetteer("LAO", cache_dir)
 
     assert "sznzmxzy" in rekeyed.names, "the index was rebuilt under the changed rule"
+
+
+def test_changing_which_rows_the_index_reads_turns_the_cache_over(write_gadm_cache, monkeypatch):
+    """Fingerprinting the keying rules covers how a name becomes a key, not which rows get one.
+    Ethiopia's index carries Eritrea because a table here says it used to hold it, and a cache that
+    cannot see that table change serves an index built when it said something else."""
+    cache_dir = write_gadm_cache()
+    read_gazetteer("ETH", cache_dir)
+
+    monkeypatch.setattr(place_names, "FORMERLY_INCLUDED", {})
+    reread = read_gazetteer("ETH", cache_dir)
+
+    assert "maekel" not in reread.names, "Eritrea's units cannot survive the table that pulled them in"
+
+
+def test_one_layer_does_not_answer_for_another(write_gadm_cache):
+    """`layer` chooses which table the index is built from, so two layers are two different indexes.
+    Keyed alike the second caller is handed the first one's units."""
+    cache_dir = write_gadm_cache()
+    archive = cache_dir / "gadm" / "gadm_410.gpkg"
+    everything = gpd.read_file(archive, layer="gadm_410")
+    everything[everything["GID_0"] == "ZMB"].to_file(archive, layer="zambia_only")
+
+    read_gazetteer("LAO", cache_dir)
+    from_zambia_only = read_gazetteer("LAO", cache_dir, layer="zambia_only")
+
+    assert not from_zambia_only.names, "a layer holding no Laos must not answer with another layer's units"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -633,3 +633,11 @@ def test_a_unit_word_that_names_a_real_place_is_left_alone():
     """GADM carries units called Canton, so stripping the word would reduce them to nothing and
     drop them out of the index entirely."""
     assert match_key("Canton") == "canton"
+
+
+def test_a_transposition_is_one_slip_from_the_name_it_garbles(write_gadm_cache):
+    """`Heart` for Herat and `Tapei` for Taipei are single transpositions, which a substitution-only
+    rule cannot see. Approximate matching proposes them; the table still decides."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert nearest_name("Snaamxay", gazetteer, name_shapes(gazetteer)) == "sanamxay"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -1,8 +1,14 @@
+import csv
+
+from collections import defaultdict
+
 import pytest
 
 from climate_risk.data.place_names import (
     CONTAINED_BY,
+    CORRECTED,
     LOCATED,
+    NAME_CORRECTIONS,
     NAMED,
     Placement,
     Unit,
@@ -10,6 +16,7 @@ from climate_risk.data.place_names import (
     name_shapes,
     nearest_name,
     read_gazetteer,
+    read_name_corrections,
     resolve_event_places,
     resolve_place,
 )
@@ -314,3 +321,58 @@ def test_a_name_two_edits_away_is_not_a_misspelling_of_it(write_gadm_cache):
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert nearest_name("Sanamxii", gazetteer, name_shapes(gazetteer)) is None
+
+
+def test_a_checked_misspelling_reaches_the_unit_it_stands_for(write_gadm_cache):
+    """Approximate matching proposes corrections; only the ones written into the table are applied."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": "sanamxay"})
+
+    assert resolve_event_places([("Sanamxai", None)], gazetteer) == [Placement({"LAO.1.1_1"}, CORRECTED)]
+
+
+def test_a_misspelling_nobody_checked_is_left_unplaced(write_gadm_cache):
+    """One edit from a published name is a proposal, not a correction: `Lynmouth` sits one edit from
+    Lynemouth, four hundred miles away."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_event_places([("Sanamxai", None)], gazetteer) == [Placement(set(), NAMED)]
+
+
+def test_a_container_is_preferred_to_a_checked_misspelling(write_gadm_cache):
+    """The container is coarse but certain. A wrong district is worse for a damage estimate than a
+    correct province."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": "sanamxay"})
+
+    (placed,) = resolve_event_places([("Sanamxai", "Bokeo")], gazetteer)
+
+    assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)
+
+
+def test_a_correction_is_read_only_for_the_country_that_declares_it(write_gadm_cache, tmp_path):
+    """The same written name means different places in different countries, and a table keyed only
+    on the name would carry one country's correction into every other."""
+    table = tmp_path / "corrections.csv"
+    table.write_text("iso,written,corrected\nLAO,Sanamxai,sanamxay\nZMB,Sanamxai,kabwe\n", encoding="utf-8")
+
+    assert read_name_corrections("LAO", path=table) == {"sanamxai": "sanamxay"}
+
+
+def test_a_correction_the_table_leaves_blank_is_not_applied(write_gadm_cache, tmp_path):
+    """A row can record that a candidate was checked and rejected; that is not a correction."""
+    table = tmp_path / "corrections.csv"
+    table.write_text("iso,written,corrected\nLAO,Lynmouth,\n", encoding="utf-8")
+
+    assert read_name_corrections("LAO", path=table) == {}
+
+
+def test_no_country_corrects_one_name_to_two_different_units(write_gadm_cache):
+    """`Badakhstan` and `Badakhstan province` reduce to one key, which is fine while they agree.
+    Two rows disagreeing would resolve on file order, and the table is curated by hand."""
+    targets: dict[tuple[str, str], set[str]] = defaultdict(set)
+    with NAME_CORRECTIONS.open(encoding="utf-8", newline="") as handle:
+        for row in csv.DictReader(handle):
+            targets[(row["iso"], match_key(row["written"]))].add(row["corrected"])
+
+    conflicting = {key: sorted(published) for key, published in targets.items() if len(published) > 1}
+
+    assert not conflicting, f"one name corrected two ways: {sorted(conflicting.items())[:5]}"

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -9,6 +9,7 @@ from climate_risk.data import place_names
 from climate_risk.data.place_names import (
     CONTAINED_BY,
     CORRECTED,
+    INFERRED,
     LOCATED,
     NAME_CORRECTIONS,
     NAMED,
@@ -314,16 +315,6 @@ def test_a_misspelling_nobody_checked_is_left_unplaced(write_gadm_cache):
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     assert resolve_event_places([("Sanamxai", None)], gazetteer) == [Placement(set(), NAMED)]
-
-
-def test_a_container_is_preferred_to_a_checked_misspelling(write_gadm_cache):
-    """The container is coarse but certain. A wrong district is worse for a damage estimate than a
-    correct province."""
-    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": ("sanamxay",)})
-
-    (placed,) = resolve_event_places([("Sanamxai", "Bokeo")], gazetteer)
-
-    assert placed == Placement({"LAO.2_1"}, CONTAINED_BY)
 
 
 def test_a_name_two_edits_away_is_not_a_misspelling_of_it(write_gadm_cache):
@@ -713,3 +704,59 @@ def test_a_country_that_lost_nothing_reads_only_itself(write_gadm_cache):
     gazetteer = read_gazetteer("ERI", write_gadm_cache())
 
     assert resolve_place("Mekele", None, gazetteer) == set()
+
+
+def test_a_checked_misspelling_is_preferred_to_the_container(write_gadm_cache):
+    """A correction someone checked is as certain as the container and names one unit where the
+    container names everything inside it."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())._replace(corrections={"sanamxai": ("sanamxay",)})
+
+    (placed,) = resolve_event_places([("Sanamxai", "Bokeo")], gazetteer)
+
+    assert placed == Placement({"LAO.1.1_1"}, CORRECTED)
+
+
+def test_an_unchecked_slip_the_container_vouches_for_is_taken(write_gadm_cache):
+    """`Zheijang` beside Guangdong, Hunan and Fujian is not a guess. Where the container holds
+    exactly one candidate, one edit from a published name is enough."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Sanamxai", "Attapu")], gazetteer)
+
+    assert placed == Placement({"LAO.1.1_1"}, INFERRED)
+
+
+def test_an_unchecked_slip_a_sibling_vouches_for_is_taken(write_gadm_cache):
+    """The event's other places do the vouching where the prose gave no container."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    _, inferred = resolve_event_places([("Samakhixay", None), ("Sanamxai", None)], gazetteer)
+
+    assert inferred == Placement({"LAO.1.1_1"}, INFERRED)
+
+
+def test_an_unchecked_slip_nothing_vouches_for_is_refused(write_gadm_cache):
+    """`Lynmouth` sits one edit from Lynemouth, four hundred miles away. With no container and no
+    sibling, one edit is a guess and the place stays unplaced."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    assert resolve_event_places([("Sanamxai", None)], gazetteer) == [Placement(set(), NAMED)]
+
+
+def test_a_slip_the_container_does_not_hold_is_refused(write_gadm_cache):
+    """A container that vouches for none of the candidates is not corroboration."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Sanamxai", "Bokeo")], gazetteer)
+
+    assert placed == Placement({"LAO.2_1"}, CONTAINED_BY), "falls back to the container, not the slip"
+
+
+def test_a_slip_vouched_for_at_two_places_at_once_is_refused(write_gadm_cache):
+    """`Attapu` is a province and, elsewhere, a district of Bokeo. An event naming places in both
+    vouches for both candidates, which is not corroboration — it is a coin toss."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    *_, ambiguous = resolve_event_places([("Sanamxay", None), ("Houayxay", None), ("Attapy", None)], gazetteer)
+
+    assert ambiguous == Placement(set(), NAMED)

--- a/tests/data/test_placement.py
+++ b/tests/data/test_placement.py
@@ -1,0 +1,34 @@
+from climate_risk.data.placement import available_geocoders
+
+
+def test_a_gazetteer_of_settlements_is_asked_before_a_gazetteer_of_everything(write_geonames_cache, write_osm_cache):
+    """GeoNames rows are populated places, so a name it knows is a settlement. Nominatim answers
+    with whatever carries the name, which is worth having only where GeoNames has nothing."""
+    write_geonames_cache()
+    cache_dir = write_osm_cache([("bacolod", "Bacolod", 0.0, 0.0, "place", "village")], iso="PHL")
+
+    first, _ = available_geocoders("PHL", cache_dir)
+
+    assert first("PHL", "Bacolod") == (122.95, 10.667), "the GeoNames city, not the OSM point"
+
+
+def test_a_name_geonames_has_no_row_for_reaches_the_openstreetmap_point(write_geonames_cache, write_osm_cache):
+    """The whole reason for the second source: two thirds of what stays unplaced has no GeoNames
+    row at all."""
+    write_geonames_cache()
+    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")], iso="PHL")
+
+    answers = [point for locate in available_geocoders("PHL", cache_dir) if (point := locate("PHL", "Dzidzole"))]
+
+    assert answers == [(1.23, 6.16)]
+
+
+def test_a_country_with_no_geonames_dump_still_offers_openstreetmap(write_geonames_cache, write_osm_cache):
+    """GeoNames files its dumps by country and does not publish one for every country. A source
+    that cannot answer has to step aside, not take the country's other points down with it."""
+    write_geonames_cache(alpha2="PH", alpha3="PHL")
+    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")], iso="LAO")
+
+    (only,) = available_geocoders("LAO", cache_dir)
+
+    assert only("LAO", "Dzidzole") == (1.23, 6.16)

--- a/tests/data/test_placement.py
+++ b/tests/data/test_placement.py
@@ -5,7 +5,7 @@ def test_a_gazetteer_of_settlements_is_asked_before_a_gazetteer_of_everything(wr
     """GeoNames rows are populated places, so a name it knows is a settlement. Nominatim answers
     with whatever carries the name, which is worth having only where GeoNames has nothing."""
     write_geonames_cache()
-    cache_dir = write_osm_cache([("bacolod", "Bacolod", 0.0, 0.0, "place", "village")], iso="PHL")
+    cache_dir = write_osm_cache([("Bacolod", 0.0, 0.0, "place", "village")], iso="PHL")
 
     first, _ = available_geocoders("PHL", cache_dir)
 
@@ -16,7 +16,7 @@ def test_a_name_geonames_has_no_row_for_reaches_the_openstreetmap_point(write_ge
     """The whole reason for the second source: two thirds of what stays unplaced has no GeoNames
     row at all."""
     write_geonames_cache()
-    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")], iso="PHL")
+    cache_dir = write_osm_cache([("Dzidzole", 1.23, 6.16, "place", "village")], iso="PHL")
 
     answers = [point for locate in available_geocoders("PHL", cache_dir) if (point := locate("PHL", "Dzidzole"))]
 
@@ -27,7 +27,7 @@ def test_a_country_with_no_geonames_dump_still_offers_openstreetmap(write_geonam
     """GeoNames files its dumps by country and does not publish one for every country. A source
     that cannot answer has to step aside, not take the country's other points down with it."""
     write_geonames_cache(alpha2="PH", alpha3="PHL")
-    cache_dir = write_osm_cache([("dzidzole", "Dzidzole", 1.23, 6.16, "place", "village")], iso="LAO")
+    cache_dir = write_osm_cache([("Dzidzole", 1.23, 6.16, "place", "village")], iso="LAO")
 
     (only,) = available_geocoders("LAO", cache_dir)
 

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -8,6 +8,7 @@ from climate_risk.config.schema import CountryConfig
 from climate_risk.data.co2 import CO2
 from climate_risk.data.fetch import USER_AGENT
 from climate_risk.data.gadm import GADM
+from climate_risk.data.geonames import COUNTRY_INFO, country_dump
 from climate_risk.data.gpcc import FULL_DATA, MONITORING
 from climate_risk.data.hadcrut import HADCRUT
 from climate_risk.data.ocean_heat import OCEAN_HEAT
@@ -137,6 +138,9 @@ SOURCES = (
         "WORLD": WORLD,
         "COASTLINE": COASTLINE,
         "RIVERS": RIVERS,
+        "GEONAMES_COUNTRY_INFO": COUNTRY_INFO,
+        # Every country dump shares one URL pattern, so one stands for all of them.
+        "GEONAMES_DUMP": country_dump("PH"),
     }
     | {archive.filename: archive for archive in FULL_DATA.sources}
     | {archive.filename: archive for archive in (MONITORING.sources[0], MONITORING.sources[-1])}

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -503,6 +503,15 @@ def test_a_preposition_joining_a_place_to_its_container_is_dropped():
     ]
 
 
+def test_a_leaked_spreadsheet_label_is_dropped_from_the_name():
+    """EM-DAT writes `Level 1 = Uttar Pradesh` in the location column, and the label reaches the
+    matcher as part of the place name."""
+    assert named_places("Level 1 = Uttar Pradesh; Bihar") == [
+        NamedPlace("Uttar Pradesh", None),
+        NamedPlace("Bihar", None),
+    ]
+
+
 def test_a_place_named_twice_appears_once():
     """`Savannakhet, Kham Muane, Savannakhet` would otherwise weight one province double in
     whatever counts the places."""

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -494,6 +494,15 @@ def test_unbalanced_parentheses_still_yield_the_container(location, expected):
     assert named_places(location) == [NamedPlace(*pair) for pair in expected]
 
 
+def test_a_preposition_joining_a_place_to_its_container_is_dropped():
+    """EM-DAT writes `Montgomery County in (Tennessee state)`, and the split leaves the preposition
+    on the end of a name that would otherwise match."""
+    assert named_places("Clarksville City, Montgomery County in (Tennesee state)") == [
+        NamedPlace("Clarksville City", "Tennesee state"),
+        NamedPlace("Montgomery County", "Tennesee state"),
+    ]
+
+
 def test_a_place_named_twice_appears_once():
     """`Savannakhet, Kham Muane, Savannakhet` would otherwise weight one province double in
     whatever counts the places."""

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -12,12 +12,14 @@ from climate_risk.data_functions.emdat_processing import (
     DISASTER_TYPES,
     EMDAT_WINDOW_START,
     GEOMETRY_SOURCES,
+    NamedPlace,
     count_events_by_type,
     country_year_grid,
     event_filter,
     event_geography,
     event_units,
     load_emdat_events,
+    named_places,
     total_damage,
 )
 from tests.conftest import emdat_event
@@ -406,6 +408,87 @@ def test_a_unit_carrying_no_gid_names_the_event_it_came_from(write_emdat_cache):
 
     with pytest.raises(ValueError, match="broken"):
         event_units(load_emdat_events(cache_dir))
+
+
+def test_a_flat_list_of_places_explodes_to_one_row_each():
+    assert named_places("Cagayan, Ilocos Norte, Kalin-Aapayo province") == [
+        NamedPlace("Cagayan", None),
+        NamedPlace("Ilocos Norte", None),
+        NamedPlace("Kalin-Aapayo province", None),
+    ]
+
+
+def test_a_container_applies_to_every_place_since_the_last_one():
+    """EM-DAT writes a run of districts then the province holding all of them. Attaching the parent
+    to the nearest place alone would leave the rest unconstrained, and the parent is what tells a
+    repeated district name which province it is in."""
+    places = named_places("Muang Nakhon Si Thammarat, Hua Sai, Pak Phanang districts (Nakhon Si Thammarat province)")
+
+    assert [place.parent for place in places] == ["Nakhon Si Thammarat province"] * 3
+
+
+def test_a_second_container_starts_a_new_group():
+    """One event names districts of several provinces in sequence. A parent that leaked past its
+    own group would put every later district in the first province named."""
+    places = named_places("Ilocos Norte districts (Region II province), Batanes, Cagayan (Region III province)")
+
+    assert places == [
+        NamedPlace("Ilocos Norte districts", "Region II province"),
+        NamedPlace("Batanes", "Region III province"),
+        NamedPlace("Cagayan", "Region III province"),
+    ]
+
+
+def test_a_nested_parenthesis_glosses_the_container_rather_than_nesting_inside_it():
+    """`Region I (Ilocos region)` is one place under two names, not a place inside a place. Reading
+    the inner group as a further parent invents a level of hierarchy the prose does not claim."""
+    assert named_places("Ilocos Norte district (Region I (Ilocos region) province)") == [
+        NamedPlace("Ilocos Norte district", "Region I province")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        ("Maradu, Long Lama (Northern Sarawak", [("Maradu", "Northern Sarawak"), ("Long Lama", "Northern Sarawak")]),
+        ("Kakinada (Andhra Pradesh state))", [("Kakinada", "Andhra Pradesh state")]),
+    ],
+    ids=["never closed", "closed twice"],
+)
+def test_unbalanced_parentheses_still_yield_the_container(location, expected):
+    """Fifty of the workbook's location strings are truncated or double-closed. A parser that gave
+    up on them would drop the container that disambiguates the places it does read."""
+    assert named_places(location) == [NamedPlace(*pair) for pair in expected]
+
+
+def test_a_place_named_twice_appears_once():
+    """`Savannakhet, Kham Muane, Savannakhet` would otherwise weight one province double in
+    whatever counts the places."""
+    assert named_places("Savannakhet, Kham Muane, Savannakhet") == [
+        NamedPlace("Savannakhet", None),
+        NamedPlace("Kham Muane", None),
+    ]
+
+
+def test_a_conjunction_is_not_a_separator():
+    """Seventy-five GADM units are named like this. Splitting on `and` would destroy exactly the
+    names the match is looking for, so a span is left whole for the resolver to interpret."""
+    assert named_places("Newfoundland and Labrador") == [NamedPlace("Newfoundland and Labrador", None)]
+
+
+def test_a_conjunction_stranded_by_the_split_is_dropped():
+    """`X, and Y` splits on the comma and leaves the conjunction on the second place. No GADM unit
+    is named with a leading `and`, so the fragment would match nothing and lose the place."""
+    assert named_places("Aceh, and Sumatera Utara provinces") == [
+        NamedPlace("Aceh", None),
+        NamedPlace("Sumatera Utara provinces", None),
+    ]
+
+
+@pytest.mark.parametrize("location", [None, "", "   ", "()"], ids=["null", "empty", "whitespace", "empty group"])
+def test_text_naming_nothing_yields_nothing(location):
+    """Two thirds of the workbook has no location text, and a country-tier event reaches here."""
+    assert named_places(location) == []
 
 
 @pytest.mark.requires_emdat

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -18,6 +18,7 @@ from climate_risk.data_functions.emdat_processing import (
     event_filter,
     event_geography,
     event_units,
+    events_missing_units,
     load_emdat_events,
     named_places,
     total_damage,
@@ -299,6 +300,38 @@ def test_every_disaster_type_gets_a_column_in_a_stable_order(write_emdat_cache):
 REAL_CACHE_DIR = Path(__file__).parents[2] / "data"
 
 SHIPPED_PLACE_KEYS = sorted(path.stem for path in (CONFIG_ROOT / "places").glob("*.toml"))
+
+
+def test_an_event_carrying_units_is_not_offered_for_resolution(write_emdat_cache):
+    """Two thirds of the workbook has no units, and re-resolving the third that does would override
+    EM-DAT's own coding with a name match."""
+    events = load_emdat_events(
+        write_emdat_cache(
+            [
+                emdat_event(
+                    {"DisNo.": "2018-0001-LAO", "Location": "Attapu", "GADM Admin Units": '[{"gid_1": "LAO.1_1"}]'}
+                ),
+                emdat_event({"DisNo.": "2018-0002-LAO", "Location": "Bokeo", "GADM Admin Units": ""}),
+            ]
+        )
+    )
+
+    assert [event.disno for event in events_missing_units(events)] == ["2018-0002-LAO"]
+
+
+def test_an_event_whose_text_names_nothing_is_left_out(write_emdat_cache):
+    """`Countrywide` and `N.A. on the source` reach no gazetteer, and carrying them makes a caller
+    fetch an archive for a country it can place nothing in."""
+    events = load_emdat_events(
+        write_emdat_cache(
+            [
+                emdat_event({"DisNo.": "2018-0003-LAO", "Location": "()", "GADM Admin Units": ""}),
+                emdat_event({"DisNo.": "2018-0004-LAO", "Location": "Bokeo", "GADM Admin Units": ""}),
+            ]
+        )
+    )
+
+    assert [event.disno for event in events_missing_units(events)] == ["2018-0004-LAO"]
 
 
 @pytest.mark.requires_emdat

--- a/tools/fetch_geonames.py
+++ b/tools/fetch_geonames.py
@@ -1,0 +1,87 @@
+import sys
+
+from pathlib import Path
+
+import requests
+
+from climate_risk.data.geonames import load_place_points, read_country_codes
+from climate_risk.data_functions.emdat_processing import events_missing_units, load_emdat_events
+
+CACHE_DIR = Path(__file__).parents[1] / "data"
+
+
+def countries_needing_a_geocoder(cache_dir: Path) -> list[str]:
+    """
+    Name every country holding an event EM-DAT left without administrative units.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    list of str
+        ISO 3166-1 alpha-3 codes, in alphabetical order.
+    """
+    return sorted({event.iso for event in events_missing_units(load_emdat_events(cache_dir))})
+
+
+# One host, a couple of hundred requests: a transient timeout is expected, not exceptional.
+ATTEMPTS = 3
+
+
+def _index_country(iso: str, cache_dir: Path) -> int:
+    for attempt in range(1, ATTEMPTS):
+        try:
+            return len(load_place_points(iso, cache_dir))
+        except requests.RequestException as failure:
+            print(f"  {iso}: {type(failure).__name__}, retrying ({attempt}/{ATTEMPTS})", flush=True)
+
+    return len(load_place_points(iso, cache_dir))
+
+
+def fetch(isos: list[str], cache_dir: Path) -> int:
+    """
+    Download and index each country's dump, carrying on past the ones that fail.
+
+    Parameters
+    ----------
+    isos : list of str
+        ISO 3166-1 alpha-3 codes to index.
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    int
+        How many countries could not be indexed, which is the process exit status.
+    """
+    codes = read_country_codes(cache_dir)
+    absent, failed, built = [], [], 0
+
+    for position, iso in enumerate(isos, start=1):
+        if iso not in codes:
+            absent.append(iso)
+            continue
+        try:
+            names = _index_country(iso, cache_dir)
+        except (requests.RequestException, OSError, ValueError) as failure:
+            failed.append(iso)
+            print(f"[{position}/{len(isos)}] {iso}: FAILED, {type(failure).__name__}: {failure}", flush=True)
+            continue
+        built += 1
+        print(f"[{position}/{len(isos)}] {iso} ({codes[iso]}): {names} names", flush=True)
+
+    print(f"\nindexed {built} countries")
+    if absent:
+        print(f"GeoNames publishes no dump for {len(absent)}: {', '.join(absent)}")
+    if failed:
+        print(f"{len(failed)} failed and can be retried by running again: {', '.join(failed)}")
+
+    return len(failed)
+
+
+if __name__ == "__main__":
+    requested = [iso.upper() for iso in sys.argv[1:]] or countries_needing_a_geocoder(CACHE_DIR)
+    raise SystemExit(fetch(requested, CACHE_DIR))

--- a/tools/fetch_osm_places.py
+++ b/tools/fetch_osm_places.py
@@ -1,0 +1,187 @@
+import logging
+import sys
+
+from collections import defaultdict
+from pathlib import Path
+
+import requests
+
+from climate_risk.data.geocoding import units_containing_points, units_from_geocoders
+from climate_risk.data.geonames import read_country_codes
+from climate_risk.data.osm import (
+    PLACE_CATEGORIES,
+    RATE_LIMIT_SECONDS,
+    NominatimAnswer,
+    osm_geocoder,
+    read_osm_places,
+    record_lookups,
+    search_nominatim,
+)
+from climate_risk.data.place_names import NAMED, read_gazetteer, resolve_event_places
+from climate_risk.data.placement import available_geocoders
+from climate_risk.data_functions.emdat_processing import events_missing_units, load_emdat_events
+from climate_risk.exceptions import UpstreamUnavailableError
+
+_log = logging.getLogger(__name__)
+
+CACHE_DIR = Path(__file__).parents[1] / "data"
+
+# Written often enough to be worth a request, and no more than Nominatim should be asked in one go.
+MOST_NAMES_PER_RUN = 4000
+
+# A failed request is usually one bad name and sometimes a block. Enough failures in a row mean
+# the second, and carrying on would cache thousands of absences that were never asked about.
+MOST_FAILURES_IN_A_ROW = 5
+
+
+def places_still_unplaced(cache_dir: Path) -> dict[str, set[str]]:
+    """
+    Collect the written places the resolver still reaches no unit for, keyed by country.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    dict mapping str to set of str
+        The distinct names left unplaced in each country.
+    """
+    by_country: dict[str, list] = defaultdict(list)
+    for event in events_missing_units(load_emdat_events(cache_dir)):
+        by_country[event.iso].append(event)
+
+    unplaced: dict[str, set[str]] = defaultdict(set)
+    for iso, events in sorted(by_country.items()):
+        gazetteer = read_gazetteer(iso, cache_dir)
+        if not gazetteer.names:
+            continue
+        wanted = {place.name for event in events for place in event.places}
+        located = units_from_geocoders(wanted, iso, cache_dir, available_geocoders(iso, cache_dir))
+
+        for event in events:
+            placed = resolve_event_places([(p.name, p.parent) for p in event.places], gazetteer, located=located)
+            for place, placement in zip(event.places, placed, strict=True):
+                if not placement.gids and placement.how == NAMED:
+                    unplaced[iso].add(place.name)
+
+    return unplaced
+
+
+def crawl(cache_dir: Path, wanted: list[str] | None = None) -> None:
+    """
+    Ask Nominatim about every unplaced name not already asked about, and cache what it says.
+
+    A name is asked about once, ever. Misses are cached alongside hits, so a second run costs a
+    request only for names the workbook has gained since the first.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+    wanted : list of str, optional
+        ISO 3166-1 alpha-3 codes to crawl. Default None, which crawls every country with unplaced
+        names.
+    """
+    unplaced = places_still_unplaced(cache_dir)
+    countries = [iso for iso in sorted(unplaced) if not wanted or iso in wanted]
+    alpha2 = read_country_codes(cache_dir)
+
+    outstanding = {
+        iso: sorted(unplaced[iso] - set(read_osm_places(iso, cache_dir)["written"].to_list())) for iso in countries
+    }
+    total = sum(len(names) for names in outstanding.values())
+    if total > MOST_NAMES_PER_RUN:
+        print(f"{total} names outstanding, which is more than {MOST_NAMES_PER_RUN} to ask in one run.")
+        print("Name the countries to crawl, worst first — see tools/survey_unplaced_places.py.")
+        return
+
+    print(
+        f"{total} names to ask about across {len(countries)} countries, {total * RATE_LIMIT_SECONDS / 60:.0f} minutes"
+    )
+    with requests.Session() as session:
+        for iso in countries:
+            names = outstanding[iso]
+            if not names:
+                continue
+            answers = ask_about(names, alpha2.get(iso), session)
+            record_lookups(iso, cache_dir, answers)
+            usable = sum(1 for answer in answers.values() if answer and answer.category in PLACE_CATEGORIES)
+            print(
+                f"  {iso}  asked {len(answers):4d}, {sum(answer is not None for answer in answers.values()):4d} found, "
+                f"{usable:4d} of them a place or boundary",
+                flush=True,
+            )
+            if len(answers) < len(names):
+                print(f"  stopping: Nominatim failed {MOST_FAILURES_IN_A_ROW} times running. Nothing else was asked.")
+                return
+
+    report(cache_dir, countries)
+
+
+def ask_about(names: list[str], alpha2: str | None, session: requests.Session) -> dict[str, NominatimAnswer | None]:
+    """
+    Ask Nominatim about each name, stopping early if it stops answering at all.
+
+    Parameters
+    ----------
+    names : list of str
+        The places as written.
+    alpha2 : str or None
+        ISO 3166-1 alpha-2 code to confine the search to.
+    session : requests.Session
+        Session to make the requests on.
+
+    Returns
+    -------
+    dict mapping str to NominatimAnswer or None
+        What Nominatim said about each name it was asked about. Shorter than ``names`` where the run
+        stopped early, so the names it never reached stay unasked rather than cached as missing.
+    """
+    answers: dict[str, NominatimAnswer | None] = {}
+    failures = 0
+    for name in names:
+        try:
+            answers[name] = search_nominatim(name, alpha2, session=session)
+        except UpstreamUnavailableError as unreachable:
+            _log.warning(unreachable)
+            failures += 1
+            if failures >= MOST_FAILURES_IN_A_ROW:
+                break
+            continue
+        failures = 0
+
+    return answers
+
+
+def report(cache_dir: Path, countries: list[str]) -> None:
+    """
+    Say how many unplaced names the cached answers would now place, country by country.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+    countries : list of str
+        ISO 3166-1 alpha-3 codes to report on.
+    """
+    unplaced = places_still_unplaced(cache_dir)
+    asked = placeable = 0
+    for iso in countries:
+        locate = osm_geocoder(iso, cache_dir)
+        points = {name: xy for name in unplaced.get(iso, ()) if (xy := locate(iso, name)) is not None}
+        inside = units_containing_points(points, iso, cache_dir) if points else {}
+        asked += len(unplaced.get(iso, ()))
+        placeable += len(inside)
+        if points:
+            print(f"  {iso}  {len(inside):4d} of {len(unplaced.get(iso, ())):4d} unplaced names now reach a unit")
+
+    if asked:
+        print(
+            f"\n{placeable} of {asked} unplaced names reach a GADM unit through OpenStreetMap ({placeable / asked:.1%})"
+        )
+
+
+if __name__ == "__main__":
+    crawl(CACHE_DIR, [code.upper() for code in sys.argv[1:]] or None)

--- a/tools/survey_unplaced_places.py
+++ b/tools/survey_unplaced_places.py
@@ -1,0 +1,276 @@
+import re
+import sys
+
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from climate_risk.data.geocoding import units_from_geocoders
+from climate_risk.data.place_names import (
+    CONJUNCTION,
+    DASH,
+    FEATURE,
+    MIN_APPROXIMATE_LENGTH,
+    MIN_SPLIT_LENGTH,
+    NAMED,
+    UNIT_NOUNS,
+    Gazetteer,
+    match_key,
+    read_gazetteer,
+    resolve_event_places,
+    resolve_place,
+)
+from climate_risk.data.placement import available_geocoders
+from climate_risk.data_functions.emdat_processing import events_missing_units, load_emdat_events
+
+CACHE_DIR = Path(__file__).parents[1] / "data"
+
+# How far a written name is allowed to stray before the search stops calling it the same name.
+EDIT_BUDGET = 2
+
+# Longer than any single published name in GADM, so a mention this long is several run together.
+LONGEST_SINGLE_NAME = 24
+
+# Shorter than this, capitalisation says nothing: plenty of real names are three letters.
+SHORTEST_SHOUTED_NAME = 3
+
+MOJIBAKE = re.compile(r"[ÃÂ]")
+ABBREVIATION = re.compile(r"\b(?:st|ste|sta|mt|ft|isl|is|no|dept)\b\.?", re.IGNORECASE)
+ADJECTIVAL = re.compile(r"(?:ski|cki|zki|sky|ien|ais|ese|ien)$", re.IGNORECASE)
+PARENTHETICAL = re.compile(r"[(\[]")
+POSSESSIVE = re.compile(r"\w's\b", re.IGNORECASE)
+SENTENCE = re.compile(r"\b(?:of|the|de|du|des|la|le|el|in|on|at)\b", re.IGNORECASE)
+
+
+def edits_away(written: str, published: str, budget: int) -> int | None:
+    """
+    Count the edits turning one key into another, or None where it takes more than the budget.
+
+    Parameters
+    ----------
+    written : str
+        The key the mention reduces to.
+    published : str
+        The key a GADM name reduces to.
+    budget : int
+        The most edits worth counting.
+
+    Returns
+    -------
+    int or None
+        The distance, or None where it exceeds the budget.
+    """
+    if abs(len(written) - len(published)) > budget:
+        return None
+
+    previous = list(range(len(published) + 1))
+    for position, letter in enumerate(written, start=1):
+        current = [position]
+        for other, published_letter in enumerate(published, start=1):
+            current.append(
+                min(previous[other] + 1, current[other - 1] + 1, previous[other - 1] + (letter != published_letter))
+            )
+        if min(current) > budget:
+            return None
+        previous = current
+
+    return previous[-1] if previous[-1] <= budget else None
+
+
+def signatures(name: str, parent: str | None, gazetteer: Gazetteer) -> set[str]:
+    """
+    Name every mechanically detectable property of a written place that a repair could act on.
+
+    A property is listed whether or not anything acts on it yet, because the point of the survey is
+    to show what the residual is made of rather than to confirm what is already handled. A name
+    carrying none of them is what the next rule has to be found in.
+
+    Parameters
+    ----------
+    name : str
+        The place as written.
+    parent : str or None
+        The container the prose gave, or None.
+    gazetteer : Gazetteer
+        The country's units, from :func:`read_gazetteer`.
+
+    Returns
+    -------
+    set of str
+        The properties the name carries.
+    """
+    found: set[str] = set()
+    key = match_key(name)
+
+    if MOJIBAKE.search(name):
+        found.add("mis-decoded characters")
+    if name.isupper() and len(name) > SHORTEST_SHOUTED_NAME:
+        found.add("written in capitals")
+    if any(character.isdigit() for character in name):
+        found.add("carries a digit")
+    if PARENTHETICAL.search(name):
+        found.add("carries a parenthetical")
+    if POSSESSIVE.search(name):
+        found.add("carries a possessive")
+    if ABBREVIATION.search(name):
+        found.add("carries an abbreviation")
+    if UNIT_NOUNS.search(name):
+        found.add("carries a unit noun")
+    if FEATURE.search(name):
+        found.add("names a physical feature")
+    if ADJECTIVAL.search(key):
+        found.add("ends in an adjectival suffix")
+    if len(SENTENCE.findall(name)) >= 2:
+        found.add("reads as a phrase rather than a name")
+    if len(key) < MIN_APPROXIMATE_LENGTH:
+        found.add("too short to correct")
+    if len(key) > LONGEST_SINGLE_NAME:
+        found.add("long enough to be several names run together")
+
+    parts = [part.strip() for part in DASH.split(name) if part.strip()]
+    if len(parts) > 1:
+        if any(len(match_key(part)) < MIN_SPLIT_LENGTH for part in parts):
+            found.add("dashed, and a part is too short to be a place")
+        else:
+            reached = [bool(resolve_place(part, parent, gazetteer)) for part in parts]
+            if not any(reached):
+                found.add("dashed, and no part names a unit")
+            elif not all(reached):
+                found.add("dashed, and only some parts name a unit")
+
+    if CONJUNCTION.search(name):
+        joined = [part.strip() for part in CONJUNCTION.split(name) if part.strip()]
+        if not any(resolve_place(part, parent, gazetteer) for part in joined):
+            found.add("joined by a conjunction, and no part names a unit")
+
+    if parent:
+        found.add(
+            "has a container that reaches a unit"
+            if resolve_place(parent, None, gazetteer)
+            else "has a container that reaches nothing"
+        )
+    else:
+        found.add("has no container")
+
+    return found
+
+
+def survey(cache_dir: Path, only: str | None = None) -> None:
+    """
+    Partition every unplaced place by what it is made of, and by how far it sits from a published name.
+
+    Countries are ranked by the share of their rows left unplaced rather than by the count. A count
+    ranking follows how many events a country has, so it puts the countries the resolver already
+    handles at the top and buries the ones with a cause of their own.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+    only : str, optional
+        ISO 3166-1 alpha-3 code to list every distinct unplaced name for, instead of surveying every
+        country. Default None, which surveys all of them.
+    """
+    by_country: dict[str, list] = defaultdict(list)
+    for event in events_missing_units(load_emdat_events(cache_dir)):
+        by_country[event.iso].append(event)
+    if only:
+        by_country = {only: by_country.get(only, [])}
+
+    carried: Counter[str] = Counter()
+    unplaced_per_country: Counter[str] = Counter()
+    rows_per_country: Counter[str] = Counter()
+    distances: Counter[str] = Counter()
+    repeated: Counter[tuple[str, str]] = Counter()
+    unsignatured: list[tuple[str, str, str | None]] = []
+    rows = 0
+
+    for position, (iso, events) in enumerate(sorted(by_country.items()), start=1):
+        gazetteer = read_gazetteer(iso, cache_dir)
+        if not gazetteer.names:
+            continue
+        wanted = {place.name for event in events for place in event.places}
+        located = units_from_geocoders(wanted, iso, cache_dir, available_geocoders(iso, cache_dir))
+
+        for event in events:
+            placed = resolve_event_places([(p.name, p.parent) for p in event.places], gazetteer, located=located)
+            for place, placement in zip(event.places, placed, strict=True):
+                rows_per_country[iso] += 1
+                if placement.gids or placement.how != NAMED:
+                    continue
+                rows += 1
+                unplaced_per_country[iso] += 1
+                repeated[(iso, place.name)] += 1
+                carrying = signatures(place.name, place.parent, gazetteer)
+                carried.update(carrying)
+                if not (
+                    carrying
+                    - {
+                        "has no container",
+                        "has a container that reaches a unit",
+                        "has a container that reaches nothing",
+                    }
+                ):
+                    unsignatured.append((iso, place.name, place.parent))
+
+                key = match_key(place.name)
+                near = {
+                    distance
+                    for published in gazetteer.names
+                    if (distance := edits_away(key, published, EDIT_BUDGET)) is not None
+                }
+                distances[
+                    f"{min(near)} edits from a published name" if near else "no published name within two edits"
+                ] += 1
+
+        if position % 40 == 0:
+            print(f"  ... {position}/{len(by_country)} countries", flush=True)
+
+    if only:
+        print(f"\n{rows} of {rows_per_country[only]} {only} rows unplaced, {len(repeated)} distinct names:\n")
+        for (_, name), count in sorted(repeated.items(), key=lambda item: item[0][1]):
+            print(f"  x{count}  {name!r}")
+        return
+
+    distinct = len(repeated)
+    print(f"\n{rows} unplaced rows, {distinct} distinct names, {rows / distinct:.2f} rows per name\n")
+
+    print("how far each sits from the nearest published name:")
+    for label, count in distances.most_common():
+        print(f"  {count:6d}  {count / rows:5.1%}  {label}")
+
+    print("\nwhat the names are made of, one row counted under every property it carries:")
+    for label, count in carried.most_common():
+        print(f"  {count:6d}  {count / rows:5.1%}  {label}")
+
+    print(f"\n{len(unsignatured)} rows carry no property at all, which is where the next rule has to be found:")
+    for iso, name, parent in unsignatured[:40]:
+        print(f"    {iso}  {name!r}   container: {parent!r}")
+
+    print("\nwhere a country-wide cause is most likely, by the share of its rows left unplaced:")
+    print("  (countries with fewer than 20 unplaced rows are left out, being too small to read)")
+    running = 0
+    worst = sorted(
+        unplaced_per_country, key=lambda iso: unplaced_per_country[iso] / rows_per_country[iso], reverse=True
+    )
+    for iso in [iso for iso in worst if unplaced_per_country[iso] >= 20][:25]:
+        count = unplaced_per_country[iso]
+        running += count
+        share = count / rows_per_country[iso]
+        print(f"  {iso}  {count:5d} of {rows_per_country[iso]:6d} rows  {share:5.1%} unplaced   {running / rows:5.1%}")
+    holding_half = 0
+    running = 0
+    for _, count in unplaced_per_country.most_common():
+        running += count
+        holding_half += 1
+        if running >= rows // 2:
+            break
+    print(f"\n  {holding_half} of {len(unplaced_per_country)} countries hold half the residual")
+
+    print("\nthe names that would repay a fix most, by how many rows carry them:")
+    for (iso, name), count in repeated.most_common(30):
+        print(f"  {count:4d}  {iso}  {name!r}")
+
+
+if __name__ == "__main__":
+    requested = sys.argv[1].upper() if len(sys.argv) > 1 else None
+    survey(CACHE_DIR, requested)

--- a/tools/verify_geocoder_against_gadm.py
+++ b/tools/verify_geocoder_against_gadm.py
@@ -1,0 +1,85 @@
+import sys
+
+from collections import Counter
+from pathlib import Path
+
+from climate_risk.data.geocoding import score_geocoder, unambiguous_units
+from climate_risk.data.geonames import geonames_geocoder
+from climate_risk.data.place_names import read_gazetteer
+from climate_risk.data_functions.emdat_processing import events_missing_units, load_emdat_events
+
+CACHE_DIR = Path(__file__).parents[1] / "data"
+
+# Candidate sources, each building a geocoder for one country.
+GEOCODERS = {"geonames": geonames_geocoder}
+
+
+def places_needing_geography(cache_dir: Path) -> dict[str, list[tuple[str, str | None]]]:
+    """
+    Collect the places every event EM-DAT left uncoded names, keyed by country.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    dict mapping str to list of tuple
+        Each a name as written and the container the prose gave, or None.
+    """
+    by_country: dict[str, list[tuple[str, str | None]]] = {}
+    for event in events_missing_units(load_emdat_events(cache_dir)):
+        by_country.setdefault(event.iso, []).extend((place.name, place.parent) for place in event.places)
+
+    return by_country
+
+
+def report_answer_key(cache_dir: Path) -> None:
+    """Report how many written names already resolve to one unit, which is what a score is built on."""
+    totals: Counter[str] = Counter()
+    per_country: Counter[str] = Counter()
+
+    for iso, places in places_needing_geography(cache_dir).items():
+        gazetteer = read_gazetteer(iso, cache_dir)
+        if not gazetteer.names:
+            continue
+        settled = unambiguous_units(places, gazetteer)
+        totals["names"] += len({name for name, _ in places})
+        totals["with an answer"] += len(settled)
+        per_country[iso] = len(settled)
+
+    print(f"{totals['with an answer']} of {totals['names']} distinct written names resolve to exactly one unit")
+    print(f"{sum(1 for count in per_country.values() if count >= 30)} countries carry at least 30\n")
+    print(f"{'iso':<5}{'answer key':>12}")
+    for iso, count in per_country.most_common(15):
+        print(f"{iso:<5}{count:>12}")
+
+
+def report_score(name: str, cache_dir: Path) -> None:
+    """Score one registered geocoder against every country's answer key."""
+    outcomes: Counter[str] = Counter()
+
+    for iso, places in places_needing_geography(cache_dir).items():
+        gazetteer = read_gazetteer(iso, cache_dir)
+        if not gazetteer.names:
+            continue
+        geocode = GEOCODERS[name](iso, cache_dir)
+        for scored in score_geocoder(geocode, iso, places, gazetteer, cache_dir):
+            outcomes[scored.outcome] += 1
+
+    judged = sum(outcomes.values())
+    print(f"{name}: {judged} names judged")
+    for outcome, count in outcomes.most_common():
+        print(f"  {count:>7}  {count / judged:>5.1%}  {outcome}")
+
+
+if __name__ == "__main__":
+    requested = sys.argv[1] if len(sys.argv) > 1 else None
+    if requested is None:
+        report_answer_key(CACHE_DIR)
+    elif requested in GEOCODERS:
+        report_score(requested, CACHE_DIR)
+    else:
+        print(f"no geocoder named {requested!r} is registered; known: {sorted(GEOCODERS) or 'none yet'}")
+        raise SystemExit(1)

--- a/tools/verify_name_corrections.py
+++ b/tools/verify_name_corrections.py
@@ -1,0 +1,181 @@
+import csv
+import json
+import re
+import sys
+
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import requests
+
+from climate_risk.data.place_names import NAME_CORRECTIONS, read_gazetteer
+
+CACHE_DIR = Path(__file__).parents[1] / "data"
+
+# Verdicts land here for review. Promoting them into the shipped table is a separate, deliberate
+# step: that file is curated, and a rerun must not overwrite what someone has already checked.
+PROPOSED = Path(__file__).parents[1] / "proposed_name_corrections.csv"
+
+OLLAMA = "http://localhost:11434/api/generate"
+MODEL = "qwen3.8:27b-mlx"
+BATCH = 20
+TOKEN_BUDGET_PER_ITEM = 60
+TIMEOUT_SECONDS = 600
+
+INSTRUCTION = """You are checking whether two place names refer to the same real-world place.
+
+For each numbered line you are given a country code, a place name as someone wrote it, and a
+candidate name it might be a misspelling of. The candidate is lowercased with spaces and
+punctuation removed; that is expected and is never a reason to answer DIFFERENT.
+
+Ignore anything in the written name that says what kind of unit it is rather than which one it is:
+"province", "provinces", "district", "region", "city", "isl", "island", "regency", "prefecture",
+and any leading dash or stray punctuation. "- Badakshan Province" and "Badakshan" are the same
+name for this purpose.
+
+Answer SAME only if the written name is a misspelling, transliteration or alternative rendering of
+the candidate. Answer DIFFERENT if they are two distinct real places, or if the written name is a
+country, a region, a body of water, or a well-known place elsewhere. Answer UNSURE if you cannot
+tell.
+
+Reply with one line per item, exactly `<number>: SAME`, `<number>: DIFFERENT` or `<number>: UNSURE`.
+No other text."""
+
+VERDICTS = ("SAME", "DIFFERENT", "UNSURE")
+ANSWER = re.compile(rf"\b(\d{{1,3}})\b[^0-9\n]*?\b({'|'.join(VERDICTS)})\b", re.IGNORECASE)
+
+
+def ask(items: list[tuple[str, str, str]], *, echo: bool = False) -> dict[int, str]:
+    """Put one batch to the model and read back a verdict per item, echoing the reply as it arrives."""
+    listing = "\n".join(
+        f'{n}. {iso}: "{written}" -> "{candidate}"' for n, (iso, written, candidate) in enumerate(items, 1)
+    )
+    spoken = []
+    with requests.post(
+        OLLAMA,
+        json={
+            "model": MODEL,
+            "prompt": f"{INSTRUCTION}\n\n{listing}",
+            "stream": True,
+            "think": False,
+            # Left uncapped the model restarts its answer and never stops; a verdict a line needs
+            # far less than this, and temperature 0 makes a rerun reproduce the same table.
+            "options": {"num_predict": TOKEN_BUDGET_PER_ITEM * len(items), "temperature": 0},
+        },
+        stream=True,
+        timeout=TIMEOUT_SECONDS,
+    ) as response:
+        response.raise_for_status()
+        for chunk in response.iter_lines():
+            if not chunk:
+                continue
+            piece = json.loads(chunk).get("response", "")
+            spoken.append(piece)
+            if echo:
+                print(piece, end="", flush=True)
+
+    # The model reasons in prose before answering, so a verdict is whatever it settled on last.
+    verdicts = {}
+    for number, verdict in ANSWER.findall("".join(spoken)):
+        verdicts[int(number)] = verdict.upper()
+
+    return verdicts
+
+
+def adjudicate(candidates: list[tuple[str, str, str]], *, echo: bool = False) -> dict[tuple[str, str], str]:
+    """Walk the candidates in batches, re-asking singly for any the model skipped."""
+    settled: dict[tuple[str, str], str] = {}
+
+    for start in range(0, len(candidates), BATCH):
+        batch = candidates[start : start + BATCH]
+        if echo:
+            print(f"\n--- {start + 1}-{min(start + BATCH, len(candidates))} of {len(candidates)} ---", flush=True)
+            for position, (iso, written, candidate) in enumerate(batch, 1):
+                print(f"  {position}. {iso}: {written}  ->  {candidate}", flush=True)
+            print("  model:", flush=True)
+        try:
+            verdicts = ask(batch, echo=echo)
+        except requests.RequestException as failure:
+            print(f"  batch at {start}: {type(failure).__name__}, asking one at a time", flush=True)
+            verdicts = {}
+
+        for position, (iso, written, candidate) in enumerate(batch, 1):
+            verdict = verdicts.get(position)
+            if verdict is None:
+                verdict = ask([(iso, written, candidate)], echo=echo).get(1, "UNSURE")
+            settled[(iso, written)] = verdict
+
+        done = min(start + BATCH, len(candidates))
+        print(f"  {done}/{len(candidates)}", flush=True)
+
+    return settled
+
+
+def read_candidates(path: Path) -> list[tuple[str, str, str]]:
+    """Read the `ISO  written  ->  candidate` listing the matcher produces."""
+    candidates = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        iso, _, rest = line.partition("  ")
+        written, arrow, candidate = rest.partition("  ->  ")
+        if arrow:
+            candidates.append((iso.strip(), written.strip(), candidate.strip()))
+
+    return candidates
+
+
+def check_shipped_table(cache_dir: Path) -> int:
+    """
+    Confirm every shipped correction names a unit its country publishes.
+
+    The table is curated by hand and nothing else checks it: a correction pointing at a name GADM
+    does not publish places nothing at all, silently. Reading a gazetteer for each of the countries
+    it covers takes minutes, which is why this is a script rather than a test.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    int
+        How many corrections name nothing, which is the process exit status.
+    """
+    by_country: dict[str, list[str]] = defaultdict(list)
+    with NAME_CORRECTIONS.open(encoding="utf-8", newline="") as handle:
+        for row in csv.DictReader(handle):
+            by_country[row["iso"]].append(row["corrected"])
+
+    unpublished = []
+    for iso, corrections in sorted(by_country.items()):
+        published = read_gazetteer(iso, cache_dir).names
+        unpublished += [(iso, correction) for correction in corrections if correction not in published]
+
+    total = sum(len(corrections) for corrections in by_country.values())
+    print(f"{total} corrections across {len(by_country)} countries, {len(unpublished)} naming no GADM unit")
+    for iso, correction in unpublished:
+        print(f"  {iso}  {correction}")
+
+    return len(unpublished)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "check":
+        raise SystemExit(check_shipped_table(CACHE_DIR))
+
+    listing = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("fuzzy_matches.txt")
+    candidates = read_candidates(listing)
+    print(f"adjudicating {len(candidates)} candidate corrections with {MODEL}", flush=True)
+
+    settled = adjudicate(candidates, echo=True)
+    tally = Counter(settled.values())
+
+    with PROPOSED.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(("iso", "written", "corrected", "verdict"))
+        for (iso, written), verdict in sorted(settled.items()):
+            candidate = next(c for i, w, c in candidates if (i, w) == (iso, written))
+            writer.writerow((iso, written, candidate if verdict == "SAME" else "", verdict.lower()))
+
+    print(f"\n{json.dumps(dict(tally))}")
+    print(f"written to {PROPOSED}; promote what survives review into the shipped table")

--- a/tools/verify_name_corrections.py
+++ b/tools/verify_name_corrections.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     tally = Counter(settled.values())
 
     with PROPOSED.open("w", encoding="utf-8", newline="") as handle:
-        writer = csv.writer(handle)
+        writer = csv.writer(handle, lineterminator="\n")
         writer.writerow(("iso", "written", "corrected", "verdict"))
         for (iso, written), verdict in sorted(settled.items()):
             candidate = next(c for i, w, c in candidates if (i, w) == (iso, written))

--- a/tools/verify_placement_against_emdat.py
+++ b/tools/verify_placement_against_emdat.py
@@ -112,7 +112,9 @@ def place_pinned_units(
     return placed
 
 
-def compare(expected: dict[tuple[int, int], tuple[frozenset[str], str]], placed: dict[tuple[int, int], set[str]]):
+def compare(
+    expected: dict[tuple[int, int], tuple[frozenset[str], str]], placed: dict[tuple[int, int], set[str]]
+) -> pd.DataFrame:
     """
     Score the placement of every pinned unit that had a footprint.
 
@@ -159,8 +161,8 @@ def main() -> int:
 
     print(f"agreement: {scored['agrees'].sum()}/{len(scored)} ({scored['agrees'].mean():.1%})\n")
     by_method = (
-        scored.groupby("method")["agrees"]
-        .agg(matched="sum", units="count", share="mean")
+        scored.groupby("method")
+        .agg(matched=("agrees", "sum"), units=("agrees", "count"), share=("agrees", "mean"))
         .sort_values("units", ascending=False)
     )
     print("by the migration method EM-DAT used, which the units partition between:")


### PR DESCRIPTION
EM-DAT gives most events a free-text `Location` column and no administrative units. This reads that text and resolves each written place to GADM units, trying weaker evidence in turn: the name itself, a point from a gazetteer, a checked correction, a misspelling the rest of the event vouches for, and last the container it was written in. Nothing ambiguous is taken unless another place in the same event corroborates it — that gate is what keeps a homonym from silently relocating an event, and it is applied everywhere except the point lookup, which is measured at 91% and has no second candidate to choose between.

Events with subnational geography go from **37% to 90%** of the workbook.

### Where the rows end up

The location text explodes to 34,659 written places. How each one reached a unit:

| | rows | share | |
|---|---:|---:|---|
| by its own name | 21,803 | 62.9% | exact match against GADM, including variant spellings |
| by a point | 6,180 | 17.8% | GeoNames or OpenStreetMap coordinate, resolved to the finest unit containing it |
| by the container it was written in | 1,154 | 3.3% | `Wayanad district, Kerala state` when the district itself matches nothing |
| as a checked misspelling | 688 | 2.0% | from `name_corrections.csv` |
| as a slip the event vouches for | 167 | 0.5% | one edit from a published name, corroborated by a sibling place |
| as a direction-qualified unit | 120 | 0.3% | `South Bihar` → Bihar |
| as an adjective built from a name | 16 | 0.0% | `Tarnobrzeski` → Tarnobrzeg |
| **placed** | **30,128** | **86.9%** | |
| names no unit | 1,402 | 4.0% | seas, compass points covering a whole country, empty strings |
| country absent from GADM | 608 | 1.8% | |
| unplaced | 2,521 | 7.3% | |

Of rows that could ever be placed — excluding the noise and the countries GADM does not cover — **92.3%**.

The 2,521 that remain are mostly not a matching problem: 73% have no published name within two edits. They are villages and neighborhoods no gazetteer indexes, plus statistical regions that are not administrative units. `tools/survey_unplaced_places.py` partitions them and ranks countries by the share of their rows left unplaced, which is where a country-wide cause shows up.

### Sources

| source | licence | how it arrives | what it contributes |
|---|---|---|---|
| EM-DAT | non-commercial, no redistribution | manual download after registering | the location text and the events |
| GADM 4.1 | non-commercial, no redistribution or automated download | manual download | the administrative units everything resolves to |
| GeoNames | CC BY 4.0 | `tools/fetch_geonames.py`, per country | points for names GADM does not publish |
| OpenStreetMap (Nominatim) | ODbL 1.0 | `tools/fetch_osm_places.py`, one-time rate-limited crawl | 419 usable points from 2,832 names GeoNames had nothing for |
| `name_corrections.csv` | — | ships in the package, 617 rows | misspellings and defunct units, each checked individually |

GADM and EM-DAT are declared as `ManualSource` and never appear in the fetchable registry, because both licences forbid automated download.

### Two things needing a decision

The OpenStreetMap points are cached under `data/osm/`, and `data/*` is gitignored — a fresh clone re-crawls Nominatim for about 50 minutes. Whether that 900 KB should ship in the repo is open; it is ODbL, so committing it puts an attribution and share-alike obligation on the repository that the other sources do not.

At 5,345 lines this is a lot to review in one sitting. The natural seam is `cdadf44 Place a written place by the point a geocoder gives it` — before it, resolution against GADM alone; after it, external point sources.
