### PR TITLE
Resume an interrupted download instead of starting it again

### DIFF
--- a/climate_risk/data/fetch.py
+++ b/climate_risk/data/fetch.py
@@ -18,13 +18,23 @@ USER_AGENT = "climate-risk (+https://github.com/jessegrabowski/laos-climate-chan
 CHUNK_BYTES = 1 << 20
 TIMEOUT_SECONDS = 60
 
+# Hosts serving multi-hundred-megabyte rasters drop long transfers, so one read timeout is not a
+# failure. Each attempt after the first asks for the bytes the last one stopped at.
+ATTEMPTS = 5
+
+PARTIAL_CONTENT = 206
+RANGE_NOT_SATISFIABLE = 416
+
 
 def fetch(source: DataSource, cache_dir: Path, *, force: bool = False) -> Path:
     """
     Download ``source`` into ``cache_dir`` unless it is already there, and return its path.
 
     The download goes to a sibling ``.part`` file and is moved into place only once complete, so an
-    interrupted transfer can never be mistaken for a cache hit.
+    interrupted transfer can never be mistaken for a cache hit. A dropped connection is retried, and
+    each retry continues from the bytes already written rather than starting the file again. A
+    ``.part`` left by an earlier call is discarded instead: nothing proves it is a prefix of this
+    file, and appending to bytes from elsewhere would write a corrupt archive that looks complete.
 
     Parameters
     ----------
@@ -47,20 +57,59 @@ def fetch(source: DataSource, cache_dir: Path, *, force: bool = False) -> Path:
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     partial = destination.with_suffix(destination.suffix + ".part")
+    partial.unlink(missing_ok=True)
 
     _log.info(f"Downloading {source.filename} from {source.url}")
-    with requests.get(source.url, stream=True, timeout=TIMEOUT_SECONDS, headers={"User-Agent": USER_AGENT}) as response:
+    for attempt in range(1, ATTEMPTS + 1):
+        try:
+            _download(source, partial)
+            break
+        except requests.RequestException as err:
+            if attempt == ATTEMPTS:
+                raise
+            _log.warning(f"{source.filename}: attempt {attempt} of {ATTEMPTS} stopped ({err}), continuing from disk")
+
+    os.replace(partial, destination)
+
+    return destination
+
+
+def _download(source: DataSource, partial: Path) -> None:
+    """Write ``source`` into ``partial``, continuing from whatever it already holds."""
+    have = partial.stat().st_size if partial.exists() else 0
+    headers = {"User-Agent": USER_AGENT}
+    if have:
+        headers["Range"] = f"bytes={have}-"
+
+    with requests.get(source.url, stream=True, timeout=TIMEOUT_SECONDS, headers=headers) as response:
+        if have and response.status_code == RANGE_NOT_SATISFIABLE:
+            return
+
         response.raise_for_status()
-        total = int(response.headers.get("Content-Length", 0))
+
+        # A host may answer a ranged request with the whole file. Appending then would double it,
+        # so the partial is thrown away and rewritten.
+        continuing = have > 0 and response.status_code == PARTIAL_CONTENT
+        already = have if continuing else 0
+        expected = int(response.headers.get("Content-Length", 0))
 
         with (
-            partial.open("wb") as handle,
-            tqdm(total=total or None, unit="B", unit_scale=True, desc=source.filename) as progress,
+            partial.open("ab" if continuing else "wb") as handle,
+            tqdm(
+                total=(expected + already) or None,
+                initial=already,
+                unit="B",
+                unit_scale=True,
+                desc=source.filename,
+            ) as progress,
         ):
             for chunk in response.iter_content(chunk_size=CHUNK_BYTES):
                 handle.write(chunk)
                 progress.update(len(chunk))
 
-    os.replace(partial, destination)
-
-    return destination
+    written = partial.stat().st_size
+    if expected and written != expected + already:
+        # Retryable: the loop above continues from what is on disk rather than starting again.
+        raise requests.ConnectionError(
+            f"{source.filename}: {written} bytes written against {expected + already} declared"
+        )

--- a/tests/data/test_fetch.py
+++ b/tests/data/test_fetch.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 
-from climate_risk.data.fetch import USER_AGENT, fetch
+from climate_risk.data.fetch import ATTEMPTS, USER_AGENT, fetch
 from climate_risk.data.source import DataSource
 
 PAYLOAD = b"Year,co2\n1990,354.4\n"
@@ -19,9 +19,11 @@ def make_source(**overrides) -> DataSource:
 
 
 class FakeResponse:
-    def __init__(self, payload: bytes, status_error: Exception | None = None):
+    def __init__(self, payload: bytes, status_error: Exception | None = None, status_code: int = 200, stop_after=None):
         self.payload = payload
         self.status_error = status_error
+        self.status_code = status_code
+        self.stop_after = stop_after
         self.headers = {"Content-Length": str(len(payload))}
 
     def __enter__(self):
@@ -34,9 +36,18 @@ class FakeResponse:
         if self.status_error is not None:
             raise self.status_error
 
+    # Fixed small pieces regardless of what the caller asks for, so a drop part-way through a
+    # payload is expressible without a megabyte of fixture.
+    PIECE = 64
+
     def iter_content(self, chunk_size):
-        for start in range(0, len(self.payload), chunk_size):
-            yield self.payload[start : start + chunk_size]
+        sent = 0
+        for start in range(0, len(self.payload), self.PIECE):
+            if self.stop_after is not None and sent >= self.stop_after:
+                raise requests.ConnectionError("the host dropped the transfer")
+            chunk = self.payload[start : start + self.PIECE]
+            sent += len(chunk)
+            yield chunk
 
 
 @pytest.fixture
@@ -110,3 +121,105 @@ def test_a_cache_directory_that_does_not_exist_yet_is_created(tmp_path, download
     nested = tmp_path / "gpcc" / "raw"
 
     assert fetch(make_source(), nested).read_bytes() == PAYLOAD
+
+
+LONG_PAYLOAD = b"".join(f"{year},{year % 97}\n".encode() for year in range(1900, 2001))
+
+
+def serve_with_ranges(monkeypatch, payload, *, drop_first_after=None, ignore_range=False):
+    """A host that honours Range, and optionally drops the first transfer part-way through."""
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append({"url": url, **kwargs})
+        start = 0
+        offered = kwargs.get("headers", {}).get("Range")
+        if offered and not ignore_range:
+            start = int(offered.removeprefix("bytes=").rstrip("-"))
+            return FakeResponse(payload[start:], status_code=206)
+        return FakeResponse(payload, status_code=200)
+
+    def dropping_get(url, **kwargs):
+        response = fake_get(url, **kwargs)
+        if len(calls) == 1:
+            response.stop_after = drop_first_after
+        return response
+
+    monkeypatch.setattr(requests, "get", dropping_get if drop_first_after else fake_get)
+
+    return calls
+
+
+def test_a_dropped_transfer_continues_from_the_bytes_already_written(tmp_path, monkeypatch):
+    """A host serving half-gigabyte rasters drops long transfers, and restarting each time never
+    converges. The second attempt asks for the remainder rather than the whole file."""
+    calls = serve_with_ranges(monkeypatch, LONG_PAYLOAD, drop_first_after=len(LONG_PAYLOAD) // 4)
+
+    path = fetch(make_source(), tmp_path)
+
+    assert path.read_bytes() == LONG_PAYLOAD
+    assert "Range" not in calls[0]["headers"]
+    assert calls[1]["headers"]["Range"].startswith("bytes=")
+
+
+def test_a_host_ignoring_the_range_restarts_rather_than_doubling(tmp_path, monkeypatch):
+    """Answering a ranged request with the whole file is allowed. Appending it to what is already
+    on disk would write a file of the right name and twice the length."""
+    serve_with_ranges(monkeypatch, LONG_PAYLOAD, drop_first_after=len(LONG_PAYLOAD) // 4, ignore_range=True)
+
+    assert fetch(make_source(), tmp_path).read_bytes() == LONG_PAYLOAD
+
+
+def test_a_short_transfer_is_not_moved_into_place(tmp_path, monkeypatch):
+    """The declared length is the only check that the bytes are all there; without it a truncated
+    archive gets the real filename and every later read fails somewhere further away."""
+
+    class ShortResponse(FakeResponse):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.headers = {"Content-Length": str(len(PAYLOAD) * 2)}
+
+    monkeypatch.setattr(requests, "get", lambda url, **kwargs: ShortResponse(PAYLOAD))
+
+    with pytest.raises(requests.ConnectionError, match="declared"):
+        fetch(make_source(), tmp_path)
+
+    assert not (tmp_path / "noaa_co2.csv").exists()
+
+
+def test_a_host_that_keeps_dropping_gives_up(tmp_path, monkeypatch):
+    """Retrying forever on a host that is down hangs a loader with no way to tell why."""
+    attempts = []
+
+    def always_drops(url, **kwargs):
+        attempts.append(url)
+        return FakeResponse(LONG_PAYLOAD, status_code=200, stop_after=0)
+
+    monkeypatch.setattr(requests, "get", always_drops)
+
+    with pytest.raises(requests.ConnectionError):
+        fetch(make_source(), tmp_path)
+
+    assert len(attempts) == ATTEMPTS
+
+
+def test_a_complete_partial_is_accepted_rather_than_refetched(tmp_path, monkeypatch):
+    """A transfer that dropped after the last byte leaves a whole file waiting to be renamed. Asking
+    for bytes past the end answers 416, which means done rather than failed."""
+    requested = []
+
+    class DropsAfterTheLastByte(FakeResponse):
+        def iter_content(self, chunk_size):
+            yield self.payload
+            raise requests.ConnectionError("the host dropped after the last byte")
+
+    def range_not_satisfiable(url, **kwargs):
+        requested.append(kwargs.get("headers", {}).get("Range"))
+        if len(requested) == 1:
+            return DropsAfterTheLastByte(PAYLOAD, status_code=200)
+        return FakeResponse(b"", status_code=416)
+
+    monkeypatch.setattr(requests, "get", range_not_satisfiable)
+
+    assert fetch(make_source(), tmp_path).read_bytes() == PAYLOAD
+    assert requested[1] == f"bytes={len(PAYLOAD)}-"


### PR DESCRIPTION
Downloads had no retry and no resume, so a host that drops long transfers could never deliver a large file — every attempt started from zero. `fetch` now retries, and each attempt continues from the bytes already on disk.

A `.part` left by an earlier call is still discarded rather than resumed, because nothing proves it's a prefix of the same file. The declared length is checked before anything is moved into place, which matters more now that a truncated transfer can end cleanly.
