### PR TITLE
Let a point choose between the units one name reaches

### DIFF
--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -718,6 +718,21 @@ def _innermost_container(parent: str | None, pinned: set[str], gazetteer: Gazett
     return set()
 
 
+def _chosen_by_point(gids: set[str], inside: str | None, gazetteer: Gazetteer) -> set[str]:
+    """
+    Let a point choose between the candidates a name cannot separate itself.
+
+    The candidates a name reaches are disjoint, so a point sits in at most one of them. Where it
+    sits in none, or where no source placed the name, every candidate is kept.
+    """
+    if inside is None or len(gids) < 2:
+        return gids
+
+    holding = {gid for gid in gids if gid == inside or gid in gazetteer.ancestry(inside)}
+
+    return holding or gids
+
+
 def _narrowed(gids: set[str], pinned: set[str], gazetteer: Gazetteer) -> set[str]:
     """Keep the candidates inside something the event already pinned, or all of them if none are."""
     if len(gids) < 2:
@@ -837,9 +852,12 @@ def resolve_event_places(
     """
     Resolve the places one event names together, letting the unambiguous ones narrow the rest.
 
-    An event's places share a footprint, so a mention that lands on exactly one unit tells the
-    ambiguous mentions beside it where to look. Candidates outside everything the event has already
-    pinned are dropped, and a mention narrowed to nothing keeps its candidates.
+    A name reaching several units is settled first by a point, which sits in at most one of them
+    because the candidates are disjoint. What is left is settled by the event: its places share a
+    footprint, so a mention that lands on exactly one unit tells the ambiguous mentions beside it
+    where to look, and a mention a point has just settled speaks with the same authority. Candidates
+    outside everything the event has pinned are dropped, and a mention narrowed to nothing keeps its
+    candidates.
 
     A place naming nothing takes the unit a point put it in where one is offered. Failing that it
     falls back to the container the prose wrote it in — ``Pesisir Selaten (West Sumatra province)``
@@ -856,8 +874,9 @@ def resolve_event_places(
     gazetteer : Gazetteer
         The country's units, from :func:`read_gazetteer`.
     located : mapping of str to str, optional
-        The unit a point put a written place in, keyed on the name. Default None. A point beats the
-        container because it names one unit where the container names everything inside it.
+        The unit a point put a written place in, keyed on the name. Default None. A point chooses
+        between the units a name reaches, and beats the container where the name reaches none,
+        because it names one unit where the container names everything inside it.
 
     Returns
     -------
@@ -865,7 +884,11 @@ def resolve_event_places(
         Where each place put the event, in the order the places were given.
     """
     written = list(places)
-    resolved = [resolve_place(name, parent, gazetteer) for name, parent in written]
+    points = located or {}
+    resolved = [
+        _chosen_by_point(resolve_place(name, parent, gazetteer), points.get(name), gazetteer)
+        for name, parent in written
+    ]
 
     pinned: set[str] = set()
     for gids in resolved:
@@ -873,7 +896,7 @@ def resolve_event_places(
             pinned |= gazetteer.ancestry(next(iter(gids)))
 
     return [
-        _place_one(name, parent, gids, located or {}, pinned, gazetteer)
+        _place_one(name, parent, gids, points, pinned, gazetteer)
         for (name, parent), gids in zip(written, resolved, strict=True)
     ]
 

--- a/climate_risk/data/place_names.py
+++ b/climate_risk/data/place_names.py
@@ -728,9 +728,7 @@ def _chosen_by_point(gids: set[str], inside: str | None, gazetteer: Gazetteer) -
     if inside is None or len(gids) < 2:
         return gids
 
-    holding = {gid for gid in gids if gid == inside or gid in gazetteer.ancestry(inside)}
-
-    return holding or gids
+    return (gids & gazetteer.ancestry(inside)) or gids
 
 
 def _narrowed(gids: set[str], pinned: set[str], gazetteer: Gazetteer) -> set[str]:

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -348,8 +348,8 @@ def test_a_place_its_own_name_reaches_ignores_the_point_offered_for_it(write_gad
 
 
 def test_a_point_chooses_between_the_units_one_name_reaches(write_gadm_cache):
-    """`Attapu` is both a province and a district three hundred kilometres away. Keeping both puts
-    the event in a place it never happened, and the point says which one the writer meant."""
+    """`Attapu` is both a province and a district of another province. Keeping both puts the event
+    in a place it never happened, and the point says which one the writer meant."""
     gazetteer = read_gazetteer("LAO", write_gadm_cache())
 
     (placed,) = resolve_event_places([("Attapu", None)], gazetteer, located={"Attapu": "LAO.2.2_1"})

--- a/tests/data/test_place_names.py
+++ b/tests/data/test_place_names.py
@@ -347,6 +347,48 @@ def test_a_place_its_own_name_reaches_ignores_the_point_offered_for_it(write_gad
     assert placed == Placement({"LAO.1.1_1"}, NAMED)
 
 
+def test_a_point_chooses_between_the_units_one_name_reaches(write_gadm_cache):
+    """`Attapu` is both a province and a district three hundred kilometres away. Keeping both puts
+    the event in a place it never happened, and the point says which one the writer meant."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Attapu", None)], gazetteer, located={"Attapu": "LAO.2.2_1"})
+
+    assert placed == Placement({"LAO.2.2_1"}, NAMED), "the district, not the province as well"
+
+
+def test_a_point_inside_a_candidate_chooses_it_from_any_depth(write_gadm_cache):
+    """A geocoder answers with the finest unit holding the point, which is below the level the
+    written name reaches. Matching the two literally would settle nothing."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Attapu", None)], gazetteer, located={"Attapu": "LAO.1.1.1_1"})
+
+    assert placed == Placement({"LAO.1_1"}, NAMED), "the province holding the village the point fell in"
+
+
+def test_a_point_outside_every_candidate_settles_nothing(write_gadm_cache):
+    """Geocoders are wrong often enough that a point landing somewhere else is evidence of nothing.
+    Discarding candidates on it would trade an ambiguous placement for a confident wrong one."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    (placed,) = resolve_event_places([("Attapu", None)], gazetteer, located={"Attapu": "LAO.2.1_1"})
+
+    assert placed == Placement({"LAO.1_1", "LAO.2.2_1"}, NAMED)
+
+
+def test_a_name_a_point_settled_narrows_the_places_beside_it(write_gadm_cache):
+    """A settled name is as good as one that was never ambiguous, so it has to reach `pinned` before
+    the event's other places are read against it."""
+    gazetteer = read_gazetteer("LAO", write_gadm_cache())
+
+    _, fallen_back = resolve_event_places(
+        [("Attapu", None), ("Nowhere At All", "Attapu")], gazetteer, located={"Attapu": "LAO.1_1"}
+    )
+
+    assert fallen_back == Placement({"LAO.1_1"}, CONTAINED_BY), "the province the point settled on, not both"
+
+
 def test_a_correction_is_read_only_for_the_country_that_declares_it(write_gadm_cache, tmp_path):
     """The same written name means different places in different countries, and a table keyed only
     on the name would carry one country's correction into every other."""


### PR DESCRIPTION
When EM-DAT's location text names a place that several GADM units share, the resolver kept all of them, so an event landed in every province with a village of that name. Geocoder points were already being computed and passed in, but only consulted where a name reached nothing; now a point sitting inside exactly one candidate picks it, and a name settled that way anchors the event's other places the same as one that was never ambiguous.

This also corrects rows that were never ambiguous. Narrowing on a pinned sibling could pick a namesake inside it, so `Nevada` beside `California` reached Nevada County rather than the state — one unit, confidently wrong, invisible to any count of extra units.

Across the workbook: rows placed unchanged at 30,130, units emitted down from 30,153 to 24,807. A point landing outside every candidate settles nothing and keeps them all, since geocoders are wrong often enough that the alternative trades ambiguity for false certainty.
