### PR TITLE
Add the objective for events observed through windows

### DIFF
--- a/climate_risk/models/aggregated_poisson.py
+++ b/climate_risk/models/aggregated_poisson.py
@@ -138,6 +138,52 @@ def sample_log_intensity(
     return log_totals
 
 
+def mean_log_intensity(
+    svgp: SVGP,
+    aggregation: Aggregation,
+    moments: tuple[TensorVariable, TensorVariable, TensorVariable],
+    *,
+    n_draws: int = 16,
+    seed: int = 0,
+) -> TensorVariable:
+    r"""
+    :math:`\mathbb{E}_q[\log \Lambda_A]` for each row of the operator, estimated on fixed draws.
+
+    The draws are fixed once so the objective stays deterministic and a quasi-Newton optimizer can
+    be used on it.
+
+    Parameters
+    ----------
+    svgp : SVGP
+        A whitened ptgp SVGP over the cell features.
+    aggregation : Aggregation
+        The cell-to-row operator whose totals are being logged.
+    moments : tuple of TensorVariable
+        The mean, independent variance and factor from :func:`latent_moments`.
+    n_draws : int, optional
+        Draws behind the estimate. Default 16.
+    seed : int, optional
+        Seed for the fixed draw matrices. Default 0.
+
+    Returns
+    -------
+    TensorVariable
+        Shape ``(aggregation.n_units,)``.
+    """
+    rng = np.random.default_rng(seed)
+    # Shared rather than constant: at raster scale the cell draws are far too large to fold into
+    # the graph, and numba refuses to cache a function carrying one.
+    inducing_draws = shared(rng.standard_normal((svgp.inducing_variable.num_inducing, n_draws)), name="inducing_draws")
+    cell_draws = shared(rng.standard_normal((aggregation.n_cells, n_draws)), name="cell_draws")
+
+    estimate: TensorVariable = pt.mean(
+        sample_log_intensity(aggregation, *moments, inducing_draws, cell_draws),
+        axis=1,
+    )
+
+    return estimate
+
+
 def aggregated_poisson_elbo(
     svgp: SVGP,
     cell_features: TensorVariable,
@@ -178,19 +224,9 @@ def aggregated_poisson_elbo(
     TensorVariable
         Scalar.
     """
-    mean, independent_variance, factor = latent_moments(svgp, cell_features)
-
-    rng = np.random.default_rng(seed)
-    # Shared rather than constant: at raster scale the cell draws are far too large to fold into
-    # the graph, and numba refuses to cache a function carrying one.
-    inducing_draws = shared(rng.standard_normal((svgp.inducing_variable.num_inducing, n_draws)), name="inducing_draws")
-    cell_draws = shared(rng.standard_normal((aggregation.n_cells, n_draws)), name="cell_draws")
-
-    expected = expected_intensity(aggregation, mean, independent_variance, factor)
-    log_intensity = pt.mean(
-        sample_log_intensity(aggregation, mean, independent_variance, factor, inducing_draws, cell_draws),
-        axis=1,
-    )
+    moments = latent_moments(svgp, cell_features)
+    expected = expected_intensity(aggregation, *moments)
+    log_intensity = mean_log_intensity(svgp, aggregation, moments, n_draws=n_draws, seed=seed)
 
     log_likelihood = unit_counts * log_intensity - expected - pt.gammaln(unit_counts + 1.0)
 

--- a/climate_risk/models/aggregated_poisson.py
+++ b/climate_risk/models/aggregated_poisson.py
@@ -201,8 +201,7 @@ def aggregated_poisson_elbo(
     and an aggregated observation satisfies neither.
 
     :math:`\mathbb{E}_q[\Lambda_A]` is closed form and only :math:`\mathbb{E}_q[\log \Lambda_A]` is
-    sampled, on draws fixed once so the objective stays deterministic and a quasi-Newton optimizer
-    can be used on it.
+    sampled, by :func:`mean_log_intensity`.
 
     Parameters
     ----------

--- a/climate_risk/models/areal.py
+++ b/climate_risk/models/areal.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pytensor.tensor as pt
+
+from ptgp.gp import SVGP
+from pytensor.compile import shared
+from pytensor.tensor import TensorVariable
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.models.aggregated_poisson import expected_intensity, latent_moments, sample_log_intensity
+from climate_risk.models.aggregation import Aggregation
+
+
+def windowed_poisson_elbo(
+    svgp: SVGP,
+    cell_features: TensorVariable,
+    window_counts: TensorVariable,
+    aggregation: Aggregation,
+    region: Aggregation,
+    *,
+    n_draws: int = 16,
+    seed: int = 0,
+) -> TensorVariable:
+    r"""
+    The variational objective for events observed through windows that need not partition the place.
+
+    Events are a point process whose locations are known only to lie somewhere in the window they
+    were reported through, which gives
+
+    .. math::
+
+        \log L = -\Lambda_R + \sum_A y_A \log \Lambda_A
+
+    one exponential term for the whole region and one log term per window. Windows may nest or
+    overlap, which is what lets a province-level report sit beside a district-level one. Where they
+    do partition the place this is the binned Poisson objective, up to the count factorials.
+
+    Parameters
+    ----------
+    svgp : SVGP
+        A whitened ptgp SVGP over the cell features.
+    cell_features : TensorVariable
+        Shape ``(n_cells, n_features)``.
+    window_counts : TensorVariable
+        Events observed through each window, in the row order of ``aggregation.units``.
+    aggregation : Aggregation
+        The cell-to-window operator.
+    region : Aggregation
+        A single-row operator over every cell the place holds, giving the term for the ground where
+        nothing was recorded.
+    n_draws : int, optional
+        Draws behind the log-intensity term. Default 16.
+    seed : int, optional
+        Seed for the fixed draw matrices. Default 0.
+
+    Returns
+    -------
+    TensorVariable
+        Scalar.
+    """
+    if region.n_units != 1:
+        raise DataValidationError(f"The region operator covers the place in one row, not {region.n_units}.")
+    if region.n_cells != aggregation.n_cells:
+        raise DataValidationError(
+            f"The region spans {region.n_cells} cells and the windows {aggregation.n_cells}; they index the same grid."
+        )
+
+    mean, independent_variance, factor = latent_moments(svgp, cell_features)
+
+    rng = np.random.default_rng(seed)
+    # Shared rather than constant: at raster scale the cell draws are far too large to fold into
+    # the graph, and numba refuses to cache a function carrying one.
+    inducing_draws = shared(rng.standard_normal((svgp.inducing_variable.num_inducing, n_draws)), name="inducing_draws")
+    cell_draws = shared(rng.standard_normal((aggregation.n_cells, n_draws)), name="cell_draws")
+
+    log_intensity = pt.mean(
+        sample_log_intensity(aggregation, mean, independent_variance, factor, inducing_draws, cell_draws),
+        axis=1,
+    )
+    over_the_region = expected_intensity(region, mean, independent_variance, factor)
+
+    elbo: TensorVariable = pt.sum(window_counts * log_intensity) - pt.sum(over_the_region) - svgp.prior_kl()
+
+    return elbo

--- a/climate_risk/models/areal.py
+++ b/climate_risk/models/areal.py
@@ -1,12 +1,10 @@
-import numpy as np
 import pytensor.tensor as pt
 
 from ptgp.gp import SVGP
-from pytensor.compile import shared
 from pytensor.tensor import TensorVariable
 
 from climate_risk.exceptions import DataValidationError
-from climate_risk.models.aggregated_poisson import expected_intensity, latent_moments, sample_log_intensity
+from climate_risk.models.aggregated_poisson import expected_intensity, latent_moments, mean_log_intensity
 from climate_risk.models.aggregation import Aggregation
 
 
@@ -64,19 +62,9 @@ def windowed_poisson_elbo(
             f"The region spans {region.n_cells} cells and the windows {aggregation.n_cells}; they index the same grid."
         )
 
-    mean, independent_variance, factor = latent_moments(svgp, cell_features)
-
-    rng = np.random.default_rng(seed)
-    # Shared rather than constant: at raster scale the cell draws are far too large to fold into
-    # the graph, and numba refuses to cache a function carrying one.
-    inducing_draws = shared(rng.standard_normal((svgp.inducing_variable.num_inducing, n_draws)), name="inducing_draws")
-    cell_draws = shared(rng.standard_normal((aggregation.n_cells, n_draws)), name="cell_draws")
-
-    log_intensity = pt.mean(
-        sample_log_intensity(aggregation, mean, independent_variance, factor, inducing_draws, cell_draws),
-        axis=1,
-    )
-    over_the_region = expected_intensity(region, mean, independent_variance, factor)
+    moments = latent_moments(svgp, cell_features)
+    log_intensity = mean_log_intensity(svgp, aggregation, moments, n_draws=n_draws, seed=seed)
+    over_the_region = expected_intensity(region, *moments)
 
     elbo: TensorVariable = pt.sum(window_counts * log_intensity) - pt.sum(over_the_region) - svgp.prior_kl()
 

--- a/climate_risk/models/frame.py
+++ b/climate_risk/models/frame.py
@@ -1,0 +1,122 @@
+import numpy as np
+import pandas as pd
+import polars as pl
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.geo.raster import ISO_COLUMN, CellGrid
+from climate_risk.models.aggregation import Aggregation, build_aggregation, build_aggregation_from_overlaps
+
+EVENT_KEY = "DisNo."
+
+
+def region_aggregation(grid: CellGrid, cell_weights: np.ndarray, *, label: str = "place") -> Aggregation:
+    """
+    The one-row operator over every cell, giving the intensity across the whole place.
+
+    Parameters
+    ----------
+    grid : CellGrid
+        The lattice the model integrates over.
+    cell_weights : ndarray
+        Weight of each cell, in the order of ``grid.cells``.
+    label : str, optional
+        Row label. Default 'place'.
+
+    Returns
+    -------
+    Aggregation
+        One row spanning every cell.
+    """
+    if cell_weights.shape[0] != len(grid.cells):
+        raise DataValidationError(
+            f"{cell_weights.shape[0]} weights against {len(grid.cells)} cells; they index the same grid."
+        )
+
+    return build_aggregation(unit_of_cell=[label] * len(grid.cells), weights=cell_weights)
+
+
+def _cells_of_named_windows(windows: pl.DataFrame, coverage: pd.DataFrame) -> pd.DataFrame:
+    """Every cell each event's named units reach, with the share of the cell the window covers."""
+    # Empty windows are the country tier and are handled separately, so none reach the explode.
+    named = windows.filter(pl.col("gids").list.len() > 0).select(EVENT_KEY, "gids").explode("gids", empty_as_null=False)
+
+    return coverage.merge(
+        named.rename({"gids": "gid"}).to_pandas(),
+        on="gid",
+        how="inner",
+    )[[EVENT_KEY, "cell_id", "coverage"]]
+
+
+def _cells_of_whole_country_windows(windows: pl.DataFrame, grid: CellGrid) -> pd.DataFrame:
+    """Every cell of an event's country, for the events no source placed inside one."""
+    unplaced = windows.filter(pl.col("gids").list.len() == 0).select(EVENT_KEY, "ISO")
+    if unplaced.is_empty():
+        return pd.DataFrame(
+            {EVENT_KEY: pd.Series(dtype=str), "cell_id": pd.Series(dtype=int), "coverage": pd.Series(dtype=float)}
+        )
+
+    cells = grid.cells[["cell_id", ISO_COLUMN]].rename(columns={ISO_COLUMN: "ISO"})
+
+    return (
+        unplaced.to_pandas()
+        .merge(cells, on="ISO", how="inner")
+        .assign(coverage=1.0)[[EVENT_KEY, "cell_id", "coverage"]]
+    )
+
+
+def window_aggregation(
+    windows: pl.DataFrame,
+    coverage: pd.DataFrame,
+    grid: CellGrid,
+    *,
+    cell_weights: np.ndarray,
+) -> Aggregation:
+    """
+    Build the operator taking a cell-level intensity to the total each event was observed through.
+
+    An event's window is the union of the units its geography names, so a cell held by two of them
+    counts once. An event no source placed inside a unit is observed through its whole country.
+    Events whose window reaches no cell of the grid are dropped, since the model has nowhere to put
+    them; the caller compares the row count against the frame to see how many.
+
+    Parameters
+    ----------
+    windows : DataFrame
+        One row per event, from :func:`~climate_risk.data.model_frame.event_windows`.
+    coverage : DataFrame
+        One row per cell and unit, from :func:`~climate_risk.geo.raster.assign_cells_to_units`.
+    grid : CellGrid
+        The lattice the model integrates over.
+    cell_weights : ndarray
+        Weight of each cell, in the order of ``grid.cells``. Population gives an exposure-weighted
+        total, area an unweighted one.
+
+    Returns
+    -------
+    Aggregation
+        One row per event that reaches the grid, labelled by ``DisNo.``.
+    """
+    if cell_weights.shape[0] != len(grid.cells):
+        raise DataValidationError(
+            f"{cell_weights.shape[0]} weights against {len(grid.cells)} cells; they index the same grid."
+        )
+
+    reached = pd.concat(
+        [_cells_of_named_windows(windows, coverage), _cells_of_whole_country_windows(windows, grid)],
+        ignore_index=True,
+    )
+    if reached.empty:
+        raise DataValidationError("No event window reaches a cell of this grid.")
+
+    # Units inside one window can nest, so their shares of a cell are a union rather than a sum.
+    union = reached.groupby([EVENT_KEY, "cell_id"], as_index=False)["coverage"].sum()
+    union["coverage"] = union["coverage"].clip(upper=1.0)
+
+    columns = grid.column_of_cell(union["cell_id"].to_numpy())
+
+    return build_aggregation_from_overlaps(
+        unit_of_overlap=union[EVENT_KEY].tolist(),
+        cell_of_overlap=columns,
+        weights=union["coverage"].to_numpy() * cell_weights[columns],
+        n_cells=len(grid.cells),
+    )

--- a/tests/models/test_areal.py
+++ b/tests/models/test_areal.py
@@ -1,0 +1,185 @@
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+import scipy.optimize
+
+from ptgp.gp import SVGP, init_variational_params
+from ptgp.inducing import Points
+from ptgp.kernels import ExpQuad
+from ptgp.likelihoods import Poisson
+from ptgp.optim.training import compile_scipy_objective, get_trained_params
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.models.aggregation import build_aggregation, build_aggregation_from_overlaps
+from climate_risk.models.areal import windowed_poisson_elbo
+
+CELLS_PER_AXIS = 16
+INDUCING_PER_AXIS = 4
+TRUE_COEFFICIENTS = np.array([0.9, -0.6])
+TRUE_INTERCEPT = 4.0
+
+
+def square_grid(cells_per_axis=CELLS_PER_AXIS):
+    """Cell centres and equal weights over the unit square."""
+    edges = np.linspace(0.0, 1.0, cells_per_axis + 1)
+    centres = (edges[:-1] + edges[1:]) / 2.0
+    x, y = (axis.ravel() for axis in np.meshgrid(centres, centres, indexing="ij"))
+
+    return np.column_stack([x, y]), np.full(x.shape, 1.0 / cells_per_axis**2)
+
+
+def windows_of(coordinates, units_per_axis):
+    """Label each cell with the square block it falls in."""
+    column = np.minimum((coordinates[:, 0] * units_per_axis).astype(int), units_per_axis - 1)
+    row = np.minimum((coordinates[:, 1] * units_per_axis).astype(int), units_per_axis - 1)
+
+    return [f"u{r:02d}{c:02d}" for r, c in zip(row, column, strict=True)]
+
+
+def linear_mean_process(covariates, coordinates, inducing, *, lengthscale):
+    """A regression mean under a spatial field, with the priors written where a reader can see them."""
+    with pm.Model() as model:
+        coefficients = pm.Normal("coefficients", 0.0, 1.0, shape=(covariates.shape[1],))
+        intercept = pm.Normal("intercept", 0.0, 5.0)
+        amplitude = pm.HalfNormal("amplitude", 1.0)
+        svgp = SVGP(
+            kernel=amplitude**2 * ExpQuad(input_dim=coordinates.shape[1], ls=lengthscale),
+            likelihood=Poisson(),
+            mean=lambda _: intercept + pt.dot(pt.as_tensor_variable(covariates), coefficients),
+            inducing_variable=Points(Z=inducing),
+            variational_params=init_variational_params(inducing.shape[0]),
+            whiten=True,
+        )
+
+    return model, svgp
+
+
+def test_the_coefficients_come_back_from_simulated_counts():
+    """The covariates are what identify the surface inside a window, so a fit that cannot recover
+    them from counts it generated itself has nothing to say about sub-window structure.
+
+    The covariates are spatially rough on purpose. A smooth one is a function of position and the
+    field can imitate it, which is the confounding a real fit has to live with; a rough one is
+    separable and says whether the linear part is being fitted at all.
+    """
+    rng = np.random.default_rng(0)
+    coordinates, areas = square_grid()
+    covariates = rng.standard_normal((coordinates.shape[0], 2))
+
+    log_intensity = TRUE_INTERCEPT + covariates @ TRUE_COEFFICIENTS
+    labels = windows_of(coordinates, units_per_axis=8)
+    aggregation = build_aggregation(unit_of_cell=labels, weights=areas)
+    region = build_aggregation(unit_of_cell=["place"] * len(labels), weights=areas)
+    counts = rng.poisson(aggregation.aggregate(np.exp(log_intensity))).astype(float)
+
+    axis_points = np.linspace(0.1, 0.9, INDUCING_PER_AXIS)
+    inducing = np.column_stack([axis.ravel() for axis in np.meshgrid(axis_points, axis_points, indexing="ij")])
+    model, svgp = linear_mean_process(covariates, coordinates, inducing, lengthscale=0.3)
+
+    with model:
+
+        def objective(gp, cell_features, window_counts):
+            return windowed_poisson_elbo(gp, cell_features, window_counts, aggregation, region, n_draws=16, seed=1)
+
+        loss_and_grad, start, unpack, shared_params, _ = compile_scipy_objective(
+            objective, svgp, pt.matrix("X", shape=(None, 2)), pt.vector("y", shape=(None,)), model=model
+        )
+        fitted = scipy.optimize.minimize(
+            loss_and_grad,
+            start,
+            args=(coordinates, counts),
+            jac=True,
+            method="L-BFGS-B",
+            options={"maxiter": 300},
+        )
+        unpack(fitted.x)
+        recovered = get_trained_params(model, shared_params)["coefficients"]
+
+    assert np.allclose(recovered, TRUE_COEFFICIENTS, atol=0.25), f"recovered {recovered} for {TRUE_COEFFICIENTS}"
+
+
+def test_the_region_term_does_not_depend_on_how_the_windows_are_drawn():
+    """The exponential term is the intensity over the place, so it is the same whether the place is
+    described by four windows or by four plus a coarse one laid over two of them. Summing the
+    windows instead would count the overlap twice and the ground no window covers not at all.
+    """
+    coordinates, areas = square_grid(cells_per_axis=4)
+    region = build_aggregation(unit_of_cell=["place"] * 16, weights=areas)
+    inducing = coordinates[::4]
+
+    partitioning = windows_of(coordinates, units_per_axis=2)
+    nested = build_aggregation_from_overlaps(
+        unit_of_overlap=[*partitioning, *(["coarse"] * 8)],
+        cell_of_overlap=np.concatenate([np.arange(16), np.arange(8)]),
+        weights=np.concatenate([areas, areas[:8]]),
+        n_cells=16,
+    )
+    flat = build_aggregation(unit_of_cell=partitioning, weights=areas)
+
+    scores = []
+    for aggregation in (flat, nested):
+        model, svgp = linear_mean_process(np.zeros((16, 1)), coordinates, inducing, lengthscale=0.3)
+        counts = np.zeros(aggregation.n_units)
+        with model:
+
+            def objective(gp, cell_features, window_counts, aggregation=aggregation):
+                return windowed_poisson_elbo(gp, cell_features, window_counts, aggregation, region, seed=1)
+
+            loss_and_grad, start, *_ = compile_scipy_objective(
+                objective, svgp, pt.matrix("X", shape=(None, 2)), pt.vector("y", shape=(None,)), model=model
+            )
+            scores.append(float(loss_and_grad(start, coordinates, counts)[0]))
+
+    assert scores[0] == pytest.approx(scores[1]), "the region term moved when the windows were redrawn"
+
+
+def test_a_region_operator_spanning_several_rows_is_an_error():
+    """The exponential term is the intensity over the whole place once. Several rows would subtract
+    it several times and pull every count down without touching the fit's shape."""
+    coordinates, areas = square_grid(cells_per_axis=4)
+    labels = windows_of(coordinates, units_per_axis=2)
+    aggregation = build_aggregation(unit_of_cell=labels, weights=areas)
+    split_region = build_aggregation(unit_of_cell=["north"] * 8 + ["south"] * 8, weights=areas)
+
+    model, svgp = linear_mean_process(np.zeros((16, 1)), coordinates, coordinates[::4], lengthscale=0.3)
+
+    with model, pytest.raises(DataValidationError, match="one row"):
+        windowed_poisson_elbo(svgp, pt.as_tensor_variable(coordinates), pt.ones(4), aggregation, split_region)
+
+
+def test_the_region_and_the_windows_must_span_the_same_grid():
+    """Both operators index cells by position. Built against different grids they would still
+    multiply, and the exponential term would be subtracted over the wrong ground."""
+    coordinates, areas = square_grid(cells_per_axis=4)
+    aggregation = build_aggregation(unit_of_cell=windows_of(coordinates, units_per_axis=2), weights=areas)
+    smaller = build_aggregation(unit_of_cell=["place"] * 9, weights=areas[:9])
+
+    model, svgp = linear_mean_process(np.zeros((16, 1)), coordinates, coordinates[::4], lengthscale=0.3)
+
+    with model, pytest.raises(DataValidationError, match="index the same grid"):
+        windowed_poisson_elbo(svgp, pt.as_tensor_variable(coordinates), pt.ones(4), aggregation, smaller)
+
+
+def test_the_objective_is_the_same_twice_for_one_seed():
+    """The log-intensity term is sampled, and L-BFGS assumes the objective is a function of the
+    parameters alone. Redrawing per call turns a converged fit into a random walk."""
+    coordinates, areas = square_grid(cells_per_axis=4)
+    aggregation = build_aggregation(unit_of_cell=windows_of(coordinates, units_per_axis=2), weights=areas)
+    region = build_aggregation(unit_of_cell=["place"] * 16, weights=areas)
+    counts = np.array([2.0, 0.0, 1.0, 3.0])
+
+    scores = []
+    for _ in range(2):
+        model, svgp = linear_mean_process(np.zeros((16, 1)), coordinates, coordinates[::4], lengthscale=0.3)
+        with model:
+
+            def objective(gp, cell_features, window_counts):
+                return windowed_poisson_elbo(gp, cell_features, window_counts, aggregation, region, seed=7)
+
+            loss_and_grad, start, *_ = compile_scipy_objective(
+                objective, svgp, pt.matrix("X", shape=(None, 2)), pt.vector("y", shape=(None,)), model=model
+            )
+            scores.append(float(loss_and_grad(start, coordinates, counts)[0]))
+
+    assert scores[0] == scores[1]

--- a/tests/models/test_frame.py
+++ b/tests/models/test_frame.py
@@ -1,0 +1,172 @@
+import geopandas as gpd
+import numpy as np
+import polars as pl
+import pytest
+
+from shapely.geometry import box
+
+from climate_risk.exceptions import DataValidationError
+from climate_risk.geo.raster import assign_cells_to_units, build_cell_grid
+from climate_risk.models.frame import region_aggregation, window_aggregation
+
+RESOLUTION_KM = 30.0
+
+
+def one_degree_place(iso="AAA", corner=(0.0, 0.0)):
+    """A square country a degree on a side, which grids to sixteen cells at 30 km."""
+    west, south = corner
+
+    return gpd.GeoDataFrame({"ISO_A3": [iso], "geometry": [box(west, south, west + 1.0, south + 1.0)]}, crs="EPSG:4326")
+
+
+def halves(iso="AAA", corner=(0.0, 0.0)):
+    """The place split into a west and an east unit, plus a district inside the west one."""
+    west, south = corner
+
+    return gpd.GeoDataFrame(
+        {
+            "gid": [f"{iso}.1_1", f"{iso}.2_1", f"{iso}.1.1_1"],
+            "geometry": [
+                box(west, south, west + 0.5, south + 1.0),
+                box(west + 0.5, south, west + 1.0, south + 1.0),
+                box(west, south, west + 0.5, south + 0.5),
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+
+def events(*rows, iso="AAA"):
+    """One row per event, shaped like `event_windows` output."""
+    # `event_windows` aggregates to a genuine empty list for a country-tier event. A literal `[]`
+    # in the DataFrame constructor becomes null instead, which the country-tier branch would miss.
+    return pl.from_records(
+        [(name, iso, gids) for name, gids in rows],
+        schema={"DisNo.": pl.String, "ISO": pl.String, "gids": pl.List(pl.String)},
+        orient="row",
+    )
+
+
+def test_a_window_naming_a_unit_and_a_unit_inside_it_counts_each_cell_once():
+    """Names in one event nest freely — a province and a district inside it are two names for
+    overlapping ground. Adding their shares would weight the overlap twice and quietly make the
+    event look like it happened harder there."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+    weights = np.ones(len(grid.cells))
+
+    nested = window_aggregation(events(("nested", ["AAA.1_1", "AAA.1.1_1"])), coverage, grid, cell_weights=weights)
+    province_only = window_aggregation(events(("province", ["AAA.1_1"])), coverage, grid, cell_weights=weights)
+
+    assert nested.matrix.sum() == pytest.approx(province_only.matrix.sum())
+    assert nested.matrix.max() == pytest.approx(1.0), "a cell carries at most its own weight"
+
+
+def test_an_event_no_source_placed_is_observed_through_its_whole_country():
+    """A country-tier event happened somewhere, and the window that says so is the country. Dropping
+    it would discard an eighth of the workbook for being imprecise rather than absent."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+    weights = np.arange(1.0, len(grid.cells) + 1.0)
+
+    aggregation = window_aggregation(events(("unplaced", [])), coverage, grid, cell_weights=weights)
+
+    assert aggregation.units == ("unplaced",)
+    assert aggregation.matrix.sum() == pytest.approx(weights.sum()), "the window is every cell of the country"
+
+
+def test_a_country_window_stops_at_its_own_border():
+    """A region holds several countries on one grid, and an unplaced Lao event says nothing about
+    Vietnam. Covering the whole grid would spread it over the neighbours."""
+    two = gpd.GeoDataFrame({"ISO_A3": ["AAA", "BBB"], "geometry": [box(0, 0, 1, 1), box(1, 0, 2, 1)]}, crs="EPSG:4326")
+    grid = build_cell_grid(two, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+    weights = np.ones(len(grid.cells))
+
+    aggregation = window_aggregation(events(("unplaced", []), iso="AAA"), coverage, grid, cell_weights=weights)
+    at_home = (grid.cells["ISO_A3"] == "AAA").sum()
+
+    assert aggregation.matrix.sum() == pytest.approx(float(at_home))
+    assert at_home < len(grid.cells), "the grid holds cells of the other country too"
+
+
+def test_the_weights_carry_the_exposure_the_caller_supplied():
+    """The operator's weight is what multiplies the intensity, so an exposure-weighted total needs
+    the population in it rather than the fraction of a cell the window covers."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+    people = np.full(len(grid.cells), 100.0)
+
+    aggregation = window_aggregation(events(("west", ["AAA.1_1"])), coverage, grid, cell_weights=people)
+
+    assert aggregation.matrix.sum() == pytest.approx(100.0 * len(grid.cells) / 2.0)
+
+
+def test_weights_that_do_not_index_the_grid_are_an_error():
+    """Cell weights arrive from a raster and the grid from a boundary. A length mismatch would index
+    the wrong cells and produce a plausible operator over the wrong ground."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+
+    with pytest.raises(DataValidationError, match="index the same grid"):
+        window_aggregation(events(("west", ["AAA.1_1"])), coverage, grid, cell_weights=np.ones(3))
+
+    with pytest.raises(DataValidationError, match="index the same grid"):
+        region_aggregation(grid, np.ones(3))
+
+
+def test_the_region_spans_every_cell_in_one_row():
+    """The objective subtracts this once for the whole place, so it has to be one row and it has to
+    miss nothing."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    weights = np.arange(1.0, len(grid.cells) + 1.0)
+
+    region = region_aggregation(grid, weights)
+
+    assert region.n_units == 1
+    assert region.matrix.sum() == pytest.approx(weights.sum())
+
+
+def test_an_event_whose_units_miss_the_grid_is_dropped_and_the_rest_survive():
+    """A place's grid holds its own units. An event carried over from a neighbour reaches no cell,
+    and the model has nowhere to put it — but it must not take the rest of the frame with it."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+    weights = np.ones(len(grid.cells))
+
+    aggregation = window_aggregation(
+        events(("here", ["AAA.1_1"]), ("elsewhere", ["ZZZ.9_1"])), coverage, grid, cell_weights=weights
+    )
+
+    assert aggregation.units == ("here",)
+
+
+def test_no_window_reaching_the_grid_at_all_is_an_error():
+    """An operator with no rows fits nothing and says nothing. Far better to fail where the grid and
+    the events were chosen than to hand the model an empty likelihood."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+
+    with pytest.raises(DataValidationError, match="No event window reaches"):
+        window_aggregation(events(("elsewhere", ["ZZZ.9_1"])), coverage, grid, cell_weights=np.ones(len(grid.cells)))
+
+
+def test_the_rows_carry_a_defined_order():
+    """Counts are supplied by position, so the caller has to know which row is which event. Sorted
+    labels make that a lookup rather than a guess about insertion order."""
+    place = one_degree_place()
+    grid = build_cell_grid(place, resolution_km=RESOLUTION_KM)
+    coverage = assign_cells_to_units(grid, halves())
+
+    aggregation = window_aggregation(
+        events(("zeta", ["AAA.1_1"]), ("alpha", ["AAA.2_1"])), coverage, grid, cell_weights=np.ones(len(grid.cells))
+    )
+
+    assert aggregation.units == ("alpha", "zeta")


### PR DESCRIPTION
EM-DAT events arrive located at whatever level the sources reached — a district for one, a province for the next, a whole country for a third — and a binned Poisson likelihood can't represent that, because a zero written in a district contradicts a province-level event in the same year. Treating each event as one point-process observation through its own window does: subtract the intensity over the place once, then add one log term per event. Windows may nest, and the two forms agree wherever they happen to partition.

`frame.py` builds the operators that feed it, from a place's grid and its events. Two things there aren't obvious: units named by a single event nest, so their shares of a cell are a union rather than a sum, and an event no source placed inside a unit is observed through its own country rather than dropped.

No model here, deliberately. Priors, inducing points and the exposure offset are decisions that need real data in front of them, so they live in the notebook rather than in a builder function.
