### PR TITLE
Add the GHS-POP population raster loader

### DIFF
--- a/climate_risk/data/ghsl.py
+++ b/climate_risk/data/ghsl.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from zipfile import ZipFile
+
+from climate_risk.data.fetch import fetch
+from climate_risk.data.source import DataSource
+from climate_risk.exceptions import DataValidationError
+
+GHSL_URL = "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL"
+GHSL_SUBDIRECTORY = "ghsl"
+GHSL_RELEASE = "R2023A"
+GHSL_LICENCE = "European Commission reuse notice: reuse authorised provided the source is acknowledged"
+GHSL_CITATION = (
+    "Schiavina, M., Freire, S., Carioli, A., MacManus, K. (2026): GHS-POP R2023A - GHS population "
+    "grid multitemporal (1975-2030). European Commission, Joint Research Centre. "
+    "doi:10.2905/2FF68A52-5B5B-4A22-8F40-C41DA8332CFE"
+)
+GHSL_RETRIEVED = "2026-08-23"
+
+# Epochs the release publishes. Five-yearly, so the panel's 1981 opening is covered from below.
+POPULATION_EPOCHS = tuple(range(1975, 2031, 5))
+
+# Arc-seconds per cell in the WGS84 grids. 30 is roughly a kilometre, ample under a 5 km analysis
+# cell; the 3 arc-second grid is a hundred times the bytes for a mean that cannot move.
+RESOLUTION = "30ss"
+
+
+def ghsl_dir(cache_dir: Path) -> Path:
+    return cache_dir / GHSL_SUBDIRECTORY
+
+
+def population_source(epoch: int) -> DataSource:
+    """
+    Declare the population raster for one epoch.
+
+    Parameters
+    ----------
+    epoch : int
+        Year the grid describes, one of ``POPULATION_EPOCHS``.
+
+    Returns
+    -------
+    DataSource
+        The zipped GeoTIFF as GHSL publishes it.
+    """
+    if epoch not in POPULATION_EPOCHS:
+        raise DataValidationError(f"GHS-POP publishes {POPULATION_EPOCHS}, not {epoch}")
+
+    stem = f"GHS_POP_E{epoch}_GLOBE_{GHSL_RELEASE}_4326_{RESOLUTION}"
+
+    return DataSource(
+        url=f"{GHSL_URL}/GHS_POP_GLOBE_{GHSL_RELEASE}/{stem}/V1-0/{stem}_V1_0.zip",
+        filename=f"{stem}_V1_0.zip",
+        licence=GHSL_LICENCE,
+        citation=GHSL_CITATION,
+        retrieved=GHSL_RETRIEVED,
+    )
+
+
+def population_raster(epoch: int, cache_dir: Path) -> str:
+    """
+    Name the population raster for one epoch, fetching the archive if it is not there.
+
+    The GeoTIFF is read where it lies, through GDAL's virtual filesystem, so the archive is the only
+    copy on disk. The member is found by extension because GHSL ships metadata beside the raster.
+
+    Parameters
+    ----------
+    epoch : int
+        Year the grid describes, one of ``POPULATION_EPOCHS``.
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    str
+        A URI :func:`rasterio.open` accepts, addressing the GeoTIFF inside its archive. The band
+        holds people per cell.
+    """
+    source = population_source(epoch)
+    archive = fetch(source, ghsl_dir(cache_dir))
+
+    with ZipFile(archive) as unpacked:
+        members = [name for name in unpacked.namelist() if name.lower().endswith(".tif")]
+
+    if len(members) != 1:
+        raise DataValidationError(f"{source.filename} holds {len(members)} rasters, expected exactly one")
+
+    return f"zip://{archive}!/{members[0]}"

--- a/pixi.lock
+++ b/pixi.lock
@@ -231,6 +231,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.1-py312h5d657d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.1-h462bb3b_0.conda
@@ -280,12 +281,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.2.0-pyh8e99733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.2.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
@@ -294,6 +297,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
@@ -369,6 +375,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-83.0.0-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -403,12 +410,14 @@ environments:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.2.0-pyh8e99733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.2.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
@@ -417,6 +426,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.8-h7e67a1e_1.conda
@@ -492,6 +504,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-83.0.0-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -705,6 +718,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.13.0-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.5.1-py312hcf83bec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-h5d60da5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.16.1-h828de30_0.conda
@@ -972,6 +986,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.1-py312h5d657d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py312h192e038_0.conda
@@ -1023,6 +1038,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
@@ -1047,6 +1063,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
@@ -1180,6 +1199,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-83.0.0-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
@@ -1234,6 +1254,7 @@ environments:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1259,6 +1280,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
@@ -1392,6 +1416,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-83.0.0-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
@@ -1623,6 +1648,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.5.1-py312hcf83bec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-h5d60da5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py312h8b1d842_0.conda
@@ -5676,6 +5702,33 @@ packages:
     - qt6-main >=6.11.1,<7.0a0
   size: 60185421
   timestamp: 1780593127053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.1-py312h5d657d5_1.conda
+  sha256: 75a098544de4e265b36f05f26655bf2c62a64549d5baa0e2060d52fdbe807fcf
+  md5: c0d4e6e0b2f6a3e73ab81630deab839d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - affine
+  - attrs
+  - certifi
+  - click >=4,!=8.2.*
+  - click-plugins
+  - cligj >=0.5
+  - libgcc >=14
+  - libgdal-core >=3.13.2,<3.14.0a0
+  - libstdcxx >=14
+  - numpy >=1.25,<3
+  - proj >=9.8.1,<9.9.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/rasterio?source=hash-mapping
+  run_exports: {}
+  size: 7505563
+  timestamp: 1786313811246
 - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
   sha256: 7279908454f0c87b84ebc4aec6924f02f41a105d88420fb35dfaf5ecd976e0f5
   md5: d83f2ee212d217a6d745a00e5be84671
@@ -6478,6 +6531,19 @@ packages:
   run_exports: {}
   size: 631452
   timestamp: 1758743294412
+- conda: https://conda.anaconda.org/conda-forge/noarch/affine-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 5a72f7fbb1adb86817fde49acf972148638cc613edae9c15ac575d176da2746a
+  md5: 71dd867a02739013ae65894ca32d67b7
+  depends:
+  - attrs
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/affine?source=compressed-mapping
+  run_exports: {}
+  size: 16762
+  timestamp: 1786226684740
 - conda: https://conda.anaconda.org/conda-forge/noarch/anyascii-0.3.3-pyhe01879c_0.conda
   sha256: e7e8110ada1a45fa7103704d7996c94a1e69f2ae45da17c89ca5d214a089e658
   md5: e5438b5cd3552aca55f7ab5b25891590
@@ -6824,6 +6890,46 @@ packages:
   run_exports: {}
   size: 61418
   timestamp: 1783505332569
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+  sha256: ccc4787f511964f9a1f2d2d2859c91c5d571fb60f7f09d4c4e092c9b7a94e671
+  md5: 2c4bd6aeb90bb157456841c3270a0d92
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/click?source=hash-mapping
+  run_exports: {}
+  size: 107155
+  timestamp: 1783085363526
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+  sha256: ba1ee6e2b2be3da41d70d0d51d1159010de900aa3f33fceaea8c52e9bd30a26e
+  md5: e9b05deb91c013e5224672a4ba9cf8d1
+  depends:
+  - click >=4.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/click-plugins?source=hash-mapping
+  run_exports: {}
+  size: 12683
+  timestamp: 1750848314962
+- conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
+  sha256: 1a52ae1febfcfb8f56211d1483a1ac4419b0028b7c3e9e61960a298978a42396
+  md5: 55c7804f428719241a90b152016085a1
+  depends:
+  - click >=4.0
+  - python >=3.9,<4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/cligj?source=hash-mapping
+  run_exports: {}
+  size: 12521
+  timestamp: 1733750069604
 - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
   sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
   md5: 61b8078a0905b12529abc622406cb62c
@@ -8835,6 +8941,20 @@ packages:
   run_exports: {}
   size: 15698
   timestamp: 1762941572482
+- conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
+  sha256: 61f9373709e7d9009e3a062b135dbe44b16e684a4fcfe2dd624143bc0f80d402
+  md5: 9aa358575bbd4be126eaa5e0039f835c
+  depends:
+  - numpy
+  - pyparsing >=2.1.6
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/snuggs?source=hash-mapping
+  run_exports: {}
+  size: 11313
+  timestamp: 1733818738919
 - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.1-pyhd8ed1ab_0.conda
   sha256: d10bfe45ffd6fa37baef69d852f9fa882be4e6fe4cdd7286f3543e79b803cadb
   md5: 0fc47d7f5a6dbafd186a8f92cad5de3f
@@ -12739,6 +12859,33 @@ packages:
     - qhull >=2020.2,<2020.3.0a0
   size: 516376
   timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.5.1-py312hcf83bec_1.conda
+  sha256: 773db6654aabdf762795d39479e1d748138fca287ee3ad21a1fbb4ce8e31c3f5
+  md5: b81e23b4dfb40a90159500bc04d1548e
+  depends:
+  - __osx >=11.0
+  - affine
+  - attrs
+  - certifi
+  - click >=4,!=8.2.*
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=19
+  - libgdal-core >=3.13.2,<3.14.0a0
+  - numpy >=1.25,<3
+  - proj >=9.8.1,<9.9.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/rasterio?source=hash-mapping
+  run_exports: {}
+  size: 7952183
+  timestamp: 1786314131626
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-h5d60da5_2.conda
   sha256: ba1154085d70e8e8f94cfc38a018a13d1a734ff1bcc2ab384e4fc3e532b23066
   md5: a2578dc92c16ab5b6b183cfcdc8e8b79
@@ -13172,6 +13319,7 @@ packages:
   - pymc-extras>=0.14.0,<1
   - pymc>=6.3,<7
   - pytensor>=3.3,<4
+  - rasterio>=1.5,<2
   - requests>=2.34,<3
   - scikit-learn>=1.9,<2
   - scipy>=1.18,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "kuznets[polars]>=1.0.1,<2",
     "geopandas>=1.1,<2",
     "exactextract>=0.3,<1",
+    "rasterio>=1.5,<2",
     "pymc>=6.3,<7",
     "pytensor>=3.3,<4",
     "arviz>=1.2,<2",
@@ -91,6 +92,7 @@ openpyxl = ">=3.1,<4"
 xlrd = ">=2.0,<3"
 geopandas = ">=1.1,<2"
 exactextract = ">=0.3,<1"
+rasterio = ">=1.5,<2"
 pymc = ">=6.3,<7"
 pytensor = ">=3.3,<4"
 arviz = ">=1.2,<2"
@@ -168,6 +170,7 @@ markers = [
     "requires_emdat: needs the licensed EM-DAT workbook, absent from CI",
     "requires_gadm: needs the GADM GeoPackage, which is non-commercial and absent from CI",
     "requires_geo_disasters: needs the Geo-Disasters GeoPackage, non-commercial and absent from CI",
+    "requires_ghsl: needs the GHS-POP raster, half a gigabyte and absent from CI",
 ]
 filterwarnings = [
     "error",
@@ -221,7 +224,7 @@ enable_error_code = ["possibly-undefined"]
 
 # No stubs exist for these, on the index or in the packages themselves.
 [[tool.mypy.overrides]]
-module = ["arviz.*", "pymc.*", "pytensor.*", "ptgp.*", "exactextract.*", "sklearn.*", "statsmodels.*"]
+module = ["arviz.*", "pymc.*", "pytensor.*", "ptgp.*", "exactextract.*", "rasterio.*", "sklearn.*", "statsmodels.*"]
 ignore_missing_imports = true
 
 # Test functions carry no annotations, so their bodies need checking on their own terms.

--- a/tests/data/test_ghsl.py
+++ b/tests/data/test_ghsl.py
@@ -1,0 +1,117 @@
+import zipfile
+
+from pathlib import Path
+
+import pytest
+import rasterio
+
+from exactextract import exact_extract
+from exactextract.raster import RasterioRasterSource
+
+from climate_risk.data.gadm import load_units_in_country
+from climate_risk.data.ghsl import (
+    POPULATION_EPOCHS,
+    population_raster,
+    population_source,
+)
+from climate_risk.exceptions import DataValidationError
+
+
+def write_archive(cache_dir, epoch, members):
+    """Write the zip GHSL publishes for an epoch, holding whatever members a test needs."""
+    directory = cache_dir / "ghsl"
+    directory.mkdir(parents=True, exist_ok=True)
+    archive = directory / population_source(epoch).filename
+    with zipfile.ZipFile(archive, "w") as writing:
+        for name, payload in members.items():
+            writing.writestr(name, payload)
+
+    return archive
+
+
+def test_an_epoch_the_release_does_not_publish_is_an_error():
+    """The URL is built from the epoch, so a wrong one would 404 halfway through a download rather
+    than failing where the caller can see why."""
+    with pytest.raises(DataValidationError, match="1976"):
+        population_source(1976)
+
+
+@pytest.mark.parametrize("epoch", [1975, 1990, 2020])
+def test_the_declared_url_names_the_epoch_it_was_asked_for(epoch):
+    """One template serves twelve epochs, so the year has to reach both the path and the filename.
+    Asking for one epoch only would not catch a template that had the year baked in."""
+    source = population_source(epoch)
+
+    assert f"E{epoch}" in source.url
+    assert f"E{epoch}" in source.filename
+    assert source.url.endswith(source.filename)
+
+
+def test_the_raster_is_addressed_inside_its_archive(tmp_path):
+    """Half a gigabyte per epoch, twelve epochs: extracting each one doubles the cost for a file
+    GDAL can read where it lies. The metadata beside it must not be mistaken for the raster."""
+    archive = write_archive(tmp_path, 2020, {"GHS_POP_E2020.tif": b"raster bytes", "GHS_POP_E2020.txt": b"metadata"})
+
+    uri = population_raster(2020, tmp_path)
+
+    assert uri == f"zip://{archive}!/GHS_POP_E2020.tif"
+    assert not list(tmp_path.glob("**/*.tif")), "nothing is extracted"
+
+
+def test_an_archive_holding_no_single_raster_is_an_error(tmp_path):
+    """GHSL ships metadata beside the raster, so the member is found by extension. Two of them means
+    the archive is not the product this loader was written against."""
+    write_archive(tmp_path, 2020, {"first.tif": b"a", "second.tif": b"b"})
+
+    with pytest.raises(DataValidationError, match="2 rasters"):
+        population_raster(2020, tmp_path)
+
+
+def test_the_epochs_reach_back_past_the_study_window():
+    """Exposure is interpolated between epochs, so the window's 1981 opening has to sit inside them.
+    An epoch list starting later would extrapolate population backwards over the whole first decade."""
+    assert min(POPULATION_EPOCHS) <= 1981
+
+
+# Half a gigabyte per epoch, so it is absent on CI and on a fresh clone.
+REAL_CACHE_DIR = Path(__file__).parents[2] / "data"
+REAL_ARCHIVE = REAL_CACHE_DIR / "ghsl" / population_source(2020).filename
+
+
+@pytest.mark.requires_ghsl
+@pytest.mark.requires_gadm
+@pytest.mark.skipif(not REAL_ARCHIVE.exists(), reason="needs the GHS-POP archive")
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg").exists(), reason="needs the GADM GeoPackage")
+@pytest.mark.parametrize(("iso", "published"), [("LAO", 7.4e6), ("KHM", 16.4e6)], ids=["Laos", "Cambodia"])
+def test_the_raster_totals_a_country_to_its_published_population(iso, published):
+    """A synthetic fixture cannot catch the wrong product, the wrong units, or a grid read against
+    the wrong transform. Summing real polygons against a number from outside the repo can."""
+    units = load_units_in_country(iso, 1, REAL_CACHE_DIR)
+    with rasterio.open(population_raster(2020, REAL_CACHE_DIR)) as source:
+        totals = exact_extract(RasterioRasterSource(source), units, ["sum"], output="pandas")
+
+    assert totals["sum"].sum() == pytest.approx(published, rel=0.05)
+
+
+@pytest.mark.slow
+@pytest.mark.requires_ghsl
+@pytest.mark.requires_gadm
+@pytest.mark.skipif(not REAL_ARCHIVE.exists(), reason="needs the GHS-POP archive")
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg").exists(), reason="needs the GADM GeoPackage")
+def test_the_epochs_form_one_series_on_one_grid():
+    """The exposure offset interpolates between epochs, so a swapped or mislabelled year would move
+    population backwards in time and no single-epoch check would see it. Every grid must also share
+    a shape, since one operator is built against all of them."""
+    units = load_units_in_country("LAO", 1, REAL_CACHE_DIR)
+    grids, totals = set(), []
+
+    for epoch in POPULATION_EPOCHS:
+        uri = population_raster(epoch, REAL_CACHE_DIR)
+        if not Path(uri.removeprefix("zip://").split("!/")[0]).exists():
+            pytest.skip(f"epoch {epoch} is not in the cache")
+        with rasterio.open(uri) as source:
+            grids.add((source.shape, source.crs.to_string()))
+            totals.append(exact_extract(RasterioRasterSource(source), units, ["sum"], output="pandas")["sum"].sum())
+
+    assert len(grids) == 1, "the epochs are read against different grids"
+    assert totals == sorted(totals), "Laos population does not rise through the series"


### PR DESCRIPTION
Population per grid cell from the JRC's Global Human Settlement Layer, five-yearly from 1975 to 2030. The frequency model needs it as an exposure offset, and it has to be time-varying because population roughly doubled across the panel. Free with attribution rather than licensed, so unlike GADM and the EM-DAT workbook the code is allowed to fetch it.

GDAL reads the GeoTIFF inside its zip, so the archive is the only copy on disk. Adds `rasterio`: `exactextract` was already here to do the aggregation but needs a reader object, and ships a `RasterioRasterSource` for exactly that.
