### PR TITLE
Stop dropping small and unquantified events by default

### DIFF
--- a/climate_risk/config/schema.py
+++ b/climate_risk/config/schema.py
@@ -41,8 +41,9 @@ class EventFilters:
         First year of the study window, included. Default 1981.
     end_year : int, optional
         Last year, included. Default None, meaning the newest event in the workbook.
-    min_total_affected : int
-        An event must affect more than this many people to count. Default 1000.
+    min_total_affected : int, optional
+        An event must affect more than this many people to count. Default None, which counts an
+        event however small, and counts one whose reach was never recorded.
     min_deaths : int, optional
         An event must kill more than this many people to count. Default None, which counts an event
         on its reach alone.
@@ -50,7 +51,7 @@ class EventFilters:
 
     start_year: int = 1981
     end_year: int | None = None
-    min_total_affected: int = 1000
+    min_total_affected: int | None = None
     min_deaths: int | None = None
 
     def __post_init__(self) -> None:

--- a/climate_risk/config/schema.py
+++ b/climate_risk/config/schema.py
@@ -42,8 +42,8 @@ class EventFilters:
     end_year : int, optional
         Last year, included. Default None, meaning the newest event in the workbook.
     min_total_affected : int, optional
-        An event must affect more than this many people to count. Default None, which counts an
-        event however small, and counts one whose reach was never recorded.
+        An event must affect more than this many people to count. Default None, which counts every
+        event, including one whose reach was never recorded.
     min_deaths : int, optional
         An event must kill more than this many people to count. Default None, which counts an event
         on its reach alone.

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -712,16 +712,16 @@ def event_filter(filters: EventFilters) -> pl.Expr:
     Returns
     -------
     Expr
-        True for events that count. A severity threshold a place does not set is not applied, so an
-        event whose severity is unrecorded counts by default and is dropped by any threshold.
+        True for events that count. An event whose severity is unrecorded clears every threshold a
+        place leaves unset, and fails any it sets.
     """
     counts = pl.col("Start_Year") >= pl.date(filters.start_year, 1, 1)
 
-    if filters.min_total_affected is not None:
-        counts = counts & (pl.col("Total_Affected") > filters.min_total_affected)
-
     if filters.end_year is not None:
         counts = counts & (pl.col("Start_Year") <= pl.date(filters.end_year, 12, 31))
+
+    if filters.min_total_affected is not None:
+        counts = counts & (pl.col("Total_Affected") > filters.min_total_affected)
 
     if filters.min_deaths is not None:
         counts = counts & (pl.col("Deaths") > filters.min_deaths)

--- a/climate_risk/data_functions/emdat_processing.py
+++ b/climate_risk/data_functions/emdat_processing.py
@@ -712,11 +712,13 @@ def event_filter(filters: EventFilters) -> pl.Expr:
     Returns
     -------
     Expr
-        True for events that count. An event whose severity is unrecorded does not.
+        True for events that count. A severity threshold a place does not set is not applied, so an
+        event whose severity is unrecorded counts by default and is dropped by any threshold.
     """
-    counts = (pl.col("Total_Affected") > filters.min_total_affected) & (
-        pl.col("Start_Year") >= pl.date(filters.start_year, 1, 1)
-    )
+    counts = pl.col("Start_Year") >= pl.date(filters.start_year, 1, 1)
+
+    if filters.min_total_affected is not None:
+        counts = counts & (pl.col("Total_Affected") > filters.min_total_affected)
 
     if filters.end_year is not None:
         counts = counts & (pl.col("Start_Year") <= pl.date(filters.end_year, 12, 31))

--- a/climate_risk/data_functions/rivers_damage.py
+++ b/climate_risk/data_functions/rivers_damage.py
@@ -16,6 +16,9 @@ from climate_risk.geo.distance import get_distance_to
 
 DAMAGE_COLUMNS = ("ISO", "End Year", "Latitude", "Longitude", "River Basin", "Total_Damage", "Total_Affected", "Deaths")
 
+# The damage regressions are specified over events reaching more than this many people.
+REPLICATION_FILTERS = EventFilters(min_total_affected=1_000)
+
 
 def _create_rivers_damage(
     cache_dir: Path,
@@ -56,7 +59,7 @@ def _create_rivers_damage(
 
     def build() -> gpd.GeoDataFrame:
         big_rivers = load_rivers_data(cache_dir)
-        emdat = load_emdat_events(cache_dir).filter(event_filter(EventFilters())).to_pandas()
+        emdat = load_emdat_events(cache_dir).filter(event_filter(REPLICATION_FILTERS)).to_pandas()
         world = load_shapefile("world", cache_dir, repair_ISO_codes=True)
 
         events = emdat.query(query)

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -192,9 +192,42 @@ def test_an_event_exactly_on_the_affected_threshold_does_not_count(write_emdat_c
         ]
     )
 
-    kept = selected_events(cache_dir)["DisNo."]
+    kept = selected_events(cache_dir, filters=EventFilters(min_total_affected=1_000))["DisNo."]
 
     assert kept.to_list() == ["over"]
+
+
+def test_an_event_whose_reach_was_never_recorded_counts_by_default(write_emdat_cache):
+    """A fifth of the workbook records no reach at all. Comparing a null against a floor drops it, so
+    a default floor would discard events for being unquantified rather than for being small."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "counted", "Start Year": 1995, "Total Affected": 5_000}),
+            emdat_event({"DisNo.": "unquantified", "Start Year": 1995, "Total Affected": None}),
+        ]
+    )
+
+    by_default = selected_events(cache_dir)["DisNo."]
+    with_a_floor = selected_events(cache_dir, filters=EventFilters(min_total_affected=1))["DisNo."]
+
+    assert sorted(by_default.to_list()) == ["counted", "unquantified"]
+    assert with_a_floor.to_list() == ["counted"], "a floor still drops what it cannot compare"
+
+
+def test_a_small_event_counts_unless_a_place_sets_a_floor(write_emdat_cache):
+    """Small events carry the finest geography, so a floor biases the panel towards coarse units."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "large", "Start Year": 1995, "Total Affected": 5_000}),
+            emdat_event({"DisNo.": "small", "Start Year": 1995, "Total Affected": 30}),
+        ]
+    )
+
+    by_default = selected_events(cache_dir)["DisNo."]
+    with_a_floor = selected_events(cache_dir, filters=EventFilters(min_total_affected=1_000))["DisNo."]
+
+    assert by_default.to_list() == ["large", "small"]
+    assert with_a_floor.to_list() == ["large"]
 
 
 def test_the_adjusted_view_follows_the_filters_it_is_given(write_emdat_cache):

--- a/tests/data_functions/test_emdat_processing.py
+++ b/tests/data_functions/test_emdat_processing.py
@@ -198,8 +198,8 @@ def test_an_event_exactly_on_the_affected_threshold_does_not_count(write_emdat_c
 
 
 def test_an_event_whose_reach_was_never_recorded_counts_by_default(write_emdat_cache):
-    """A fifth of the workbook records no reach at all. Comparing a null against a floor drops it, so
-    a default floor would discard events for being unquantified rather than for being small."""
+    """Comparing a null against a floor drops it, so a default floor would discard events for being
+    unquantified rather than for being small."""
     cache_dir = write_emdat_cache(
         [
             emdat_event({"DisNo.": "counted", "Start Year": 1995, "Total Affected": 5_000}),
@@ -228,6 +228,23 @@ def test_a_small_event_counts_unless_a_place_sets_a_floor(write_emdat_cache):
 
     assert by_default.to_list() == ["large", "small"]
     assert with_a_floor.to_list() == ["large"]
+
+
+def test_a_deaths_threshold_drops_an_event_whose_deaths_were_never_recorded(write_emdat_cache):
+    """Every threshold compares against a possibly-null column, so the rule that an unrecorded
+    severity fails any threshold set has to hold for deaths as much as for reach."""
+    cache_dir = write_emdat_cache(
+        [
+            emdat_event({"DisNo.": "counted", "Start Year": 1995, "Total Deaths": 500}),
+            emdat_event({"DisNo.": "unquantified", "Start Year": 1995, "Total Deaths": None}),
+        ]
+    )
+
+    by_default = selected_events(cache_dir)["DisNo."]
+    with_a_floor = selected_events(cache_dir, filters=EventFilters(min_deaths=1))["DisNo."]
+
+    assert sorted(by_default.to_list()) == ["counted", "unquantified"]
+    assert with_a_floor.to_list() == ["counted"]
 
 
 def test_the_adjusted_view_follows_the_filters_it_is_given(write_emdat_cache):

--- a/tests/data_functions/test_rivers_damage.py
+++ b/tests/data_functions/test_rivers_damage.py
@@ -19,6 +19,7 @@ UNPATCHED_LATITUDE = 1.25
 FLOOD_LATITUDE = 18.25
 STORM_LATITUDE = 18.5
 DROUGHT_LATITUDE = 18.75
+BARELY_FELT_LATITUDE = 17.75
 
 VARIANTS = {
     "hydro": (create_hydro_rivers_damage, "Total_Damage_Hydro", "log_affected_hydro"),
@@ -89,6 +90,17 @@ def damage_cache(tmp_path, write_emdat_cache, write_shapefile_cache, write_river
                     "Latitude": UNDAMAGED_LATITUDE,
                     "Longitude": 101.25,
                     "Total Damage ('000 US$)": 0,
+                }
+            ),
+            # Below the damage panel's reach floor, so it must not enter the regressions.
+            emdat_event(
+                {
+                    "ISO": "LAO",
+                    "DisNo.": "LAO-barelyfelt",
+                    "Disaster Type": "Flood",
+                    "Latitude": BARELY_FELT_LATITUDE,
+                    "Longitude": 101.75,
+                    "Total Affected": 30,
                 }
             ),
             emdat_event(
@@ -184,6 +196,14 @@ def test_an_event_missing_one_coordinate_is_dropped(damage_cache):
 
     assert HALF_LOCATED_LATITUDE not in set(damage["Latitude"])
     assert damage.geometry.is_valid.all()
+
+
+def test_an_event_below_the_reach_floor_stays_out_of_the_damage_frame(damage_cache):
+    """The damage panel sets its own reach floor, so its regressions are fitted on the same events
+    whatever thresholds a place carries."""
+    damage = create_floods_rivers_damage(damage_cache)
+
+    assert BARELY_FELT_LATITUDE not in set(damage["Latitude"])
 
 
 def test_zero_damage_becomes_missing_rather_than_a_log_of_zero(damage_cache):


### PR DESCRIPTION
Every place's event panel was filtered to events affecting more than a thousand people, following a paper that pre-processed small disasters away as unreliable. On `sea` from 1981 that cut 1,182 of 2,699 events, and it cut unevenly: 49% of events coded to adm2 or finer against 31% of adm1-only ones, since a small-area event affects fewer people. That skew lands directly on the adm1-to-adm2 held-out check the frequency model is built around, so the threshold is coming out and the detection process gets modeled instead.

`min_total_affected` is now optional rather than defaulting to 1000 — a schema change and not a value change, because `null > 0` is null, so 521 of those dropped events were going for having no recorded reach rather than a small one.

`rivers_damage` keeps the old floor as `REPLICATION_FILTERS`. It hardcodes the default filters and feeds the replication panel, so without the pin its event set nearly triples globally and the published regressions refit on a different population.
