### PR TITLE
Reduce a raster onto the grid cells inside a place

### DIFF
--- a/climate_risk/data/ghsl.py
+++ b/climate_risk/data/ghsl.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 from zipfile import ZipFile
 
+import numpy as np
+
 from climate_risk.data.fetch import fetch
 from climate_risk.data.source import DataSource
 from climate_risk.exceptions import DataValidationError
+from climate_risk.geo.raster import CellGrid, sample_onto_cells
 
 GHSL_URL = "https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL"
 GHSL_SUBDIRECTORY = "ghsl"
@@ -86,3 +89,24 @@ def population_raster(epoch: int, cache_dir: Path) -> str:
         raise DataValidationError(f"{source.filename} holds {len(members)} rasters, expected exactly one")
 
     return f"zip://{archive}!/{members[0]}"
+
+
+def population_on_cells(grid: CellGrid, epoch: int, cache_dir: Path) -> np.ndarray:
+    """
+    Count the people in each grid cell.
+
+    Parameters
+    ----------
+    grid : CellGrid
+        The lattice to count onto. Values come back in the order of ``grid.cells``.
+    epoch : int
+        Year the grid describes, one of ``POPULATION_EPOCHS``.
+    cache_dir : Path
+        Directory the caches live under.
+
+    Returns
+    -------
+    ndarray
+        People per cell, aligned with ``grid.cells``.
+    """
+    return sample_onto_cells(grid, population_raster(epoch, cache_dir), statistic="sum")

--- a/climate_risk/geo/raster.py
+++ b/climate_risk/geo/raster.py
@@ -3,10 +3,11 @@ from dataclasses import dataclass
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import rasterio
 import shapely
 
 from exactextract import exact_extract
-from exactextract.raster import NumPyRasterSource
+from exactextract.raster import NumPyRasterSource, RasterioRasterSource
 from pyproj import Geod
 from shapely.geometry import box
 
@@ -184,6 +185,10 @@ class CellGrid:
     cells : GeoDataFrame
         Surviving cells, with ``cell_id``, ``lon``, ``lat``, ``ISO_A3``, ``cell_area_km2`` for the whole
         cell and ``place_area_km2`` for the part of it inside the place.
+    place : shapely geometry
+        The ground the lattice was cut to, dissolved. Anything measured over the cells is measured
+        over their intersection with this, so a raster sampled onto the grid cannot be clipped to
+        different ground than the grid itself was.
     """
 
     longitudes: np.ndarray
@@ -191,6 +196,7 @@ class CellGrid:
     longitude_step: float
     latitude_step: float
     cells: gpd.GeoDataFrame
+    place: shapely.geometry.base.BaseGeometry
 
     @property
     def shape(self) -> tuple[int, int]:
@@ -309,6 +315,47 @@ def cell_coverage(
     )
 
 
+def sample_onto_cells(grid: CellGrid, raster: str, *, statistic: str) -> np.ndarray:
+    """
+    Reduce a raster to one value per grid cell, over the part of each cell inside the place.
+
+    Parameters
+    ----------
+    grid : CellGrid
+        The lattice to reduce onto. Values come back in the order of ``grid.cells``.
+    raster : str
+        Path or URI :func:`rasterio.open` accepts.
+    statistic : str
+        An ``exactextract`` operation. It follows the quantity rather than the grid: an extensive
+        one such as a headcount takes ``"sum"``, an intensive one such as an elevation ``"mean"``.
+
+    Returns
+    -------
+    ndarray
+        One value per surviving cell, aligned with ``grid.cells``.
+    """
+    clipped = grid.footprints.intersection(grid.place)
+    missed = clipped.is_empty
+    if missed.any():
+        raise DataValidationError(
+            f"{int(missed.sum())} cells were kept for overlapping the place but do not intersect it."
+        )
+    footprints = gpd.GeoDataFrame(geometry=clipped, crs=GEOGRAPHIC_CRS)
+
+    with rasterio.open(raster) as source:
+        reduced = exact_extract(RasterioRasterSource(source), footprints, [statistic, "count"], output="pandas")
+
+    # A sum over no data is zero, which reads as an empty cell rather than an unmeasured one, so
+    # coverage is what says whether the raster answered.
+    uncovered = np.asarray(reduced["count"].to_numpy(), dtype=float) == 0.0
+    if uncovered.any():
+        raise DataValidationError(
+            f"{int(uncovered.sum())} cells are not covered by {raster}, so their value is unknown rather than zero."
+        )
+
+    return np.asarray(reduced[statistic].to_numpy(), dtype=float)
+
+
 def build_cell_grid(boundary: gpd.GeoDataFrame, *, resolution_km: float) -> CellGrid:
     """
     Lay a grid of cells over a dissolved boundary and keep every cell it touches.
@@ -384,6 +431,7 @@ def build_cell_grid(boundary: gpd.GeoDataFrame, *, resolution_km: float) -> Cell
             geometry=gpd.points_from_xy(kept["lon"], kept["lat"]),
             crs=GEOGRAPHIC_CRS,
         ),
+        place=boundary.to_crs(GEOGRAPHIC_CRS).union_all(),
     )
 
 

--- a/tests/data/test_ghsl.py
+++ b/tests/data/test_ghsl.py
@@ -11,10 +11,12 @@ from exactextract.raster import RasterioRasterSource
 from climate_risk.data.gadm import load_units_in_country
 from climate_risk.data.ghsl import (
     POPULATION_EPOCHS,
+    population_on_cells,
     population_raster,
     population_source,
 )
 from climate_risk.exceptions import DataValidationError
+from climate_risk.geo.raster import build_cell_grid, dissolve_place_boundary
 
 
 def write_archive(cache_dir, epoch, members):
@@ -115,3 +117,23 @@ def test_the_epochs_form_one_series_on_one_grid():
 
     assert len(grids) == 1, "the epochs are read against different grids"
     assert totals == sorted(totals), "Laos population does not rise through the series"
+
+
+@pytest.mark.slow
+@pytest.mark.requires_ghsl
+@pytest.mark.requires_gadm
+@pytest.mark.skipif(not REAL_ARCHIVE.exists(), reason="needs the GHS-POP archive")
+@pytest.mark.skipif(not (REAL_CACHE_DIR / "gadm" / "gadm_410.gpkg").exists(), reason="needs the GADM GeoPackage")
+def test_gridded_population_holds_the_country_total_at_any_resolution():
+    """The exposure offset must not depend on the grid it is measured on. Cells overhang the border,
+    so an unclipped count would pick up the neighbours and grow as the cells got coarser."""
+    units = load_units_in_country("LAO", 1, REAL_CACHE_DIR).assign(ISO_A3="LAO")
+    boundary = dissolve_place_boundary(units)
+
+    totals = [
+        population_on_cells(build_cell_grid(boundary, resolution_km=km), 2020, REAL_CACHE_DIR).sum()
+        for km in (10.0, 50.0)
+    ]
+
+    assert totals[0] == pytest.approx(totals[1], rel=0.001)
+    assert totals[0] == pytest.approx(7.4e6, rel=0.05)

--- a/tests/geo/test_raster.py
+++ b/tests/geo/test_raster.py
@@ -1,7 +1,10 @@
+import dataclasses
+
 import geopandas as gpd
 import numpy as np
 import pytest
 import rasterio
+import shapely
 
 from pyproj import Geod
 from rasterio.transform import from_bounds
@@ -576,3 +579,16 @@ def test_the_grid_carries_the_place_it_was_cut_to():
     grid = build_cell_grid(place, resolution_km=30.0)
 
     assert grid.place.equals(place.union_all()), "the grid clips to different ground than it was built from"
+
+
+def test_a_cell_that_misses_the_place_is_an_error(tmp_path):
+    """Cells are kept by one engine's coverage and clipped by another's intersection, so the two can
+    disagree on a sliver. Sampling an empty geometry gets a parse error out of the raster library
+    rather than a sentence about the grid."""
+    raster = write_raster(tmp_path / "field.tif", np.ones((8, 8)))
+    place = tiles([(0, 0, 1, 1)], ISO_A3=["AAA"])
+    grid = build_cell_grid(place, resolution_km=30.0)
+    detached = dataclasses.replace(grid, place=shapely.box(10.0, 10.0, 11.0, 11.0))
+
+    with pytest.raises(DataValidationError, match="do not intersect it"):
+        sample_onto_cells(detached, raster, statistic="sum")

--- a/tests/geo/test_raster.py
+++ b/tests/geo/test_raster.py
@@ -1,8 +1,10 @@
 import geopandas as gpd
 import numpy as np
 import pytest
+import rasterio
 
 from pyproj import Geod
+from rasterio.transform import from_bounds
 from shapely.geometry import box
 
 from climate_risk.exceptions import DataValidationError
@@ -14,6 +16,7 @@ from climate_risk.geo.raster import (
     build_cell_grid,
     dissolve_place_boundary,
     grid_axes,
+    sample_onto_cells,
 )
 
 
@@ -494,3 +497,82 @@ def test_a_cell_outside_the_grid_is_named_rather_than_translated():
 
     with pytest.raises(DataValidationError, match="not in the grid"):
         grid.column_of_cell(np.array([0, 10_000]))
+
+
+def write_raster(path, values, bounds=(0.0, 0.0, 1.0, 1.0)):
+    """A north-up GeoTIFF holding `values`, spread evenly over `bounds`."""
+    rows, columns = values.shape
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=rows,
+        width=columns,
+        count=1,
+        dtype="float64",
+        crs=GEOGRAPHIC_CRS,
+        transform=from_bounds(*bounds, columns, rows),
+    ) as writing:
+        writing.write(values, 1)
+
+    return str(path)
+
+
+def test_summing_conserves_the_total_the_raster_holds(tmp_path):
+    """A count is extensive: every person in the raster lands in exactly one cell, so the cells add
+    back to the whole. Averaging instead would give people per source pixel and lose the scale."""
+    raster = write_raster(tmp_path / "people.tif", np.ones((8, 8)))
+    place = tiles([(0, 0, 1, 1)], ISO_A3=["AAA"])
+    grid = build_cell_grid(place, resolution_km=30.0)
+
+    counted = sample_onto_cells(grid, raster, statistic="sum")
+
+    assert counted.sum() == pytest.approx(64.0)
+    assert len(counted) == len(grid.cells)
+
+
+def test_the_statistic_is_the_callers_choice(tmp_path):
+    """An elevation averages where a population sums, and nothing in the grid says which this is."""
+    raster = write_raster(tmp_path / "field.tif", np.full((8, 8), 3.0))
+    place = tiles([(0, 0, 1, 1)], ISO_A3=["AAA"])
+    grid = build_cell_grid(place, resolution_km=30.0)
+
+    assert sample_onto_cells(grid, raster, statistic="mean") == pytest.approx(3.0)
+    assert sample_onto_cells(grid, raster, statistic="sum").sum() == pytest.approx(64.0 * 3.0)
+
+
+def test_a_cell_the_raster_does_not_cover_is_an_error(tmp_path):
+    """A sum over no data is zero, so an unmeasured cell is indistinguishable from an empty one and
+    the exposure weight silently says nobody lives there."""
+    raster = write_raster(tmp_path / "corner.tif", np.ones((4, 4)), bounds=(0.0, 0.0, 0.4, 0.4))
+    place = tiles([(0, 0, 1, 1)], ISO_A3=["AAA"])
+    grid = build_cell_grid(place, resolution_km=30.0)
+
+    with pytest.raises(DataValidationError, match="not covered"):
+        sample_onto_cells(grid, raster, statistic="sum")
+
+
+def test_values_come_back_in_the_order_of_the_cells(tmp_path):
+    """Totals are order-invariant, so nothing above this would notice the values being shuffled —
+    and a permuted exposure vector hands each cell its neighbour's people."""
+    rising_eastwards = np.tile(np.arange(8, dtype=float), (8, 1))
+    raster = write_raster(tmp_path / "gradient.tif", rising_eastwards)
+    place = tiles([(0, 0, 1, 1)], ISO_A3=["AAA"])
+    grid = build_cell_grid(place, resolution_km=30.0)
+
+    counted = sample_onto_cells(grid, raster, statistic="sum")
+
+    eastwards = np.argsort(grid.cells["lon"].to_numpy(), kind="stable")
+    assert np.all(np.diff(counted[eastwards]) >= 0.0), "cells do not rise with longitude as the raster does"
+
+
+def test_the_grid_carries_the_place_it_was_cut_to():
+    """Sampling clips to this rather than to a boundary passed alongside. A grid built from one
+    place and sampled against another would count the neighbours and never say so."""
+    # L-shaped, so the place and its bounding box are different ground and a grid keeping the box
+    # instead would still look right on a rectangular country.
+    place = tiles([(0, 0, 1, 1), (1, 0, 2, 1), (0, 1, 1, 2)], ISO_A3=["AAA"] * 3)
+
+    grid = build_cell_grid(place, resolution_km=30.0)
+
+    assert grid.place.equals(place.union_all()), "the grid clips to different ground than it was built from"


### PR DESCRIPTION
Nothing turned a raster into per-cell values, so the population grid couldn't reach the model. `sample_onto_cells` reduces any raster over the part of each cell inside the place, and `population_on_cells` is the GHS-POP case. It sums rather than averages — people are extensive, and a cell mean gives people per source pixel, which is not an exposure weight.

`CellGrid` now keeps the dissolved place it was cut to, and sampling clips to that rather than to a boundary passed alongside. Handing it a boundary was the first design and it was wrong: a larger one silently counted the neighbours, and a smaller one died inside exactextract with `Failed to parse geometry`. Laos came out at 9.09M against a true 7.35M before the clip existed at all.

Verified against real polygons rather than fixtures: Laos totals 7.35M at 10, 25 and 50 km cells, matching what the ungridded raster gives for the country.
