### PR TITLE
Collect each event into the observation window it was seen through

### DIFF
--- a/climate_risk/data/model_frame.py
+++ b/climate_risk/data/model_frame.py
@@ -1,0 +1,68 @@
+import polars as pl
+
+from climate_risk.data_functions.emdat_processing import GEOMETRY_SOURCES
+from climate_risk.exceptions import DataValidationError
+
+EVENT_WINDOW_COLUMNS = ("DisNo.", "ISO", "year", "gids", "n_units", "finest_level", "geometry_source")
+
+# Ordered by declaration rather than alphabetically, so the best source of several is the min.
+SOURCE_ORDER = pl.Enum(GEOMETRY_SOURCES)
+
+
+def _finest_level(gids: pl.Expr) -> pl.Expr:
+    """Depth of the deepest unit a window holds, counting dots in the GADM identifier."""
+    return gids.list.eval(pl.element().str.split("_").list.first().str.count_matches(r"\.")).list.max()
+
+
+def event_windows(events: pl.DataFrame, geography: pl.DataFrame) -> pl.DataFrame:
+    """
+    Collect each event into the one observation window its geography describes.
+
+    An event is located to whatever units the sources reached, and those units are not all at one
+    administrative level: a district for one event, a province for the next, nothing at all for a
+    third. The window is the union of the units named, so the resolution an event was reported at is
+    carried rather than normalized away, and an event naming nothing reduces to its whole country.
+
+    Parameters
+    ----------
+    events : DataFrame
+        The workbook filtered to a place's window, from :func:`~climate_risk.data_functions.emdat_processing.load_emdat_events`.
+    geography : DataFrame
+        One row per event-unit, from
+        :func:`~climate_risk.data_functions.emdat_processing.event_geography`.
+
+    Returns
+    -------
+    DataFrame
+        One row per event, ordered by identifier. ``gids`` holds the units the window covers, empty
+        where the window is the whole country; ``n_units`` and ``finest_level`` describe its extent,
+        the latter null on a whole-country window. ``geometry_source`` is the best source that
+        reached the event, ranked by ``GEOMETRY_SOURCES``.
+    """
+    missing = set(events["DisNo."]) - set(geography["DisNo."])
+    if missing:
+        raise DataValidationError(
+            f"{len(missing)} events carry no geography row, so their window is undefined: {sorted(missing)[:5]}"
+        )
+
+    windows = (
+        geography.select("DisNo.", "gid", pl.col("geometry_source").cast(SOURCE_ORDER))
+        .unique()
+        .group_by("DisNo.")
+        .agg(
+            pl.col("gid").drop_nulls().sort().alias("gids"),
+            pl.col("geometry_source").min(),
+        )
+    )
+
+    return (
+        events.select("DisNo.", "ISO", pl.col("Start_Year").dt.year().alias("year"))
+        .join(windows, on="DisNo.", how="left")
+        .with_columns(
+            pl.col("gids").list.len().alias("n_units"),
+            _finest_level(pl.col("gids")).alias("finest_level"),
+            pl.col("geometry_source").cast(pl.String),
+        )
+        .select(EVENT_WINDOW_COLUMNS)
+        .sort("DisNo.")
+    )

--- a/tests/data/test_model_frame.py
+++ b/tests/data/test_model_frame.py
@@ -1,0 +1,99 @@
+import datetime
+
+import polars as pl
+import pytest
+
+from climate_risk.data.model_frame import event_windows
+from climate_risk.exceptions import DataValidationError
+
+
+def workbook(*disnos, year=1995, iso="LAO"):
+    """The columns `event_windows` reads off the filtered workbook."""
+    return pl.DataFrame(
+        {
+            "DisNo.": list(disnos),
+            "ISO": [iso] * len(disnos),
+            "Start_Year": [datetime.date(year, 6, 1)] * len(disnos),
+        }
+    )
+
+
+def placements(*rows):
+    """One row per event-unit, shaped like `event_geography` output."""
+    return pl.DataFrame(
+        {
+            "DisNo.": [row[0] for row in rows],
+            "gid": [row[1] for row in rows],
+            "geometry_source": [row[2] for row in rows],
+        },
+        schema={"DisNo.": pl.String, "gid": pl.String, "geometry_source": pl.String},
+    )
+
+
+def test_units_at_different_levels_join_into_one_window():
+    """The window is what the sources reached, so a district and the province beside it are one
+    observation rather than two, and neither is normalized to the other's level."""
+    windows = event_windows(
+        workbook("mixed"),
+        placements(("mixed", "LAO.1.2_1", "gadm"), ("mixed", "LAO.2_1", "location_text")),
+    )
+
+    assert windows["gids"].to_list() == [["LAO.1.2_1", "LAO.2_1"]]
+    assert windows["n_units"].to_list() == [2]
+
+
+def test_an_event_no_source_placed_keeps_a_whole_country_window():
+    """Dropping it would discard an event that happened; an empty window says the country is all
+    that is known, which is what the country tier means."""
+    windows = event_windows(workbook("unplaced"), placements(("unplaced", None, "country")))
+
+    assert windows["gids"].to_list() == [[]]
+    assert windows["n_units"].to_list() == [0]
+    assert windows["finest_level"].to_list() == [None]
+
+
+def test_the_finest_level_reads_the_deepest_unit_in_the_window():
+    """Window size drives the dispersion term the model needs, so a window holding one district is
+    not described by the province it also names."""
+    windows = event_windows(
+        workbook("deep"),
+        placements(("deep", "LAO.1_1", "gadm"), ("deep", "LAO.1.2.3_1", "gadm")),
+    )
+
+    assert windows["finest_level"].to_list() == [3]
+
+
+def test_the_best_source_names_the_window_when_tiers_disagree():
+    """`GEOMETRY_SOURCES` is best first and is not alphabetical, so the ranking has to come from the
+    tuple rather than from sorting the strings."""
+    windows = event_windows(
+        workbook("two-tiers"),
+        placements(("two-tiers", "LAO.1_1", "location_text"), ("two-tiers", "LAO.2_1", "emdat_point")),
+    )
+
+    assert windows["geometry_source"].to_list() == ["location_text"]
+
+
+def test_a_repeated_event_unit_pair_counts_once():
+    """A unit reached twice is still one unit of window, and counting it twice would inflate the
+    extent the dispersion term reads."""
+    windows = event_windows(
+        workbook("repeat"),
+        placements(("repeat", "LAO.1_1", "gadm"), ("repeat", "LAO.1_1", "gadm")),
+    )
+
+    assert windows["gids"].to_list() == [["LAO.1_1"]]
+
+
+def test_an_event_with_no_geography_row_is_an_error():
+    """`event_geography` emits every event, so a missing one means the two frames were built from
+    different workbooks and every window after it would be silently wrong."""
+    with pytest.raises(DataValidationError, match="no geography row"):
+        event_windows(workbook("placed", "orphan"), placements(("placed", "LAO.1_1", "gadm")))
+
+
+def test_a_source_the_precedence_does_not_rank_is_an_error():
+    """Ranking is by declaration order, so a source missing from `GEOMETRY_SOURCES` has no place in
+    it. Silently ranking it last would hide a new tier behind whichever one it was written beside."""
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        event_windows(workbook("new-tier"), placements(("new-tier", "LAO.1_1", "satellite")))


### PR DESCRIPTION
EM-DAT events are located at whatever level the sources reached — a district for one, a province for the next, nothing below the country for a third. `event_windows` gives one row per event carrying the units its window covers, so the resolution an event was reported at survives into the model instead of being normalized away.

Deliberately not a unit-year panel. Writing a zero in every district of a province contradicts a province-level event in the same year, so a rectangle can't represent mixed resolution.
