### PR TITLE
Emit the geo_disasters tier from event_geography

### DIFF
--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -497,8 +497,18 @@ EVENT_GEOGRAPHY_COLUMNS = (
     "Longitude",
 )
 
+# What a caller has to supply for the `geo_disasters` tier to be emitted.
+RESOLVED_UNIT_SCHEMA = pl.Schema(
+    {
+        "DisNo.": pl.String,
+        "gid": pl.String,
+        "name": pl.String,
+        "admin_level": pl.Int8,
+    }
+)
 
-def event_geography(events: pl.DataFrame) -> pl.DataFrame:
+
+def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = None) -> pl.DataFrame:
     """
     Say where every event's geometry comes from, one row per event-unit and one per event otherwise.
 
@@ -509,10 +519,19 @@ def event_geography(events: pl.DataFrame) -> pl.DataFrame:
     ``Latitude`` and ``Longitude`` are carried wherever EM-DAT supplies them, including on ``gadm``
     rows, so the two claims stay visible side by side rather than one being discarded.
 
+    An event EM-DAT codes to units keeps only those, and ``resolved`` fills events it codes to none.
+    The two sources never disagree about where an event was, only about how finely to say it, so
+    taking both would mix a province and the districts inside it into one observation while leaving
+    ``geometry_source`` no longer describing the row.
+
     Parameters
     ----------
     events : DataFrame
         The workbook, as :func:`load_emdat_events` returns it.
+    resolved : DataFrame, optional
+        Units another gazetteer places, with the columns of ``RESOLVED_UNIT_SCHEMA``. Default None,
+        which emits no ``geo_disasters`` rows. Reading them is the caller's job: they come from a
+        polygon overlay, and this layer holds no geometry.
 
     Returns
     -------
@@ -522,10 +541,21 @@ def event_geography(events: pl.DataFrame) -> pl.DataFrame:
     """
     units = event_units(events)
     located = events.select("DisNo.", "ISO", "Latitude", "Longitude")
+    overlay = pl.DataFrame(schema=RESOLVED_UNIT_SCHEMA) if resolved is None else resolved
 
-    from_units = units.join(located, on="DisNo.", how="left").with_columns(pl.lit("gadm").alias("geometry_source"))
+    from_units = units.join(located, on="DisNo.", how="left").with_columns(
+        pl.lit("gadm").alias("geometry_source"),
+    )
 
-    rest = located.join(units.select("DisNo.").unique(), on="DisNo.", how="anti").with_columns(
+    uncoded = located.join(units.select("DisNo.").unique(), on="DisNo.", how="anti")
+    from_overlay = uncoded.join(
+        overlay.select(list(RESOLVED_UNIT_SCHEMA)).cast(RESOLVED_UNIT_SCHEMA), on="DisNo.", how="inner"
+    ).with_columns(
+        pl.lit("geo_disasters").alias("geometry_source"),
+        pl.lit(None, dtype=pl.String).alias("migration_method"),
+    )
+
+    rest = uncoded.join(overlay.select("DisNo.").unique(), on="DisNo.", how="anti").with_columns(
         pl.when(pl.col("Latitude").is_not_null())
         .then(pl.lit("emdat_point"))
         .otherwise(pl.lit("country"))
@@ -536,9 +566,9 @@ def event_geography(events: pl.DataFrame) -> pl.DataFrame:
         pl.lit(None, dtype=pl.String).alias("migration_method"),
     )
 
-    return pl.concat([from_units.select(EVENT_GEOGRAPHY_COLUMNS), rest.select(EVENT_GEOGRAPHY_COLUMNS)]).sort(
-        "DisNo.", "gid", nulls_last=True
-    )
+    tiers = (from_units, from_overlay, rest)
+
+    return pl.concat([tier.select(EVENT_GEOGRAPHY_COLUMNS) for tier in tiers]).sort("DisNo.", "gid", nulls_last=True)
 
 
 def event_filter(filters: EventFilters) -> pl.Expr:

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -512,6 +512,30 @@ RESOLVED_UNIT_SCHEMA = pl.Schema(
     }
 )
 
+# The columns a tier need not carry, and the type each takes where it does not. A tier states only
+# what it knows, so a column added to the table is declared here once instead of in every tier.
+_ABSENT_COLUMN_TYPES = pl.Schema(
+    {
+        "gid": pl.String,
+        "name": pl.String,
+        "admin_level": pl.Int8,
+        "migration_method": pl.String,
+        "geocoding_q": pl.Int8,
+        "overlap": pl.Float64,
+    }
+)
+
+
+def _with_absent_columns(tier: pl.DataFrame) -> pl.DataFrame:
+    """Fill every geography column the tier does not carry with a null of the right type."""
+    return tier.with_columns(
+        [
+            pl.lit(None, dtype=dtype).alias(name)
+            for name, dtype in _ABSENT_COLUMN_TYPES.items()
+            if name not in tier.columns
+        ]
+    )
+
 
 def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = None) -> pl.DataFrame:
     """
@@ -524,10 +548,9 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
     ``Latitude`` and ``Longitude`` are carried wherever EM-DAT supplies them, including on ``gadm``
     rows, so the two claims stay visible side by side rather than one being discarded.
 
-    An event EM-DAT codes to units keeps only those, and ``resolved`` fills events it codes to none.
-    The two sources never disagree about where an event was, only about how finely to say it, so
-    taking both would mix a province and the districts inside it into one observation while leaving
-    ``geometry_source`` no longer describing the row.
+    An event EM-DAT codes to units keeps only those, and ``resolved`` fills events it codes to none:
+    the two sources differ on how finely to name a location rather than on where it was, so taking
+    both would mix a province with the districts inside it.
 
     Parameters
     ----------
@@ -549,36 +572,25 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
     located = events.select("DisNo.", "ISO", "Latitude", "Longitude")
     overlay = pl.DataFrame(schema=RESOLVED_UNIT_SCHEMA) if resolved is None else resolved
 
-    from_units = units.join(located, on="DisNo.", how="left").with_columns(
-        pl.lit("gadm").alias("geometry_source"),
-        pl.lit(None, dtype=pl.Int8).alias("geocoding_q"),
-        pl.lit(None, dtype=pl.Float64).alias("overlap"),
-    )
+    from_units = units.join(located, on="DisNo.", how="left").with_columns(pl.lit("gadm").alias("geometry_source"))
 
     uncoded = located.join(units.select("DisNo.").unique(), on="DisNo.", how="anti")
     from_overlay = uncoded.join(
         overlay.select(list(RESOLVED_UNIT_SCHEMA)).cast(RESOLVED_UNIT_SCHEMA), on="DisNo.", how="inner"
-    ).with_columns(
-        pl.lit("geo_disasters").alias("geometry_source"),
-        pl.lit(None, dtype=pl.String).alias("migration_method"),
-    )
+    ).with_columns(pl.lit("geo_disasters").alias("geometry_source"))
 
     rest = uncoded.join(overlay.select("DisNo.").unique(), on="DisNo.", how="anti").with_columns(
         pl.when(pl.col("Latitude").is_not_null())
         .then(pl.lit("emdat_point"))
         .otherwise(pl.lit("country"))
-        .alias("geometry_source"),
-        pl.lit(None, dtype=pl.String).alias("gid"),
-        pl.lit(None, dtype=pl.String).alias("name"),
-        pl.lit(None, dtype=pl.Int8).alias("admin_level"),
-        pl.lit(None, dtype=pl.String).alias("migration_method"),
-        pl.lit(None, dtype=pl.Int8).alias("geocoding_q"),
-        pl.lit(None, dtype=pl.Float64).alias("overlap"),
+        .alias("geometry_source")
     )
 
     tiers = (from_units, from_overlay, rest)
 
-    return pl.concat([tier.select(EVENT_GEOGRAPHY_COLUMNS) for tier in tiers]).sort("DisNo.", "gid", nulls_last=True)
+    return pl.concat([_with_absent_columns(tier).select(EVENT_GEOGRAPHY_COLUMNS) for tier in tiers]).sort(
+        "DisNo.", "gid", nulls_last=True
+    )
 
 
 def event_filter(filters: EventFilters) -> pl.Expr:

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -493,17 +493,22 @@ EVENT_GEOGRAPHY_COLUMNS = (
     "name",
     "admin_level",
     "migration_method",
+    "geocoding_q",
+    "overlap",
     "Latitude",
     "Longitude",
 )
 
-# What a caller has to supply for the `geo_disasters` tier to be emitted.
+# What the `geo_disasters` tier adds, and what a caller has to supply for it to be emitted. Null on
+# every other tier, as `migration_method` already is outside `gadm`.
 RESOLVED_UNIT_SCHEMA = pl.Schema(
     {
         "DisNo.": pl.String,
         "gid": pl.String,
         "name": pl.String,
         "admin_level": pl.Int8,
+        "geocoding_q": pl.Int8,
+        "overlap": pl.Float64,
     }
 )
 
@@ -537,7 +542,8 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
     -------
     DataFrame
         ``DisNo.``, ``ISO``, ``geometry_source`` from ``GEOMETRY_SOURCES``, the unit columns of
-        :func:`event_units` where one applies, and the event's coordinate where it has one.
+        :func:`event_units` where one applies, ``geocoding_q`` and ``overlap`` on the
+        ``geo_disasters`` tier, and the event's coordinate where it has one.
     """
     units = event_units(events)
     located = events.select("DisNo.", "ISO", "Latitude", "Longitude")
@@ -545,6 +551,8 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
 
     from_units = units.join(located, on="DisNo.", how="left").with_columns(
         pl.lit("gadm").alias("geometry_source"),
+        pl.lit(None, dtype=pl.Int8).alias("geocoding_q"),
+        pl.lit(None, dtype=pl.Float64).alias("overlap"),
     )
 
     uncoded = located.join(units.select("DisNo.").unique(), on="DisNo.", how="anti")
@@ -564,6 +572,8 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
         pl.lit(None, dtype=pl.String).alias("name"),
         pl.lit(None, dtype=pl.Int8).alias("admin_level"),
         pl.lit(None, dtype=pl.String).alias("migration_method"),
+        pl.lit(None, dtype=pl.Int8).alias("geocoding_q"),
+        pl.lit(None, dtype=pl.Float64).alias("overlap"),
     )
 
     tiers = (from_units, from_overlay, rest)

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -526,6 +526,46 @@ _ABSENT_COLUMN_TYPES = pl.Schema(
 )
 
 
+def _nesting_path(gid: pl.Expr) -> pl.Expr:
+    """Strip a GADM identifier's version suffix, leaving the path it nests by: `LAO.1.2_1` -> `LAO.1.2`."""
+    return gid.str.split("_").list.first()
+
+
+def _naming_ground_the_units_do_not(overlay: pl.DataFrame, units: pl.DataFrame) -> pl.DataFrame:
+    """
+    Keep the overlay rows for ground an event's own units leave unnamed.
+
+    GADM identifiers nest by dotted prefix, so an overlay unit repeats ground already named where
+    the event carries that unit, something containing it, or something inside it. What survives is
+    area no unit of the event covers, which an event with no units of its own is all of.
+
+    Parameters
+    ----------
+    overlay : DataFrame
+        Units another gazetteer places, with the columns of ``RESOLVED_UNIT_SCHEMA``.
+    units : DataFrame
+        The event's own units, as :func:`event_units` returns them.
+
+    Returns
+    -------
+    DataFrame
+        The rows of ``overlay`` naming ground ``units`` does not.
+    """
+    already_named = (
+        overlay.select("DisNo.", "gid", offered=_nesting_path(pl.col("gid")))
+        .join(units.select("DisNo.", carried=_nesting_path(pl.col("gid"))), on="DisNo.", how="inner")
+        .filter(
+            (pl.col("offered") == pl.col("carried"))
+            | pl.col("offered").str.starts_with(pl.col("carried") + ".")
+            | pl.col("carried").str.starts_with(pl.col("offered") + ".")
+        )
+        .select("DisNo.", "gid")
+        .unique()
+    )
+
+    return overlay.join(already_named, on=["DisNo.", "gid"], how="anti")
+
+
 def _with_absent_columns(tier: pl.DataFrame) -> pl.DataFrame:
     """Fill every geography column the tier does not carry with a null of the right type."""
     return tier.with_columns(
@@ -548,9 +588,10 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
     ``Latitude`` and ``Longitude`` are carried wherever EM-DAT supplies them, including on ``gadm``
     rows, so the two claims stay visible side by side rather than one being discarded.
 
-    An event EM-DAT codes to units keeps only those, and ``resolved`` fills events it codes to none:
-    the two sources differ on how finely to name a location rather than on where it was, so taking
-    both would mix a province with the districts inside it.
+    An event keeps every unit EM-DAT codes it to and takes from ``resolved`` only the units naming
+    ground those leave uncovered. The two sources differ on how finely to name a location rather
+    than on where it was, so a unit either already names is the same ground counted at a second
+    resolution, while one nesting with none of them is area EM-DAT never coded.
 
     Parameters
     ----------
@@ -574,12 +615,15 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
 
     from_units = units.join(located, on="DisNo.", how="left").with_columns(pl.lit("gadm").alias("geometry_source"))
 
-    uncoded = located.join(units.select("DisNo.").unique(), on="DisNo.", how="anti")
-    from_overlay = uncoded.join(
-        overlay.select(list(RESOLVED_UNIT_SCHEMA)).cast(RESOLVED_UNIT_SCHEMA), on="DisNo.", how="inner"
-    ).with_columns(pl.lit("geo_disasters").alias("geometry_source"))
+    unnamed = _naming_ground_the_units_do_not(
+        overlay.select(list(RESOLVED_UNIT_SCHEMA)).cast(RESOLVED_UNIT_SCHEMA), units
+    )
+    from_overlay = located.join(unnamed, on="DisNo.", how="inner").with_columns(
+        pl.lit("geo_disasters").alias("geometry_source")
+    )
 
-    rest = uncoded.join(overlay.select("DisNo.").unique(), on="DisNo.", how="anti").with_columns(
+    placed = pl.concat([units.select("DisNo."), unnamed.select("DisNo.")]).unique()
+    rest = located.join(placed, on="DisNo.", how="anti").with_columns(
         pl.when(pl.col("Latitude").is_not_null())
         .then(pl.lit("emdat_point"))
         .otherwise(pl.lit("country"))

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -691,19 +691,66 @@ def test_an_event_the_workbook_places_nowhere_takes_the_overlay_units(write_emda
     assert geography["overlap"].to_list() == [0.8]
 
 
-def test_the_overlay_adds_nothing_to_an_event_the_workbook_already_codes(write_emdat_cache):
-    """Precedence. Taking both sources would put a province and the districts inside it into one
-    observation, which reads as more geography than either source claims."""
+def test_an_overlay_unit_inside_one_the_workbook_codes_is_dropped(write_emdat_cache):
+    """The same ground at a second resolution. Keeping both would put a province and a district
+    inside it into one observation, which reads as more geography than either source claims."""
     cache_dir = write_emdat_cache(
         [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})})]
     )
 
     geography = event_geography(
-        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.9_1", "Elsewhere", 1, 1, 0.9)])
+        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.1.2_1", "Inside it", 2, 1, 0.9)])
     )
 
     assert set(geography["geometry_source"]) == {"gadm"}
-    assert "AAA.9_1" not in geography["gid"].to_list()
+    assert geography["gid"].to_list() == ["AAA.1_1"]
+
+
+def test_an_overlay_unit_the_workbook_already_codes_is_dropped(write_emdat_cache):
+    """The commonest case by far — the two sources mostly name the same units. Counting a repeat as
+    new ground gives the event the same unit twice under two tiers, which reads as twice the
+    footprint and double-counts it in anything aggregating over units."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})})]
+    )
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.1_1", "The same one", 1, 1, 0.9)])
+    )
+
+    assert geography["gid"].to_list() == ["AAA.1_1"]
+    assert geography["geometry_source"].to_list() == ["gadm"]
+
+
+def test_an_overlay_unit_containing_one_the_workbook_codes_is_dropped(write_emdat_cache):
+    """Nesting the other way round, which happens wherever EM-DAT codes finer than the overlay
+    resolves. Still one piece of ground named twice."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_2": "AAA.1.2_1"})})]
+    )
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.1_1", "Around it", 1, 1, 0.9)])
+    )
+
+    assert set(geography["geometry_source"]) == {"gadm"}
+    assert geography["gid"].to_list() == ["AAA.1.2_1"]
+
+
+def test_an_overlay_unit_nesting_with_none_of_the_coded_ones_is_kept(write_emdat_cache):
+    """Area EM-DAT never coded. Across the region this is 596 units over 90 events, and dropping it
+    loses geography one source holds and nothing else records."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})})]
+    )
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.9_1", "Elsewhere", 1, 2, 0.6)])
+    )
+
+    assert sorted(geography["gid"]) == ["AAA.1_1", "AAA.9_1"]
+    assert set(geography["geometry_source"]) == {"gadm", "geo_disasters"}
+    assert geography.filter(pl.col("gid") == "AAA.9_1")["geocoding_q"].to_list() == [2]
 
 
 def test_the_overlay_columns_are_null_on_every_other_tier(write_emdat_cache):

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -12,6 +12,7 @@ from climate_risk.data_functions.emdat_processing import (
     DISASTER_TYPES,
     EMDAT_WINDOW_START,
     GEOMETRY_SOURCES,
+    RESOLVED_UNIT_SCHEMA,
     NamedPlace,
     count_events_by_type,
     country_year_grid,
@@ -667,3 +668,50 @@ def test_no_tier_silently_swallows_the_others():
     # Coded events carry several units each, so the gadm tier is the longest despite being a
     # minority of events.
     assert per_source["gadm"] > per_source["country"]
+
+
+def resolved_units(rows):
+    """Units another gazetteer places, in the shape `event_geography` takes them."""
+    return pl.DataFrame(rows, schema=RESOLVED_UNIT_SCHEMA, orient="row")
+
+
+def test_an_event_the_workbook_places_nowhere_takes_the_overlay_units(write_emdat_cache):
+    """The 209 events this tier exists for: geography is available from a second gazetteer and the
+    table recorded none of it, because nothing produced the tier `GEOMETRY_SOURCES` advertised."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "uncoded", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), resolved=resolved_units([("uncoded", "AAA.1_1", "Somewhere", 1)])
+    )
+
+    assert geography["geometry_source"].to_list() == ["geo_disasters"]
+    assert geography["gid"].to_list() == ["AAA.1_1"]
+
+
+def test_the_workbook_s_own_units_are_kept_whole_over_the_overlay_s(write_emdat_cache):
+    """Precedence, and it is a choice about resolution rather than trust: on the events both cover
+    neither disagrees about where the event was, only about how finely to say it. Taking both would
+    put a province and the districts inside it into one observation, and leave `geometry_source` no
+    longer describing the row."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "coded", "GADM Admin Units": '[{"gid_1": "AAA.1_1"}]'})])
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.9_1", "Elsewhere", 1)])
+    )
+
+    assert set(geography["geometry_source"]) == {"gadm"}
+    assert "AAA.9_1" not in geography["gid"].to_list()
+
+
+def test_an_overlay_naming_an_event_the_workbook_does_not_have_is_ignored(write_emdat_cache):
+    """The overlay is resolved per country, so it carries events this frame has filtered out. One
+    arriving as its own row would be geography for an event nothing else in the table knows."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "nothing", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(
+        load_emdat_events(cache_dir),
+        resolved=resolved_units([("a-different-event", "AAA.1_1", "Somewhere", 1)]),
+    )
+
+    assert geography["DisNo."].to_list() == ["nothing"]
+    assert geography["geometry_source"].to_list() == ["country"]

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -681,11 +681,13 @@ def test_an_event_the_workbook_places_nowhere_takes_the_overlay_units(write_emda
     cache_dir = write_emdat_cache([emdat_event({"DisNo.": "uncoded", "Latitude": None, "Longitude": None})])
 
     geography = event_geography(
-        load_emdat_events(cache_dir), resolved=resolved_units([("uncoded", "AAA.1_1", "Somewhere", 1)])
+        load_emdat_events(cache_dir), resolved=resolved_units([("uncoded", "AAA.1_1", "Somewhere", 1, 3, 0.8)])
     )
 
     assert geography["geometry_source"].to_list() == ["geo_disasters"]
     assert geography["gid"].to_list() == ["AAA.1_1"]
+    assert geography["geocoding_q"].to_list() == [3]
+    assert geography["overlap"].to_list() == [0.8]
 
 
 def test_the_workbook_s_own_units_are_kept_whole_over_the_overlay_s(write_emdat_cache):
@@ -696,11 +698,28 @@ def test_the_workbook_s_own_units_are_kept_whole_over_the_overlay_s(write_emdat_
     cache_dir = write_emdat_cache([emdat_event({"DisNo.": "coded", "GADM Admin Units": '[{"gid_1": "AAA.1_1"}]'})])
 
     geography = event_geography(
-        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.9_1", "Elsewhere", 1)])
+        load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.9_1", "Elsewhere", 1, 1, 0.9)])
     )
 
     assert set(geography["geometry_source"]) == {"gadm"}
     assert "AAA.9_1" not in geography["gid"].to_list()
+
+
+def test_the_overlay_columns_are_null_on_every_other_tier(write_emdat_cache):
+    """`geocoding_q` and `overlap` describe how one gazetteer placed a unit, so a value on a row it
+    did not place would be read as its judgement of a placement it never made."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "coded", "GADM Admin Units": '[{"gid_1": "AAA.1_1"}]'}),
+            emdat_event({"DisNo.": "point", "Latitude": 1.0, "Longitude": 2.0}),
+            emdat_event({"DisNo.": "nothing", "Latitude": None, "Longitude": None}),
+        ]
+    )
+
+    geography = event_geography(load_emdat_events(cache_dir))
+
+    assert geography["geocoding_q"].null_count() == len(geography)
+    assert geography["overlap"].null_count() == len(geography)
 
 
 def test_an_overlay_naming_an_event_the_workbook_does_not_have_is_ignored(write_emdat_cache):
@@ -710,7 +729,7 @@ def test_an_overlay_naming_an_event_the_workbook_does_not_have_is_ignored(write_
 
     geography = event_geography(
         load_emdat_events(cache_dir),
-        resolved=resolved_units([("a-different-event", "AAA.1_1", "Somewhere", 1)]),
+        resolved=resolved_units([("a-different-event", "AAA.1_1", "Somewhere", 1, 1, 0.5)]),
     )
 
     assert geography["DisNo."].to_list() == ["nothing"]

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -686,16 +686,17 @@ def test_an_event_the_workbook_places_nowhere_takes_the_overlay_units(write_emda
 
     assert geography["geometry_source"].to_list() == ["geo_disasters"]
     assert geography["gid"].to_list() == ["AAA.1_1"]
+    assert geography["admin_level"].to_list() == [1]
     assert geography["geocoding_q"].to_list() == [3]
     assert geography["overlap"].to_list() == [0.8]
 
 
-def test_the_workbook_s_own_units_are_kept_whole_over_the_overlay_s(write_emdat_cache):
-    """Precedence, and it is a choice about resolution rather than trust: on the events both cover
-    neither disagrees about where the event was, only about how finely to say it. Taking both would
-    put a province and the districts inside it into one observation, and leave `geometry_source` no
-    longer describing the row."""
-    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "coded", "GADM Admin Units": '[{"gid_1": "AAA.1_1"}]'})])
+def test_the_overlay_adds_nothing_to_an_event_the_workbook_already_codes(write_emdat_cache):
+    """Precedence. Taking both sources would put a province and the districts inside it into one
+    observation, which reads as more geography than either source claims."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})})]
+    )
 
     geography = event_geography(
         load_emdat_events(cache_dir), resolved=resolved_units([("coded", "AAA.9_1", "Elsewhere", 1, 1, 0.9)])
@@ -706,20 +707,28 @@ def test_the_workbook_s_own_units_are_kept_whole_over_the_overlay_s(write_emdat_
 
 
 def test_the_overlay_columns_are_null_on_every_other_tier(write_emdat_cache):
-    """`geocoding_q` and `overlap` describe how one gazetteer placed a unit, so a value on a row it
-    did not place would be read as its judgement of a placement it never made."""
+    """`geocoding_q` and `overlap` say how one gazetteer placed a unit, so a value on a row it did
+    not place reads as its judgement of a placement it never made. The tier has to be populated for
+    this to mean anything — with no overlay at all every row is null trivially."""
     cache_dir = write_emdat_cache(
         [
-            emdat_event({"DisNo.": "coded", "GADM Admin Units": '[{"gid_1": "AAA.1_1"}]'}),
+            emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})}),
+            emdat_event({"DisNo.": "overlaid", "Latitude": None, "Longitude": None}),
             emdat_event({"DisNo.": "point", "Latitude": 1.0, "Longitude": 2.0}),
             emdat_event({"DisNo.": "nothing", "Latitude": None, "Longitude": None}),
         ]
     )
 
-    geography = event_geography(load_emdat_events(cache_dir))
+    geography = event_geography(
+        load_emdat_events(cache_dir), resolved=resolved_units([("overlaid", "AAA.2_1", "Somewhere", 2, 4, 0.6)])
+    )
 
-    assert geography["geocoding_q"].null_count() == len(geography)
-    assert geography["overlap"].null_count() == len(geography)
+    scored = geography.filter(pl.col("geometry_source") == "geo_disasters")
+    elsewhere = geography.filter(pl.col("geometry_source") != "geo_disasters")
+
+    assert scored["geocoding_q"].to_list() == [4]
+    assert elsewhere["geocoding_q"].null_count() == len(elsewhere)
+    assert elsewhere["overlap"].null_count() == len(elsewhere)
 
 
 def test_an_overlay_naming_an_event_the_workbook_does_not_have_is_ignored(write_emdat_cache):
@@ -734,3 +743,42 @@ def test_an_overlay_naming_an_event_the_workbook_does_not_have_is_ignored(write_
 
     assert geography["DisNo."].to_list() == ["nothing"]
     assert geography["geometry_source"].to_list() == ["country"]
+
+
+def test_an_overlay_placing_an_event_in_several_units_contributes_a_row_each(write_emdat_cache):
+    """An event spanning three provinces is three rows, the same as when the workbook codes it.
+    Collapsing them would make a wide event look like a point one."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "wide", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(
+        load_emdat_events(cache_dir),
+        resolved=resolved_units(
+            [
+                ("wide", "AAA.1_1", "First", 1, 1, 0.9),
+                ("wide", "AAA.2_1", "Second", 1, 1, 0.7),
+                ("wide", "AAA.3_1", "Third", 1, 2, 0.4),
+            ]
+        ),
+    )
+
+    assert sorted(geography["gid"]) == ["AAA.1_1", "AAA.2_1", "AAA.3_1"]
+    assert set(geography["geometry_source"]) == {"geo_disasters"}
+
+
+def test_every_geometry_source_the_table_advertises_can_be_produced(write_emdat_cache):
+    """`GEOMETRY_SOURCES` is what a model reads to choose the tiers it accepts, so a value nothing
+    emits is a tier a caller can filter on forever and never see."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})}),
+            emdat_event({"DisNo.": "overlaid", "Latitude": None, "Longitude": None}),
+            emdat_event({"DisNo.": "point", "Latitude": 1.0, "Longitude": 2.0}),
+            emdat_event({"DisNo.": "nothing", "Latitude": None, "Longitude": None}),
+        ]
+    )
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), resolved=resolved_units([("overlaid", "AAA.2_1", "Somewhere", 1, 1, 0.5)])
+    )
+
+    assert set(geography["geometry_source"]) == set(GEOMETRY_SOURCES)


### PR DESCRIPTION
`GEOMETRY_SOURCES` lists four tiers and `event_geography` only ever produced three, so `geo_disasters` was a value a caller could filter on forever and never see. It emits that tier now, from units the caller passes in — resolving them is a polygon overlay against GADM and this layer holds no geometry, so it can't do the reading itself.

An event keeps every unit EM-DAT codes it to, and takes from the overlay only units naming ground those leave uncovered. GADM ids nest, so a unit either source already names is the same ground at a second resolution; unioning wholesale would put a province and the districts inside it into one observation. Across the nine-country region that's 209 events gaining geography they previously had none of, plus 596 units of area EM-DAT never coded.

Nothing passes `resolved` yet — the model frame that will consume it doesn't exist. The contract lands ahead of its caller.
