### PR TITLE
Carry an event's location text into the geography table

### DIFF
--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -658,7 +658,8 @@ def event_geography(
     DataFrame
         ``DisNo.``, ``ISO``, ``geometry_source`` from ``GEOMETRY_SOURCES``, the unit columns of
         :func:`event_units` where one applies, ``geocoding_q`` and ``overlap`` on the
-        ``geo_disasters`` tier, and the event's coordinate where it has one.
+        ``geo_disasters`` tier, ``names_written`` and ``names_reached`` wherever the event's text was
+        read, and the event's coordinate where it has one.
     """
     units = event_units(events)
     located = events.select("DisNo.", "ISO", "Latitude", "Longitude")

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -9,6 +9,7 @@ import polars as pl
 
 from climate_risk.config.schema import EventFilters
 from climate_risk.data.source import ManualSource
+from climate_risk.exceptions import DataValidationError
 
 # EM-DAT requires an account and forbids redistribution, so it is fetched by a person, not by code.
 EMDAT = ManualSource(
@@ -546,6 +547,17 @@ def _as_frame(given: pl.DataFrame | None, schema: pl.Schema) -> pl.DataFrame:
     return pl.DataFrame(schema=schema) if given is None else given.select(list(schema)).cast(schema)
 
 
+def _one_row_per_event(counts: pl.DataFrame) -> pl.DataFrame:
+    """Refuse a per-event lookup that names an event twice."""
+    # Attached by a join on the event alone, so a repeated event fans out every geography row it
+    # has, including rows of tiers the reading had nothing to do with.
+    repeated = sorted(counts.filter(pl.col("DisNo.").is_duplicated())["DisNo."].unique().to_list())
+    if repeated:
+        raise DataValidationError(f"The resolution counts name an event more than once: {repeated[:5]}.")
+
+    return counts
+
+
 def _nesting_path(gid: pl.Expr) -> pl.Expr:
     """Strip a GADM identifier's version suffix, leaving the path it nests by: `LAO.1.2_1` -> `LAO.1.2`."""
     return gid.str.split("_").list.first()
@@ -679,7 +691,7 @@ def event_geography(
     every = pl.concat([_with_absent_columns(tier).select(_TIER_COLUMNS) for tier in tiers])
 
     return (
-        every.join(_as_frame(text_resolution, TEXT_RESOLUTION_SCHEMA), on="DisNo.", how="left")
+        every.join(_one_row_per_event(_as_frame(text_resolution, TEXT_RESOLUTION_SCHEMA)), on="DisNo.", how="left")
         .select(EVENT_GEOGRAPHY_COLUMNS)
         .sort("DisNo.", "gid", nulls_last=True)
     )

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -495,6 +495,8 @@ EVENT_GEOGRAPHY_COLUMNS = (
     "migration_method",
     "geocoding_q",
     "overlap",
+    "names_written",
+    "names_reached",
     "Latitude",
     "Longitude",
 )
@@ -514,6 +516,16 @@ RESOLVED_UNIT_SCHEMA = pl.Schema(
 
 # The units an event's own prose reaches, resolved elsewhere: this layer holds no gazetteer.
 TEXT_UNIT_SCHEMA = pl.Schema({"DisNo.": pl.String, "gid": pl.String, "name": pl.String, "admin_level": pl.Int8})
+
+# How complete that reading was, per event rather than per unit, so an event whose prose reached
+# nothing still records that it wrote names. Null where the event carries no parseable text.
+TEXT_RESOLUTION_SCHEMA = pl.Schema({"DisNo.": pl.String, "names_written": pl.Int16, "names_reached": pl.Int16})
+
+# What a tier assembles on its own. The rest of the table is joined on afterwards, per event
+# rather than per unit.
+_TIER_COLUMNS = tuple(
+    column for column in EVENT_GEOGRAPHY_COLUMNS if column == "DisNo." or column not in TEXT_RESOLUTION_SCHEMA
+)
 
 # The columns a tier need not carry, and the type each takes where it does not. A tier states only
 # what it knows, so a column added to the table is declared here once instead of in every tier.
@@ -590,6 +602,7 @@ def event_geography(
     *,
     resolved: pl.DataFrame | None = None,
     from_text: pl.DataFrame | None = None,
+    text_resolution: pl.DataFrame | None = None,
 ) -> pl.DataFrame:
     """
     Say where every event's geometry comes from, one row per event-unit and one per event otherwise.
@@ -607,6 +620,11 @@ def event_geography(
     second resolution; taking it again would put a province and the districts inside it into one
     observation.
 
+    ``names_written`` and ``names_reached`` say how much of an event's prose resolved, on every row
+    of an event whose text was read. They describe the prose rather than the tier, so an event whose
+    names all failed carries them at ``country`` tier, which is where a partial reading is least
+    visible and most worth recording.
+
     Parameters
     ----------
     events : DataFrame
@@ -619,6 +637,9 @@ def event_geography(
         Units an event's own location text reaches, with the columns of ``TEXT_UNIT_SCHEMA``.
         Default None, which emits no ``location_text`` rows. Resolving them needs a gazetteer, which
         this layer does not hold either.
+    text_resolution : DataFrame, optional
+        How many placeable names each event wrote and how many reached a unit, with the columns of
+        ``TEXT_RESOLUTION_SCHEMA``. Default None, which leaves both columns null.
 
     Returns
     -------
@@ -655,9 +676,12 @@ def event_geography(
     )
 
     tiers = (from_units, from_overlay, from_prose, rest)
+    every = pl.concat([_with_absent_columns(tier).select(_TIER_COLUMNS) for tier in tiers])
 
-    return pl.concat([_with_absent_columns(tier).select(EVENT_GEOGRAPHY_COLUMNS) for tier in tiers]).sort(
-        "DisNo.", "gid", nulls_last=True
+    return (
+        every.join(_as_frame(text_resolution, TEXT_RESOLUTION_SCHEMA), on="DisNo.", how="left")
+        .select(EVENT_GEOGRAPHY_COLUMNS)
+        .sort("DisNo.", "gid", nulls_last=True)
     )
 
 

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -483,7 +483,7 @@ def event_units(events: pl.DataFrame) -> pl.DataFrame:
 
 # Where an event's geometry comes from, best first. Nothing is filtered on this: the column records
 # what the source holds, and a model chooses which tiers it will accept.
-GEOMETRY_SOURCES = ("gadm", "geo_disasters", "emdat_point", "country")
+GEOMETRY_SOURCES = ("gadm", "geo_disasters", "location_text", "emdat_point", "country")
 
 EVENT_GEOGRAPHY_COLUMNS = (
     "DisNo.",
@@ -512,6 +512,9 @@ RESOLVED_UNIT_SCHEMA = pl.Schema(
     }
 )
 
+# The units an event's own prose reaches, resolved elsewhere: this layer holds no gazetteer.
+TEXT_UNIT_SCHEMA = pl.Schema({"DisNo.": pl.String, "gid": pl.String, "name": pl.String, "admin_level": pl.Int8})
+
 # The columns a tier need not carry, and the type each takes where it does not. A tier states only
 # what it knows, so a column added to the table is declared here once instead of in every tier.
 _ABSENT_COLUMN_TYPES = pl.Schema(
@@ -524,6 +527,11 @@ _ABSENT_COLUMN_TYPES = pl.Schema(
         "overlap": pl.Float64,
     }
 )
+
+
+def _as_frame(given: pl.DataFrame | None, schema: pl.Schema) -> pl.DataFrame:
+    """Take the caller's frame down to the columns and types the schema names, or an empty one."""
+    return pl.DataFrame(schema=schema) if given is None else given.select(list(schema)).cast(schema)
 
 
 def _nesting_path(gid: pl.Expr) -> pl.Expr:
@@ -577,7 +585,12 @@ def _with_absent_columns(tier: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = None) -> pl.DataFrame:
+def event_geography(
+    events: pl.DataFrame,
+    *,
+    resolved: pl.DataFrame | None = None,
+    from_text: pl.DataFrame | None = None,
+) -> pl.DataFrame:
     """
     Say where every event's geometry comes from, one row per event-unit and one per event otherwise.
 
@@ -588,10 +601,11 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
     ``Latitude`` and ``Longitude`` are carried wherever EM-DAT supplies them, including on ``gadm``
     rows, so the two claims stay visible side by side rather than one being discarded.
 
-    An event keeps every unit EM-DAT codes it to and takes from ``resolved`` only the units naming
-    ground those leave uncovered. The two sources differ on how finely to name a location rather
-    than on where it was, so a unit either already names is the same ground counted at a second
-    resolution, while one nesting with none of them is area EM-DAT never coded.
+    Sources are taken in the order ``GEOMETRY_SOURCES`` declares. An event keeps every unit EM-DAT
+    codes it to, and each later source contributes only units naming ground the ones before it leave
+    uncovered. GADM ids nest, so a unit an earlier source already names is the same ground at a
+    second resolution; taking it again would put a province and the districts inside it into one
+    observation.
 
     Parameters
     ----------
@@ -601,6 +615,10 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
         Units another gazetteer places, with the columns of ``RESOLVED_UNIT_SCHEMA``. Default None,
         which emits no ``geo_disasters`` rows. Reading them is the caller's job: they come from a
         polygon overlay, and this layer holds no geometry.
+    from_text : DataFrame, optional
+        Units an event's own location text reaches, with the columns of ``TEXT_UNIT_SCHEMA``.
+        Default None, which emits no ``location_text`` rows. Resolving them needs a gazetteer, which
+        this layer does not hold either.
 
     Returns
     -------
@@ -611,18 +629,24 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
     """
     units = event_units(events)
     located = events.select("DisNo.", "ISO", "Latitude", "Longitude")
-    overlay = pl.DataFrame(schema=RESOLVED_UNIT_SCHEMA) if resolved is None else resolved
+    overlay = _as_frame(resolved, RESOLVED_UNIT_SCHEMA)
+    prose = _as_frame(from_text, TEXT_UNIT_SCHEMA)
 
     from_units = units.join(located, on="DisNo.", how="left").with_columns(pl.lit("gadm").alias("geometry_source"))
 
-    unnamed = _naming_ground_the_units_do_not(
-        overlay.select(list(RESOLVED_UNIT_SCHEMA)).cast(RESOLVED_UNIT_SCHEMA), units
-    )
+    unnamed = _naming_ground_the_units_do_not(overlay, units)
     from_overlay = located.join(unnamed, on="DisNo.", how="inner").with_columns(
         pl.lit("geo_disasters").alias("geometry_source")
     )
 
-    placed = pl.concat([units.select("DisNo."), unnamed.select("DisNo.")]).unique()
+    # Each source answers only for ground the ones before it left unnamed, so the order in
+    # `GEOMETRY_SOURCES` decides who wins a repeat rather than who is read last.
+    already = pl.concat([units.select("DisNo.", "gid"), unnamed.select("DisNo.", "gid")])
+    from_prose = located.join(_naming_ground_the_units_do_not(prose, already), on="DisNo.", how="inner").with_columns(
+        pl.lit("location_text").alias("geometry_source")
+    )
+
+    placed = pl.concat([tier.select("DisNo.") for tier in (units, unnamed, from_prose)]).unique()
     rest = located.join(placed, on="DisNo.", how="anti").with_columns(
         pl.when(pl.col("Latitude").is_not_null())
         .then(pl.lit("emdat_point"))
@@ -630,7 +654,7 @@ def event_geography(events: pl.DataFrame, *, resolved: pl.DataFrame | None = Non
         .alias("geometry_source")
     )
 
-    tiers = (from_units, from_overlay, rest)
+    tiers = (from_units, from_overlay, from_prose, rest)
 
     return pl.concat([_with_absent_columns(tier).select(EVENT_GEOGRAPHY_COLUMNS) for tier in tiers]).sort(
         "DisNo.", "gid", nulls_last=True

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -13,6 +13,7 @@ from climate_risk.data_functions.emdat_processing import (
     EMDAT_WINDOW_START,
     GEOMETRY_SOURCES,
     RESOLVED_UNIT_SCHEMA,
+    TEXT_UNIT_SCHEMA,
     NamedPlace,
     count_events_by_type,
     country_year_grid,
@@ -670,6 +671,11 @@ def test_no_tier_silently_swallows_the_others():
     assert per_source["gadm"] > per_source["country"]
 
 
+def text_units(rows):
+    """Units an event's own prose reaches, in the shape `event_geography` takes them."""
+    return pl.DataFrame(rows, schema=TEXT_UNIT_SCHEMA, orient="row")
+
+
 def resolved_units(rows):
     """Units another gazetteer places, in the shape `event_geography` takes them."""
     return pl.DataFrame(rows, schema=RESOLVED_UNIT_SCHEMA, orient="row")
@@ -819,13 +825,59 @@ def test_every_geometry_source_the_table_advertises_can_be_produced(write_emdat_
         [
             emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})}),
             emdat_event({"DisNo.": "overlaid", "Latitude": None, "Longitude": None}),
+            emdat_event({"DisNo.": "spoken", "Latitude": None, "Longitude": None}),
             emdat_event({"DisNo.": "point", "Latitude": 1.0, "Longitude": 2.0}),
             emdat_event({"DisNo.": "nothing", "Latitude": None, "Longitude": None}),
         ]
     )
 
     geography = event_geography(
-        load_emdat_events(cache_dir), resolved=resolved_units([("overlaid", "AAA.2_1", "Somewhere", 1, 1, 0.5)])
+        load_emdat_events(cache_dir),
+        resolved=resolved_units([("overlaid", "AAA.2_1", "Somewhere", 1, 1, 0.5)]),
+        from_text=text_units([("spoken", "AAA.3_1", "Elsewhere", 1)]),
     )
 
     assert set(geography["geometry_source"]) == set(GEOMETRY_SOURCES)
+
+
+def test_an_event_only_its_prose_places_takes_the_text_units(write_emdat_cache):
+    """The 125 events of the 1980s the study window turns on: EM-DAT codes none of them and the
+    overlay starts in 1990, so the location text is the only thing that reaches them."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "spoken", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), from_text=text_units([("spoken", "AAA.1_1", "Somewhere", 1)])
+    )
+
+    assert geography["geometry_source"].to_list() == ["location_text"]
+    assert geography["gid"].to_list() == ["AAA.1_1"]
+
+
+def test_prose_naming_ground_the_workbook_already_codes_adds_nothing(write_emdat_cache):
+    """Each source answers only for ground the ones before it left unnamed, and the prose is read
+    last of the three that name units. A district inside a coded province is that province again."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})})]
+    )
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), from_text=text_units([("coded", "AAA.1.2_1", "Inside it", 2)])
+    )
+
+    assert set(geography["geometry_source"]) == {"gadm"}
+    assert geography["gid"].to_list() == ["AAA.1_1"]
+
+
+def test_prose_naming_ground_the_overlay_already_placed_adds_nothing(write_emdat_cache):
+    """The overlay is read before the prose, so ground it names is taken. Testing only against the
+    workbook's own units would leave the middle source out of the ordering."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "both", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(
+        load_emdat_events(cache_dir),
+        resolved=resolved_units([("both", "AAA.1_1", "Somewhere", 1, 1, 0.8)]),
+        from_text=text_units([("both", "AAA.1.2_1", "Inside it", 2)]),
+    )
+
+    assert set(geography["geometry_source"]) == {"geo_disasters"}
+    assert geography["gid"].to_list() == ["AAA.1_1"]

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -926,3 +926,33 @@ def test_an_event_carrying_no_text_leaves_the_resolution_columns_null(write_emda
 
     assert geography["names_written"].null_count() == 1
     assert geography["names_reached"].null_count() == 1
+
+
+def test_the_window_counts_the_year_it_opens_in(write_emdat_cache):
+    """1981 rather than 1990 is worth 125 located events, and every one of them is an off-by-one
+    away from being discarded. `end_year` is tested for the same inclusivity at the other end."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "the-year-before", "Start Year": 1980}),
+            emdat_event({"DisNo.": "the-opening-year", "Start Year": 1981}),
+            emdat_event({"DisNo.": "after", "Start Year": 1982}),
+        ]
+    )
+
+    kept = selected_events(cache_dir, filters=EventFilters(start_year=1981))["DisNo."]
+
+    assert kept.to_list() == ["the-opening-year", "after"]
+
+
+def test_a_place_that_names_no_window_opens_in_1981(write_emdat_cache):
+    """The default is the decision, so it is worth one assertion: 1990 would silently drop the
+    1980s, which are the events only the location text reaches."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "eighties", "Start Year": 1985}),
+            emdat_event({"DisNo.": "nineties", "Start Year": 1995}),
+        ]
+    )
+
+    assert EventFilters().start_year == 1981
+    assert selected_events(cache_dir)["DisNo."].to_list() == ["eighties", "nineties"]

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -920,13 +920,22 @@ def test_an_event_whose_prose_reached_nothing_still_records_that_it_wrote_names(
 
 def test_an_event_carrying_no_text_leaves_the_resolution_columns_null(write_emdat_cache):
     """Zero names written would be a claim the prose was read and held nothing; null is the absence
-    of a reading."""
-    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "silent", "Latitude": None, "Longitude": None})])
+    of a reading. The two have to sit in one table for the difference to mean anything."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "read", "Latitude": None, "Longitude": None}),
+            emdat_event({"DisNo.": "silent", "Latitude": None, "Longitude": None}),
+        ]
+    )
 
-    geography = event_geography(load_emdat_events(cache_dir))
+    geography = event_geography(load_emdat_events(cache_dir), text_resolution=resolution_counts([("read", 4, 0)]))
 
-    assert geography["names_written"].null_count() == 1
-    assert geography["names_reached"].null_count() == 1
+    was_read = geography.filter(pl.col("DisNo.") == "read")
+    silent = geography.filter(pl.col("DisNo.") == "silent")
+
+    assert was_read["names_written"].to_list() == [4]
+    assert silent["names_written"].null_count() == len(silent)
+    assert silent["names_reached"].null_count() == len(silent)
 
 
 def test_the_window_counts_the_year_it_opens_in(write_emdat_cache):
@@ -957,6 +966,37 @@ def test_a_place_that_names_no_window_opens_in_1981(write_emdat_cache):
 
     assert EventFilters().start_year == 1981
     assert selected_events(cache_dir)["DisNo."].to_list() == ["eighties", "nineties"]
+
+
+def test_prose_naming_ground_nothing_else_reaches_is_added_to_a_coded_event(write_emdat_cache):
+    """The positive half of the ordering rule. An event can be coded and still have prose naming
+    somewhere the coding missed, which is 596 units across the region for the overlay and is the
+    same argument for the text."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})})]
+    )
+
+    geography = event_geography(
+        load_emdat_events(cache_dir), from_text=text_units([("coded", "AAA.9_1", "Elsewhere", 1)])
+    )
+
+    assert sorted(geography["gid"]) == ["AAA.1_1", "AAA.9_1"]
+    assert set(geography["geometry_source"]) == {"gadm", "location_text"}
+
+
+def test_the_resolution_counts_reach_rows_of_a_tier_the_prose_did_not_place(write_emdat_cache):
+    """The counts describe the prose, not the tier, so they belong on an event EM-DAT coded as much
+    as on one the text placed — that is what makes them usable as a completeness covariate rather
+    than a property of one tier."""
+    cache_dir = write_emdat_cache(
+        [emdat_event({"DisNo.": "coded", "GADM Admin Units": units_json({"gid_1": "AAA.1_1"})})]
+    )
+
+    geography = event_geography(load_emdat_events(cache_dir), text_resolution=resolution_counts([("coded", 3, 1)]))
+
+    assert geography["geometry_source"].to_list() == ["gadm"]
+    assert geography["names_written"].to_list() == [3]
+    assert geography["names_reached"].to_list() == [1]
 
 
 def test_resolution_counts_naming_an_event_twice_are_refused(write_emdat_cache):

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -677,7 +677,7 @@ def text_units(rows):
     return pl.DataFrame(rows, schema=TEXT_UNIT_SCHEMA, orient="row")
 
 
-def text_resolution(rows):
+def resolution_counts(rows):
     """How much of each event's prose resolved, per event."""
     return pl.DataFrame(rows, schema=TEXT_RESOLUTION_SCHEMA, orient="row")
 
@@ -897,7 +897,7 @@ def test_how_much_of_the_prose_resolved_is_recorded_on_every_row_of_the_event(wr
     geography = event_geography(
         load_emdat_events(cache_dir),
         from_text=text_units([("partly", "AAA.1_1", "One", 1), ("partly", "AAA.2_1", "Two", 1)]),
-        text_resolution=text_resolution([("partly", 6, 2)]),
+        text_resolution=resolution_counts([("partly", 6, 2)]),
     )
 
     assert geography["names_written"].to_list() == [6, 6]
@@ -910,7 +910,7 @@ def test_an_event_whose_prose_reached_nothing_still_records_that_it_wrote_names(
     apart."""
     cache_dir = write_emdat_cache([emdat_event({"DisNo.": "failed", "Latitude": None, "Longitude": None})])
 
-    geography = event_geography(load_emdat_events(cache_dir), text_resolution=text_resolution([("failed", 5, 0)]))
+    geography = event_geography(load_emdat_events(cache_dir), text_resolution=resolution_counts([("failed", 5, 0)]))
 
     assert geography["geometry_source"].to_list() == ["country"]
     assert geography["names_written"].to_list() == [5]

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -13,6 +13,7 @@ from climate_risk.data_functions.emdat_processing import (
     EMDAT_WINDOW_START,
     GEOMETRY_SOURCES,
     RESOLVED_UNIT_SCHEMA,
+    TEXT_RESOLUTION_SCHEMA,
     TEXT_UNIT_SCHEMA,
     NamedPlace,
     count_events_by_type,
@@ -676,6 +677,11 @@ def text_units(rows):
     return pl.DataFrame(rows, schema=TEXT_UNIT_SCHEMA, orient="row")
 
 
+def text_resolution(rows):
+    """How much of each event's prose resolved, per event."""
+    return pl.DataFrame(rows, schema=TEXT_RESOLUTION_SCHEMA, orient="row")
+
+
 def resolved_units(rows):
     """Units another gazetteer places, in the shape `event_geography` takes them."""
     return pl.DataFrame(rows, schema=RESOLVED_UNIT_SCHEMA, orient="row")
@@ -881,3 +887,42 @@ def test_prose_naming_ground_the_overlay_already_placed_adds_nothing(write_emdat
 
     assert set(geography["geometry_source"]) == {"geo_disasters"}
     assert geography["gid"].to_list() == ["AAA.1_1"]
+
+
+def test_how_much_of_the_prose_resolved_is_recorded_on_every_row_of_the_event(write_emdat_cache):
+    """An event that named six places and reached five enters looking located while under-counting
+    the sixth, and those failures cluster by country and era. The counts say which rows are whole."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "partly", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(
+        load_emdat_events(cache_dir),
+        from_text=text_units([("partly", "AAA.1_1", "One", 1), ("partly", "AAA.2_1", "Two", 1)]),
+        text_resolution=text_resolution([("partly", 6, 2)]),
+    )
+
+    assert geography["names_written"].to_list() == [6, 6]
+    assert geography["names_reached"].to_list() == [2, 2]
+
+
+def test_an_event_whose_prose_reached_nothing_still_records_that_it_wrote_names(write_emdat_cache):
+    """The case the counts exist for. An event at country tier because every name failed is not the
+    same observation as one that carried no text at all, and nothing else in the table tells them
+    apart."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "failed", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(load_emdat_events(cache_dir), text_resolution=text_resolution([("failed", 5, 0)]))
+
+    assert geography["geometry_source"].to_list() == ["country"]
+    assert geography["names_written"].to_list() == [5]
+    assert geography["names_reached"].to_list() == [0]
+
+
+def test_an_event_carrying_no_text_leaves_the_resolution_columns_null(write_emdat_cache):
+    """Zero names written would be a claim the prose was read and held nothing; null is the absence
+    of a reading."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "silent", "Latitude": None, "Longitude": None})])
+
+    geography = event_geography(load_emdat_events(cache_dir))
+
+    assert geography["names_written"].null_count() == 1
+    assert geography["names_reached"].null_count() == 1

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -26,6 +26,7 @@ from climate_risk.data_functions.emdat_processing import (
     named_places,
     total_damage,
 )
+from climate_risk.exceptions import DataValidationError
 from tests.conftest import emdat_event
 
 
@@ -956,3 +957,15 @@ def test_a_place_that_names_no_window_opens_in_1981(write_emdat_cache):
 
     assert EventFilters().start_year == 1981
     assert selected_events(cache_dir)["DisNo."].to_list() == ["eighties", "nineties"]
+
+
+def test_resolution_counts_naming_an_event_twice_are_refused(write_emdat_cache):
+    """They are attached by a join on the event alone, so a repeated event fans out every geography
+    row it has — including rows of tiers the reading had nothing to do with. Silently doubling a
+    table is worse than refusing to build one."""
+    cache_dir = write_emdat_cache([emdat_event({"DisNo.": "twice", "Latitude": None, "Longitude": None})])
+
+    with pytest.raises(DataValidationError, match="twice"):
+        event_geography(
+            load_emdat_events(cache_dir), text_resolution=resolution_counts([("twice", 5, 2), ("twice", 5, 2)])
+        )


### PR DESCRIPTION
EM-DAT codes none of the 1980s to administrative units and the Geo-Disasters overlay starts in 1990, so for those events the location prose is the only thing that reaches a unit — 125 of 164 across the nine-country region, which is what settled the study window at 1981. `event_geography` emits them as their own tier now, taking the units from the caller since resolving them needs a gazetteer this layer doesn't hold.

Each source contributes only units naming ground the ones before it left uncovered, so the prose is read after the workbook's own coding and the overlay. Two columns record how many placeable names an event wrote and how many reached a unit — on every row of an event whose text was read, not just its prose rows, because an event whose names all failed sits at country tier and that is where a partial reading is least visible. Nothing passes `from_text` yet; the frame that consumes it doesn't exist.
